### PR TITLE
fix(graph): container resize no longer resets force simulation

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -871,3 +871,39 @@ external-package not yet visually confirmed since that subgraph happened
 to be all-file). Edge label/arrow/color change was NOT visually verified
 before merging — pushed under time pressure near a chat context limit,
 confirm in-browser before relying on it.
+
+## Update — GraphFocusView (new): replaces overlapping edge labels on high-fan-in nodes
+
+Dogfooding on the graph viewer against the arclux repo itself (mobile
+screenshot) showed hovering a high-fan-in node (index.ts, 85 incoming
+edges) popped dozens of overlapping "imports" labels on the canvas —
+unreadable. This is the same root cause already flagged in GraphEdge.tsx's
+own comment (isHighlighted covers hover, not scoped per-edge).
+
+Rather than patch the label-overlap directly, built a different
+interaction: `apps/web/components/graph/GraphFocusView.tsx` — a full-panel
+overlay (replaces `GraphSelection.tsx` in `GraphViewport.tsx`) that opens
+on node selection, showing DIRECT dependencies/dependents as two columns
+of labeled cards (icon + name + path, reusing `getGraphNodeColor` /
+`nodeIcons.tsx` already in the codebase). Capped at 12 cards per side
+("+N more") specifically because of the 85-incoming-edge case found in
+this same repo — an uncapped list would just move the unreadability
+problem into the panel instead of fixing it.
+
+Scope: DIRECT neighbors only, not transitive — this is a readable local
+map, not a replacement for `traceConsumers`/`traceDependencies` in
+packages/impact/*.
+
+**NOT YET DONE**: the underlying canvas label-overlap bug (GraphEdge.tsx)
+is still there — GraphFocusView is a new, separate way to inspect a
+node's connections, it doesn't fix hover behavior on the canvas itself.
+Also **not visually verified in-browser yet** — only typechecked
+(`tsc --noEmit -p apps/web/tsconfig.json`), pushed under time pressure
+near a chat context limit. Confirm visually before relying on it,
+same caveat as the earlier edge-label/arrow update.
+
+**Repo now requires branch protection on `main`** (PR required, verified
+by testing it against ourselves earlier) — this was pushed via
+`feat/graph-focus-view` branch + PR, not direct push. Any future session:
+you CANNOT `git push` directly to `main` anymore, always
+`git checkout -b <branch>` first.

--- a/apps/web/components/graph/GraphCanvas.tsx
+++ b/apps/web/components/graph/GraphCanvas.tsx
@@ -78,7 +78,13 @@ export function GraphCanvas() {
           .distance(60)
       )
       .force("charge", forceManyBody().strength(-120))
-      .force("center", forceCenter(dimensions.width / 2, dimensions.height / 2))
+      // Fixed virtual center, NOT dimensions.width/height. The simulation's
+      // coordinate space is independent of the actual container size —
+      // panning/zooming (via `transform`) is what maps simulation space to
+      // screen space. Using a fixed center means resizing the container
+      // (e.g. a side panel opening/closing) never needs to re-run this
+      // effect, since dimensions is no longer a dependency below.
+      .force("center", forceCenter(500, 500))
       .force("collide", forceCollide(14))
       .stop();
 
@@ -90,7 +96,13 @@ export function GraphCanvas() {
       nextPositions.set(n.id, { x: n.x ?? 0, y: n.y ?? 0 });
     }
     setPositions(nextPositions);
-  }, [graph, dimensions.width, dimensions.height, setPositions]);
+    // dimensions intentionally NOT a dependency anymore — see the
+    // forceCenter comment above. Previously this effect re-ran (and reset
+    // ALL node positions from scratch) any time the container resized,
+    // e.g. a side panel opening/closing. Re-centering the VIEWPORT on
+    // resize is a separate, not-yet-implemented concern that should adjust
+    // `transform`, not re-run the simulation.
+  }, [graph, setPositions]);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
GraphCanvas's simulation effect had dimensions.width/height in its dependency array, so any container resize (e.g. a side panel toggling) re-ran the ENTIRE force simulation from scratch, discarding existing node positions — this is what caused edges to visually disappear when closing a panel. Fixed by using a fixed virtual center for forceCenter() instead of actual container dimensions, and removing dimensions from the dependency array. Verified manually in the browser: open/close panel no longer resets node positions.