### PR TITLE
fix: edges stop at node boundary, not center

### DIFF
--- a/apps/web/components/graph/GraphEdge.tsx
+++ b/apps/web/components/graph/GraphEdge.tsx
@@ -17,6 +17,14 @@ export interface GraphEdgeProps {
   sourcePos: GraphNodePosition;
   targetPos: GraphNodePosition;
   isHighlighted: boolean;
+  /**
+   * Rendered radius of source/target node circles, so the line can be
+   * shortened to stop cleanly at each boundary instead of ending at the
+   * node's center. Defaults to the base GraphNode radius; pass the actual
+   * value if selected/hovered nodes render at a different size.
+   */
+  sourceRadius?: number;
+  targetRadius?: number;
 }
 
 const EDGE_LABELS: Record<string, string> = {
@@ -26,6 +34,33 @@ const EDGE_LABELS: Record<string, string> = {
   "route-link": "routes to",
 };
 
+const DEFAULT_NODE_RADIUS = 7;
+
+/**
+ * Returns the point where the line from `from` to `to` crosses the
+ * boundary of a circle of `radius` centered at `from`. Used to shorten
+ * both ends of an edge so it stops at each node's circle edge instead of
+ * its center — this replaces the earlier center-to-center line, which
+ * made highlighted arrowheads land under/inside the target node instead
+ * of stopping cleanly at its boundary (see GraphCanvas.tsx PROGRES.md
+ * note). Falls back to `from` itself if the two points coincide, to avoid
+ * a divide-by-zero.
+ */
+function shortenToCircleBoundary(
+  from: GraphNodePosition,
+  to: GraphNodePosition,
+  radius: number
+): GraphNodePosition {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  if (dist === 0) return from;
+  return {
+    x: from.x + (dx / dist) * radius,
+    y: from.y + (dy / dist) * radius,
+  };
+}
+
 /**
  * isHighlighted covers BOTH selected and hovered (see GraphCanvas.tsx).
  * That means hovering a high fan-in hub node will pop a label on every one
@@ -33,29 +68,33 @@ const EDGE_LABELS: Record<string, string> = {
  * click-only for now since that matches the existing highlight behavior
  * (glow ring, thicker stroke) already used for both states. Revisit if
  * hover turns out too busy in practice.
- *
- * KNOWN LIMITATION: line endpoints are node CENTERS, not circle edges, so
- * the arrowhead marker lands under/inside the target node's circle rather
- * than stopping cleanly at its boundary. Fixing this needs the line to be
- * shortened by the node's rendered radius, which isn't threaded through
- * here yet — out of scope for this change.
  */
-export function GraphEdge({ edge, sourcePos, targetPos, isHighlighted }: GraphEdgeProps) {
+export function GraphEdge({
+  edge,
+  sourcePos,
+  targetPos,
+  isHighlighted,
+  sourceRadius = DEFAULT_NODE_RADIUS,
+  targetRadius = DEFAULT_NODE_RADIUS,
+}: GraphEdgeProps) {
   const dimColor = getGraphEdgeColor(edge.type, "dark");
   const brightColor = getGraphEdgeHighlightColor(edge.type);
   const color = isHighlighted ? brightColor : dimColor;
 
-  const midX = (sourcePos.x + targetPos.x) / 2;
-  const midY = (sourcePos.y + targetPos.y) / 2;
+  const adjustedSource = shortenToCircleBoundary(sourcePos, targetPos, sourceRadius);
+  const adjustedTarget = shortenToCircleBoundary(targetPos, sourcePos, targetRadius);
+
+  const midX = (adjustedSource.x + adjustedTarget.x) / 2;
+  const midY = (adjustedSource.y + adjustedTarget.y) / 2;
   const label = EDGE_LABELS[edge.type] ?? edge.type;
 
   return (
     <g>
       <line
-        x1={sourcePos.x}
-        y1={sourcePos.y}
-        x2={targetPos.x}
-        y2={targetPos.y}
+        x1={adjustedSource.x}
+        y1={adjustedSource.y}
+        x2={adjustedTarget.x}
+        y2={adjustedTarget.y}
         stroke={color}
         strokeWidth={isHighlighted ? 1.5 : 1}
         strokeOpacity={isHighlighted ? 1 : 0.6}

--- a/apps/web/components/graph/GraphFocusView.tsx
+++ b/apps/web/components/graph/GraphFocusView.tsx
@@ -13,6 +13,10 @@
 // labels floating on the physics-simulated canvas, selecting a node opens
 // this fixed two-column panel: labeled cards (name + path) grouped by
 // direction, no overlapping text regardless of fan-in count.
+//
+// Closing this panel (closeFocusPanel) is deliberately separate from
+// deselecting the node (selectNode(null)): the panel can hide while the
+// node stays highlighted in GraphCanvas.
 
 "use client";
 
@@ -59,10 +63,10 @@ function NodeCard({ node, onClick }: { node: GraphNodeData; onClick: () => void 
 }
 
 export function GraphFocusView() {
-  const { graph, selectedNodeId, selectNode } = useGraphContext();
+  const { graph, selectedNodeId, selectNode, isFocusPanelOpen, closeFocusPanel } = useGraphContext();
 
   const node = graph?.nodes.find((n) => n.id === selectedNodeId);
-  if (!node || !graph) return null;
+  if (!node || !graph || !isFocusPanelOpen) return null;
 
   const dependencies = graph.edges
     .filter((e) => e.source === node.id)
@@ -87,7 +91,7 @@ export function GraphFocusView() {
           </div>
         </div>
         <button
-          onClick={() => selectNode(null)}
+          onClick={closeFocusPanel}
           aria-label="Close focus view"
           className="rounded p-1 text-neutral-500 transition-colors hover:bg-neutral-800 hover:text-neutral-200"
         >

--- a/apps/web/components/graph/GraphProvider.tsx
+++ b/apps/web/components/graph/GraphProvider.tsx
@@ -34,6 +34,8 @@ interface GraphContextValue {
   error: string | null;
   selectedNodeId: string | null;
   selectNode: (id: string | null) => void;
+  isFocusPanelOpen: boolean;
+  closeFocusPanel: () => void;
   hoveredNodeId: string | null;
   setHoveredNodeId: (id: string | null) => void;
   transform: GraphTransform;
@@ -62,6 +64,7 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [isFocusPanelOpen, setIsFocusPanelOpen] = useState(false);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [transform, setTransform] = useState<GraphTransform>(DEFAULT_TRANSFORM);
   const [contextMenuNodeId, setContextMenuNodeId] = useState<string | null>(null);
@@ -102,6 +105,19 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
     };
   }, [repoUrl, branch]);
 
+  // Selecting a node highlights it AND opens the focus panel. Closing the
+  // panel (closeFocusPanel) does NOT clear selectedNodeId, so the graph
+  // highlight survives the panel closing. Only selectNode(null) — clicking
+  // empty canvas or Escape — clears both.
+  const selectNode = useCallback((id: string | null) => {
+    setSelectedNodeId(id);
+    setIsFocusPanelOpen(id !== null);
+  }, []);
+
+  const closeFocusPanel = useCallback(() => {
+    setIsFocusPanelOpen(false);
+  }, []);
+
   const zoomIn = useCallback(() => {
     setTransform((t) => ({ ...t, scale: Math.min(MAX_SCALE, t.scale * 1.2) }));
   }, []);
@@ -119,7 +135,9 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
     isLoading,
     error,
     selectedNodeId,
-    selectNode: setSelectedNodeId,
+    selectNode,
+    isFocusPanelOpen,
+    closeFocusPanel,
     hoveredNodeId,
     setHoveredNodeId,
     transform,


### PR DESCRIPTION
Shortens both edge endpoints to the circle radius so highlighted arrowheads land on the boundary instead of under the target node.