### PR TITLE
fix: edge labels only on select, not hover

### DIFF
--- a/apps/web/components/graph/GraphCanvas.tsx
+++ b/apps/web/components/graph/GraphCanvas.tsx
@@ -260,6 +260,14 @@ export function GraphCanvas() {
               edge.target === selectedNodeId ||
               edge.source === hoveredNodeId ||
               edge.target === hoveredNodeId;
+            // Label only shows for the SELECTED node's edges, not hover —
+            // hovering a high fan-in hub was popping dozens of overlapping
+            // "imports" labels at once (see live dogfood screenshot).
+            // GraphFocusView already lists all connections cleanly on
+            // click, so the canvas label no longer needs to fire on hover
+            // too.
+            const showLabel =
+              edge.source === selectedNodeId || edge.target === selectedNodeId;
             return (
               <GraphEdge
                 key={edge.id}
@@ -267,6 +275,7 @@ export function GraphCanvas() {
                 sourcePos={sourcePos}
                 targetPos={targetPos}
                 isHighlighted={isHighlighted}
+                showLabel={showLabel}
               />
             );
           })}

--- a/apps/web/components/graph/GraphEdge.tsx
+++ b/apps/web/components/graph/GraphEdge.tsx
@@ -18,6 +18,14 @@ export interface GraphEdgeProps {
   targetPos: GraphNodePosition;
   isHighlighted: boolean;
   /**
+   * Whether to show the type label ("imports", "calls", etc) at the
+   * edge midpoint. Deliberately separate from isHighlighted: the line
+   * still lights up on hover, but the label only shows when this edge's
+   * node is actually SELECTED — otherwise hovering a high fan-in hub
+   * pops one label per edge at once, unreadable. See GraphCanvas.tsx.
+   */
+  showLabel: boolean;
+  /**
    * Rendered radius of source/target node circles, so the line can be
    * shortened to stop cleanly at each boundary instead of ending at the
    * node's center. Defaults to the base GraphNode radius; pass the actual
@@ -74,6 +82,7 @@ export function GraphEdge({
   sourcePos,
   targetPos,
   isHighlighted,
+  showLabel,
   sourceRadius = DEFAULT_NODE_RADIUS,
   targetRadius = DEFAULT_NODE_RADIUS,
 }: GraphEdgeProps) {
@@ -101,7 +110,7 @@ export function GraphEdge({
         markerEnd={isHighlighted ? `url(#arrow-${edge.type})` : undefined}
         className="pointer-events-none"
       />
-      {isHighlighted && (
+      {showLabel && (
         <g transform={`translate(${midX}, ${midY})`} className="pointer-events-none">
           <rect
             x={-label.length * 3.1}


### PR DESCRIPTION
Hovering a high fan-in hub node popped one overlapping label per edge. Labels now only render for the selected node's edges; hover still highlights the line itself.