### PR TITLE
fix(graph): edges stay visible when no node selected

### DIFF
--- a/apps/web/components/graph/GraphEdge.tsx
+++ b/apps/web/components/graph/GraphEdge.tsx
@@ -57,8 +57,8 @@ export function GraphEdge({ edge, sourcePos, targetPos, isHighlighted }: GraphEd
         x2={targetPos.x}
         y2={targetPos.y}
         stroke={color}
-        strokeWidth={isHighlighted ? 1.5 : 0.75}
-        strokeOpacity={isHighlighted ? 1 : 0.35}
+        strokeWidth={isHighlighted ? 1.5 : 1}
+        strokeOpacity={isHighlighted ? 1 : 0.6}
         markerEnd={isHighlighted ? `url(#arrow-${edge.type})` : undefined}
         className="pointer-events-none"
       />


### PR DESCRIPTION
Default (non-highlighted) edge stroke was opacity 0.35 / width 0.75, which on a dark background reads as 'lines disappeared' when deselecting a node. Raised to opacity 0.6 / width 1 so edges remain clearly visible at all times.