### PR TITLE
docs: rewrite CONTRIBUTING.md to match actual project state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,70 +1,112 @@
-# Contributing to Arclux
+# Contributing to ARCLUX
 
-Arclux is alpha software. The core model, graph builder, and TypeScript
-parser work; most detectors, other language parsers, and the dashboard
-do not exist yet. Expect breaking changes before 1.0.
+ARCLUX is alpha software (`v0.1.0-alpha`). The core pipeline, all 18
+detectors, full impact analysis, and the CLI are working and verified.
+Other-language parsers, the search engine, and several UI areas are still
+stubs. Check `PROGRES.md` at the repo root for the current, detailed
+status before assuming anything is done or missing — it's updated after
+every milestone and is more accurate than this file for "is X done yet."
+
+Expect breaking changes before 1.0.
 
 ## Setup
 
 ```bash
 git clone https://github.com/GSF-001/ARCLUX.git
 cd ARCLUX
-pnpm install
-pnpm test
+npm install
 ```
 
-Requires Node 20+ and pnpm. This is a `turbo` monorepo — run tasks from
-the root, not inside individual packages, unless you're iterating on one
-package in isolation.
+Requires Node 20+. This is an npm workspaces monorepo — most day-to-day
+work happens inside a specific `apps/*` or `packages/*` directory, using
+that directory's own `package.json` scripts.
 
 ## Structure
 
 ```
-apps/cli        command-line interface
+apps/cli        command-line interface (analyze, doctor, graph, config, impact)
 apps/web        Next.js dashboard
 packages/       parser, graph, impact, detectors, rules, engine,
-                indexer, search, watcher, git, db, cache
+                indexer, search, watcher, git, db, cache, incremental,
+                repository, shared
+playground/     fixture repos (python-demo, nextjs-demo, react-demo, etc.)
+                used for manual verification — see "Testing your changes"
+scripts/        testPlayground.ts — runs the pipeline + all detectors
+                against a playground/ fixture or any local path
 ```
 
-Each stage in `repository → parser → graph → detectors → engine → report`
-is an independent package. Don't reach across stages directly — go
-through the public entry point of the package you need.
+Each stage in `repository → parser → graph → detectors → impact/engine`
+is an independent package. Don't reach across stages directly in
+production code paths (CLI commands, API routes) — go through
+`packages/engine/pipeline.ts`'s `analyzeRepository()`. Calling steps
+individually is only acceptable in local dev/test scripts (see
+`scripts/testPlayground.ts` for the established pattern) — not in
+anything that ships.
 
 ## Before opening a PR
 
-- Check `packages/*` for an existing file that does what you're about to
-  write. Overlapping implementations of the same responsibility have
-  happened before and are the main source of dead code in this repo.
-- Run `pnpm test` and `pnpm typecheck` locally.
-- Keep PRs scoped to one package or one concern. Cross-cutting changes
-  are harder to review and more likely to hide a duplicate.
+- **Check for an existing implementation first.** Grep for the
+  function/file name you're about to write. This project has had files
+  implemented twice under different names by parallel sessions more than
+  once — it's the single biggest source of wasted work here. `cat` a file
+  before trusting its line count: a file with only the license header is
+  8 lines, not 0 — see `PROGRES.md`'s note on this.
+- **`tsc --noEmit` passing is not "verified."** Every detector and pipeline
+  change in this repo has been tested against a real fixture in
+  `playground/`, either via `npx tsx scripts/testPlayground.ts <fixture>`
+  or `npx tsx apps/cli/index.ts doctor <path>`. A PR that only shows a
+  clean typecheck for logic changes will likely get asked to add that.
+- Keep PRs scoped to one package or one concern.
+- Update `PROGRES.md` if your change completes something that was
+  previously listed as a stub, or if you discover the status recorded
+  there is stale (this happens — parallel sessions occasionally get out
+  of sync with what's actually written).
+- `main` requires a pull request — direct pushes are blocked by branch
+  ruleset.
 
 ## Adding a detector
 
-Detectors live in `packages/detectors/`. Each one should:
-- Take the built graph as input, not re-parse files itself
-- Return a flat list of findings with file path, message, and severity
-- Have a corresponding test in `tests/`
+Detectors live in `packages/detectors/`. Look at `detectOrphanFiles.ts`
+or `detectSharedModules.ts` for a simple example, or `detectUnusedExports.ts`
+for one with documented known limitations. Each detector should:
+- Take a `Repository` instance as input (not re-parse files itself)
+- Return a flat array of typed findings (see the `*Finding` interface
+  pattern used by existing detectors)
+- Register in `apps/cli/doctor.ts` so it runs as part of `arclux doctor`
+- If entry points matter for your detector's accuracy, use
+  `detectEntryPoints.ts`'s output to filter false positives — several
+  existing detectors don't do this yet and have documented false
+  positives as a result; don't repeat that if you can avoid it
 
 ## Adding a language parser
 
-Parsers live in `packages/parser/<language>/`. Follow the shape of the
-existing TypeScript parser — same output format for imports, exports,
-and symbols, so downstream packages don't need per-language branching.
+Parsers live in `packages/parser/<language>/`. Follow the shape of
+`parseTs.ts` (regex/AST-based) or `parsePython.ts` (tree-sitter-based) —
+same output contract (`ParsedFile` with `imports`/`exports`), so
+downstream packages don't need per-language branching. If using
+tree-sitter, **read the gotchas in `PROGRES.md`'s Python parser section
+first** (specific version pin required, WASM loading quirks) before
+hitting the same issues again.
 
-## Adding a framework rule
+## Adapting code from other open-source projects
 
-Rules live in `packages/rules/<framework>/` and are built on
-`RuleEngine.ts`. A rule is a predicate over the graph plus a message; it
-should not know about file I/O.
+This is done deliberately and carefully in this repo (see `NOTICE` at
+root for the full list — madge, knip, cmdk, tree-sitter-python, and
+others). If you adapt an algorithm or pattern from elsewhere:
+- Re-implement it against ARCLUX's own types — don't port line-by-line
+  unless it's a verbatim copy for a good reason (e.g. a syntax-highlight
+  query, which should stay byte-identical to upstream)
+- Add attribution in both the file's header comment AND `NOTICE`
+- Note explicitly, in a comment, what's different from the original and
+  why
 
 ## Commit messages
 
-Conventional commits (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`).
+Conventional commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`).
 Keep the subject line under 72 characters.
 
 ## Reporting bugs
 
-Open an issue with the repository you ran Arclux against (if public),
-the command you ran, and the actual vs. expected output. A minimal
-reproduction is more useful than a full log.
+Open an issue using the Bug report template. Include the exact command
+you ran and, if it's about parsing/detection, which file/repo triggered
+it — a `playground/` fixture reproducing it is ideal but not required.


### PR DESCRIPTION
Updates CONTRIBUTING.md — was still referencing pnpm/turbo and saying detectors don't exist yet, despite 18/18 being done. Now reflects npm, playground/ testing pattern, and current PR/branch ruleset requirement.