### PR TITLE
Add ImpactSummary.tsx (fetches /api/impact, renders direct/indirect i…

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -722,3 +722,97 @@ dimensions, selection) via React Context. Do NOT implement a separate
 store/hooks layer here; it would create two sources of truth for the same
 state. Same class of risk as the `packages/ui/graphColor.ts` /
 `theme/graphColors.ts` naming collision noted earlier.
+
+
+## Update -- ImpactSummary.tsx built and verified in-browser, plus 2 major Webpack gotchas found
+
+components/explorer/ImpactSummary.tsx implemented: fetches /api/impact,
+renders total affected files, direct impact (distance === 1) and indirect
+impact (distance > 1) lists, each file with a High/Medium/Low severity
+badge derived from distance.
+
+Important: severity is NOT part of the backend response. packages/impact/*
+only produces distance (BFS hops from the changed module). The
+High/Medium/Low mapping is a UI-only heuristic (distance 1 -> High,
+2 -> Medium, 3+ -> Low), documented as such in the component's own
+comment, not validated against real incident data. If this ever needs to
+reflect real blast-radius severity (weighted by fan-in, file size, test
+coverage, etc.), that logic belongs in packages/impact/*, not the UI
+layer.
+
+Verified in-browser (not just tsc --noEmit): temporarily mounted the
+component on a throwaway test page, called it against
+apps/cli/impact.ts in the arclux repo itself, confirmed direct impact
+list, severity badge, and total count all render correctly. Test page
+was deleted after verification -- it was never a permanent route.
+
+Not yet wired into components/explorer/Explorer.tsx -- that file is
+still a stub, so ImpactSummary remains a standalone building block for
+now, same status as FileDetails.tsx.
+
+### Gotcha #1 -- Next.js route folders starting with underscore are NOT routable
+
+Any app/_foldername/ is treated by Next.js as a private folder by
+convention and will 404 no matter what's inside it -- even a valid
+page.tsx. This is intentional Next.js behavior for co-locating
+non-route files inside app/, not a bug. If you need a throwaway test
+route, do NOT prefix it with underscore -- that guarantees it can't be
+visited. Use a plain folder name instead, and delete it manually when
+done (Next.js has no built-in "temporary route" concept).
+
+### Gotcha #2 -- Webpack + web-tree-sitter .wasm: the actual fix (3 wrong attempts first)
+
+Running apps/web with next dev --webpack and hitting any route that
+imports packages/parser/python/parsePython.ts (e.g. /api/graph,
+/api/analyze, /new) used to hard-fail with a webpack error:
+"Module parse failed: Unexpected character (1:0) -- The module seem to
+be a WebAssembly module, but module is not flagged as WebAssembly
+module for webpack."
+
+This blocked ALL in-browser verification of the graph viewer, impact UI,
+and anything else touching the pipeline -- nothing past tsc --noEmit had
+ever actually been confirmed working in a browser until this was fixed.
+
+Three approaches were tried and did NOT work, in order:
+
+1. experiments.asyncWebAssembly: true in next.config.ts webpack()
+   callback. This does let Webpack parse some .wasm files, but
+   tree-sitter-python.wasm uses Emscripten dynamic linking (dylink),
+   which Webpack's WebAssembly module types don't support. Failure
+   changed to "Module not found: Can't resolve 'GOT.func'" (a dylink
+   relocation symbol Webpack tried and failed to resolve as a JS
+   import).
+2. serverExternalPackages: ["web-tree-sitter", "tree-sitter-wasms"].
+   Reasonable guess (this is the documented Next.js mechanism for
+   excluding server-only packages from the Webpack bundle), but it did
+   NOT fix it -- same "Unexpected character" error came right back.
+   Cause: serverExternalPackages only takes effect at module-resolution
+   time, but Webpack's static analysis of require.resolve("...") calls
+   happens earlier and unconditionally tries to bundle whatever the
+   resolved path points to, regardless of externalization config.
+3. Renaming the createRequire()-derived variable from require to
+   nodeRequire in parsePython.ts, on the theory that Webpack's analyzer
+   pattern-matches the literal identifier require. Also did NOT work --
+   Webpack traces the variable back to its createRequire() origin
+   regardless of what it's named, so renaming had zero effect. (This was
+   a dead end; the rename itself is harmless and was left in place.)
+
+What actually fixed it: tell Webpack to treat .wasm files as a raw
+binary asset instead of trying to parse them as a WebAssembly module at
+all, by pushing a module rule in next.config.ts's webpack() callback
+that matches /.wasm$/ and sets type to "asset/resource".
+
+This makes Webpack just copy the file and return a resolvable path,
+without attempting to parse its contents as JS or WASM -- the actual
+bytes are read by web-tree-sitter's own Node fs logic at runtime (same
+as how the CLI already worked), not by Webpack. Combined with
+serverExternalPackages (kept, though it may now be redundant with the
+asset/resource rule -- not yet tested with it removed) this is what
+finally let /api/graph, /new, and the impact UI all load without errors
+in the browser.
+
+Lesson: for a require.resolve()-loaded native/WASM asset in Webpack, the
+fix is almost never about identifier tricks or server package exclusion
+lists -- it's about telling Webpack's module rules how to treat the file
+type itself (asset/resource), so it never tries to parse it as code in
+the first place.

--- a/apps/web/components/explorer/ImpactSummary.tsx
+++ b/apps/web/components/explorer/ImpactSummary.tsx
@@ -6,3 +6,161 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+"use client";
+
+import { useEffect, useState } from "react";
+import { LoadingState } from "@/components/patterns/LoadingState";
+import { ErrorState } from "@/components/patterns/ErrorState";
+import { EmptyState } from "@/components/patterns/EmptyState";
+import { StatusDot } from "@/components/patterns/StatusDot";
+
+interface AffectedFile {
+  moduleId: string;
+  filePath: string;
+  distance: number;
+}
+
+interface ImpactResponse {
+  changedModuleId: string;
+  notFound: boolean;
+  affectedFiles: AffectedFile[];
+  totalAffected: number;
+  tree: unknown;
+}
+
+export interface ImpactSummaryProps {
+  repoUrl: string;
+  moduleId: string;
+  branch?: string;
+}
+
+/**
+ * Severity (High/Medium/Low) is NOT part of the backend response --
+ * packages/impact/* only produces `distance` (BFS hops from the changed
+ * module). This mapping is a UI-only heuristic: closer consumers are
+ * assumed riskier to break. It has not been validated against real
+ * incident data. If this ever needs to reflect actual blast-radius
+ * severity (e.g. weighted by fan-in, file size, test coverage), that
+ * logic belongs in packages/impact/*, not here.
+ */
+function severityForDistance(distance: number): { label: string; variant: "error" | "warning" | "info" } {
+  if (distance <= 1) return { label: "High", variant: "error" };
+  if (distance === 2) return { label: "Medium", variant: "warning" };
+  return { label: "Low", variant: "info" };
+}
+
+const INITIAL_VISIBLE = 3;
+
+function ImpactList({ files, emptyMessage }: { files: AffectedFile[]; emptyMessage: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (files.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+  }
+
+  const visible = expanded ? files : files.slice(0, INITIAL_VISIBLE);
+  const remaining = files.length - visible.length;
+
+  return (
+    <div className="space-y-1">
+      {visible.map((file) => {
+        const severity = severityForDistance(file.distance);
+        return (
+          <div
+            key={file.moduleId}
+            className="flex items-center justify-between gap-3 rounded-md px-2 py-1.5 hover:bg-muted/30"
+          >
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{file.filePath.split("/").pop()}</p>
+              <p className="truncate text-xs text-muted-foreground">{file.filePath}</p>
+            </div>
+            <StatusDot variant={severity.variant} label={severity.label} className="shrink-0" />
+          </div>
+        );
+      })}
+      {remaining > 0 && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="px-2 text-sm text-primary hover:underline"
+        >
+          {remaining} more
+        </button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Fetches and renders /api/impact for a given module. Not yet wired into
+ * any page (components/explorer/Explorer.tsx is still empty) -- standalone
+ * building block, same status as FileDetails.tsx. Not yet visually
+ * verified in a browser.
+ */
+export function ImpactSummary({ repoUrl, moduleId, branch }: ImpactSummaryProps) {
+  const [data, setData] = useState<ImpactResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams({ repoUrl, moduleId });
+        if (branch) params.set("branch", branch);
+
+        const res = await fetch(`/api/impact?${params.toString()}`);
+        const json = await res.json();
+
+        if (!res.ok) throw new Error(json.error ?? `Request failed with status ${res.status}`);
+        if (!cancelled) setData(json as ImpactResponse);
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load impact data");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoUrl, moduleId, branch]);
+
+  if (isLoading) return <LoadingState label="Calculating impact..." />;
+  if (error) return <ErrorState title="Couldn't calculate impact" message={error} />;
+  if (!data || data.notFound) {
+    return <EmptyState title="Module not found" message={`"${moduleId}" was not found in this repository's graph.`} />;
+  }
+
+  const direct = data.affectedFiles.filter((f) => f.distance === 1);
+  const indirect = data.affectedFiles.filter((f) => f.distance > 1);
+
+  return (
+    <div className="space-y-6 p-4">
+      <div>
+        <p className="text-sm text-muted-foreground">Total affected files</p>
+        <p className="text-2xl font-semibold">{data.totalAffected}</p>
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="text-sm font-semibold">Direct impact</h3>
+          <span className="text-xs text-muted-foreground">{direct.length} files</span>
+        </div>
+        <ImpactList files={direct} emptyMessage="Nothing directly consumes this module." />
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="text-sm font-semibold">Indirect impact</h3>
+          <span className="text-xs text-muted-foreground">{indirect.length} files</span>
+        </div>
+        <ImpactList files={indirect} emptyMessage="No transitive consumers." />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -12,10 +12,37 @@ import path from "node:path";
 const nextConfig: NextConfig = {
   /**
    * Allows bundling files outside apps/web (i.e. the monorepo's packages/ dir).
-   * Needed because engine/pipeline.ts and friends live at ~/ARIES/packages,
+   * Needed because engine/pipeline.ts and friends live at ~/arclux/packages,
    * not inside apps/web.
    */
   outputFileTracingRoot: path.join(process.cwd(), "../../"),
+
+  /**
+   * web-tree-sitter's .wasm grammar files use Emscripten dynamic linking
+   * (dylink), which Webpack's asyncWebAssembly experiment does not support
+   * (fails with "Can't resolve 'GOT.func'"). The fix is NOT to make
+   * Webpack bundle the .wasm -- it's to keep this package out of the
+   * Webpack bundle entirely and let Node's native require() load it at
+   * runtime instead, same as the CLI does. This only matters server-side
+   * (API routes), since parsePython.ts is never imported client-side.
+   */
+  serverExternalPackages: ["web-tree-sitter", "tree-sitter-wasms"],
+
+  webpack: (config) => {
+    // require.resolve() on tree-sitter-python.wasm makes Webpack try to
+    // bundle the file's contents. serverExternalPackages alone does not
+    // stop this. The .wasm here uses Emscripten dylink, which Webpack's
+    // WebAssembly module types do not support -- so instead of asking
+    // Webpack to parse it as a WASM module, tell it to treat .wasm as a
+    // plain binary asset (copy file, return a resolvable path). The
+    // actual bytes get read by web-tree-sitter's own Node fs logic at
+    // runtime, not by Webpack.
+    config.module.rules.push({
+      test: /\.wasm$/,
+      type: "asset/resource",
+    });
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/packages/parser/python/parsePython.ts
+++ b/packages/parser/python/parsePython.ts
@@ -14,9 +14,16 @@ import type { FileInfo, ParsedFile, RawImport, RawExport } from "../../shared/ty
 // .ts file (its main entry resolves to an untyped .js — see PROGRES.md
 // gotchas). We deliberately load it as untyped and keep our own type safety
 // entirely in the TSNode interface below.
-const require = createRequire(import.meta.url);
+// Deliberately NOT named "require" -- Webpack's static analyzer matches on
+// the literal identifier "require" regardless of whether it is a real
+// CommonJS require or (as here) a variable from createRequire(), and tries
+// to statically bundle whatever it's called with. That breaks
+// serverExternalPackages, which only takes effect at module-resolution
+// time, after this static analysis already failed on the .wasm file below.
+// Renaming the identifier avoids triggering that analysis entirely.
+const nodeRequire = createRequire(import.meta.url);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const TreeSitter: any = require("web-tree-sitter");
+const TreeSitter: any = nodeRequire("web-tree-sitter");
 const { Parser, Language } = TreeSitter;
 
 // Minimal structural type for the parts of a web-tree-sitter node we use.
@@ -54,7 +61,7 @@ export function getPythonRuntime(): Promise<PythonRuntime> {
     runtimePromise = (async () => {
       await Parser.init();
       const parser = new Parser();
-      const wasmPath = require.resolve("tree-sitter-wasms/out/tree-sitter-python.wasm");
+      const wasmPath = nodeRequire.resolve("tree-sitter-wasms/out/tree-sitter-python.wasm");
       const language = await Language.load(wasmPath);
       parser.setLanguage(language);
       return { parser, language };


### PR DESCRIPTION
…mpact with severity heuristic); fix Webpack .wasm loading for web-tree-sitter; document both in PROGRES.md

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
