### PR TITLE
fix: keep node highlighted after closing focus panel

### DIFF
--- a/apps/web/components/graph/GraphFocusView.tsx
+++ b/apps/web/components/graph/GraphFocusView.tsx
@@ -13,6 +13,10 @@
 // labels floating on the physics-simulated canvas, selecting a node opens
 // this fixed two-column panel: labeled cards (name + path) grouped by
 // direction, no overlapping text regardless of fan-in count.
+//
+// Closing this panel (closeFocusPanel) is deliberately separate from
+// deselecting the node (selectNode(null)): the panel can hide while the
+// node stays highlighted in GraphCanvas.
 
 "use client";
 
@@ -59,10 +63,10 @@ function NodeCard({ node, onClick }: { node: GraphNodeData; onClick: () => void 
 }
 
 export function GraphFocusView() {
-  const { graph, selectedNodeId, selectNode } = useGraphContext();
+  const { graph, selectedNodeId, selectNode, isFocusPanelOpen, closeFocusPanel } = useGraphContext();
 
   const node = graph?.nodes.find((n) => n.id === selectedNodeId);
-  if (!node || !graph) return null;
+  if (!node || !graph || !isFocusPanelOpen) return null;
 
   const dependencies = graph.edges
     .filter((e) => e.source === node.id)
@@ -87,7 +91,7 @@ export function GraphFocusView() {
           </div>
         </div>
         <button
-          onClick={() => selectNode(null)}
+          onClick={closeFocusPanel}
           aria-label="Close focus view"
           className="rounded p-1 text-neutral-500 transition-colors hover:bg-neutral-800 hover:text-neutral-200"
         >

--- a/apps/web/components/graph/GraphProvider.tsx
+++ b/apps/web/components/graph/GraphProvider.tsx
@@ -34,6 +34,8 @@ interface GraphContextValue {
   error: string | null;
   selectedNodeId: string | null;
   selectNode: (id: string | null) => void;
+  isFocusPanelOpen: boolean;
+  closeFocusPanel: () => void;
   hoveredNodeId: string | null;
   setHoveredNodeId: (id: string | null) => void;
   transform: GraphTransform;
@@ -62,6 +64,7 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [isFocusPanelOpen, setIsFocusPanelOpen] = useState(false);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [transform, setTransform] = useState<GraphTransform>(DEFAULT_TRANSFORM);
   const [contextMenuNodeId, setContextMenuNodeId] = useState<string | null>(null);
@@ -102,6 +105,19 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
     };
   }, [repoUrl, branch]);
 
+  // Selecting a node highlights it AND opens the focus panel. Closing the
+  // panel (closeFocusPanel) does NOT clear selectedNodeId, so the graph
+  // highlight survives the panel closing. Only selectNode(null) — clicking
+  // empty canvas or Escape — clears both.
+  const selectNode = useCallback((id: string | null) => {
+    setSelectedNodeId(id);
+    setIsFocusPanelOpen(id !== null);
+  }, []);
+
+  const closeFocusPanel = useCallback(() => {
+    setIsFocusPanelOpen(false);
+  }, []);
+
   const zoomIn = useCallback(() => {
     setTransform((t) => ({ ...t, scale: Math.min(MAX_SCALE, t.scale * 1.2) }));
   }, []);
@@ -119,7 +135,9 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
     isLoading,
     error,
     selectedNodeId,
-    selectNode: setSelectedNodeId,
+    selectNode,
+    isFocusPanelOpen,
+    closeFocusPanel,
     hoveredNodeId,
     setHoveredNodeId,
     transform,


### PR DESCRIPTION
Closing GraphFocusView no longer clears selectedNodeId, so the graph highlight persists after the panel is dismissed.