### PR TITLE
feat(web): edge labels + arrows + brighter highlight colors

### DIFF
--- a/apps/web/components/graph/GraphCanvas.tsx
+++ b/apps/web/components/graph/GraphCanvas.tsx
@@ -217,6 +217,27 @@ export function GraphCanvas() {
         onDoubleClick={handleSvgDoubleClick}
         onContextMenu={handleSvgContextMenu}
       >
+        <defs>
+          {[
+            ["import", "#E5E5E5"],
+            ["export", "#C9A6F5"],
+            ["call", "#8FC4FF"],
+            ["route-link", "#8FE8D8"],
+          ].map(([type, fillColor]) => (
+            <marker
+              key={type}
+              id={`arrow-${type}`}
+              viewBox="0 0 8 8"
+              refX="6"
+              refY="4"
+              markerWidth="5"
+              markerHeight="5"
+              orient="auto-start-reverse"
+            >
+              <path d="M0,0 L8,4 L0,8 Z" fill={fillColor} />
+            </marker>
+          ))}
+        </defs>
         <g transform={`translate(${transform.x}, ${transform.y}) scale(${transform.scale})`}>
           {graph.edges.map((edge) => {
             const sourcePos = positions.get(edge.source);

--- a/apps/web/components/graph/GraphEdge.tsx
+++ b/apps/web/components/graph/GraphEdge.tsx
@@ -8,7 +8,7 @@
 
 "use client";
 
-import { getGraphEdgeColor } from "@/theme/graphColors";
+import { getGraphEdgeColor, getGraphEdgeHighlightColor } from "@/theme/graphColors";
 import type { GraphEdge as GraphEdgeData } from "@/packages/shared/types";
 import type { GraphNodePosition } from "./GraphNode";
 
@@ -19,19 +19,65 @@ export interface GraphEdgeProps {
   isHighlighted: boolean;
 }
 
+const EDGE_LABELS: Record<string, string> = {
+  import: "imports",
+  export: "exports",
+  call: "calls",
+  "route-link": "routes to",
+};
+
+/**
+ * isHighlighted covers BOTH selected and hovered (see GraphCanvas.tsx).
+ * That means hovering a high fan-in hub node will pop a label on every one
+ * of its edges at once — could get noisy on a dense hub. Not restricted to
+ * click-only for now since that matches the existing highlight behavior
+ * (glow ring, thicker stroke) already used for both states. Revisit if
+ * hover turns out too busy in practice.
+ *
+ * KNOWN LIMITATION: line endpoints are node CENTERS, not circle edges, so
+ * the arrowhead marker lands under/inside the target node's circle rather
+ * than stopping cleanly at its boundary. Fixing this needs the line to be
+ * shortened by the node's rendered radius, which isn't threaded through
+ * here yet — out of scope for this change.
+ */
 export function GraphEdge({ edge, sourcePos, targetPos, isHighlighted }: GraphEdgeProps) {
-  const color = getGraphEdgeColor(edge.type, "dark");
+  const dimColor = getGraphEdgeColor(edge.type, "dark");
+  const brightColor = getGraphEdgeHighlightColor(edge.type);
+  const color = isHighlighted ? brightColor : dimColor;
+
+  const midX = (sourcePos.x + targetPos.x) / 2;
+  const midY = (sourcePos.y + targetPos.y) / 2;
+  const label = EDGE_LABELS[edge.type] ?? edge.type;
 
   return (
-    <line
-      x1={sourcePos.x}
-      y1={sourcePos.y}
-      x2={targetPos.x}
-      y2={targetPos.y}
-      stroke={color}
-      strokeWidth={isHighlighted ? 1.5 : 0.75}
-      strokeOpacity={isHighlighted ? 0.9 : 0.35}
-      className="pointer-events-none"
-    />
+    <g>
+      <line
+        x1={sourcePos.x}
+        y1={sourcePos.y}
+        x2={targetPos.x}
+        y2={targetPos.y}
+        stroke={color}
+        strokeWidth={isHighlighted ? 1.5 : 0.75}
+        strokeOpacity={isHighlighted ? 1 : 0.35}
+        markerEnd={isHighlighted ? `url(#arrow-${edge.type})` : undefined}
+        className="pointer-events-none"
+      />
+      {isHighlighted && (
+        <g transform={`translate(${midX}, ${midY})`} className="pointer-events-none">
+          <rect
+            x={-label.length * 3.1}
+            y={-7}
+            width={label.length * 6.2}
+            height={14}
+            rx={3}
+            fill="#000"
+            fillOpacity={0.75}
+          />
+          <text x={0} y={4} fontSize={10} fontFamily="monospace" fill={brightColor} textAnchor="middle">
+            {label}
+          </text>
+        </g>
+      )}
+    </g>
   );
 }

--- a/apps/web/theme/graphColors.ts
+++ b/apps/web/theme/graphColors.ts
@@ -31,3 +31,23 @@ export function getGraphNodeColor(type: GraphNodeType, mode: "light" | "dark" = 
 export function getGraphEdgeColor(type: GraphEdgeType, mode: "light" | "dark" = "dark"): string {
   return graphEdgeColors[type][mode];
 }
+
+/**
+ * Brighter, hand-picked colors for HIGHLIGHTED edges only. graphEdgeColors
+ * dark["import"] (#454545) is deliberately dim so a busy graph doesn't look
+ * noisy at rest, but that same dimness makes it nearly invisible against
+ * GraphCanvas's black background once selected/hovered. These are NOT a
+ * theme mode (no light/dark split) — GraphCanvas is hardcoded to a black
+ * background regardless of app theme, so "highlighted" only ever needs
+ * one bright variant per edge type.
+ */
+const graphEdgeHighlightColors: Record<GraphEdgeType, string> = {
+  import: "#E5E5E5",
+  export: "#C9A6F5",
+  call: "#8FC4FF",
+  "route-link": "#8FE8D8",
+};
+
+export function getGraphEdgeHighlightColor(type: GraphEdgeType): string {
+  return graphEdgeHighlightColors[type];
+}


### PR DESCRIPTION
Highlighted edges now show a direction arrow (markerEnd) and a type label (imports/exports/calls/routes to) at the midpoint. Dim edge colors (esp. import #454545) were near-invisible on selection against the black canvas background, added separate brighter highlight-only colors. Not yet visually verified after this exact patch — verify before trusting.