### PR TITLE
docs: update PROGRES.md — GitHub infra + features/graph decision

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -700,3 +700,25 @@ interactive ones, `cn()` from `@/lib/cn`, primitives from
 
 `components/patterns/*` is now 11/11 complete (including
 `CommandPalette.tsx`, which was already done by a previous session).
+
+## Update — GitHub infra + features/graph decision
+
+**Repo infrastructure added**: branch ruleset on `main` (PR required, no
+direct push — verified by testing it against ourselves), PR + issue
+templates (`.github/`), 10 GitHub Issues created from open items in this
+file, release tag `v0.1.0-alpha` published, `CONTRIBUTING.md` rewritten
+(was stale: said pnpm/turbo, said detectors don't exist — now says npm,
+18/18 detectors, references playground/ testing pattern).
+
+Also removed `turbo.json` (0 bytes, unused leftover — project uses npm
+directly, `turbo` command never actually run against this repo).
+
+**apps/web/features/graph/* decision**: `useGraph.ts` implemented as a
+thin re-export of `GraphProvider.tsx`'s `useGraphContext()`. The other 4
+files (`graphStore.ts`, `graphEvents.ts`, `useGraphLayout.ts`,
+`useGraphSelection.ts`) are DELIBERATELY left as documentation-only stubs
+— `GraphProvider.tsx` already owns all graph state (transform, positions,
+dimensions, selection) via React Context. Do NOT implement a separate
+store/hooks layer here; it would create two sources of truth for the same
+state. Same class of risk as the `packages/ui/graphColor.ts` /
+`theme/graphColors.ts` naming collision noted earlier.


### PR DESCRIPTION
Records branch protection, issue templates, 10 issues, release tag, CONTRIBUTING.md rewrite, turbo.json removal, and the features/graph/* superseded-by-GraphProvider decision.