### PR TITLE
feat(parser): add JS/JSX/CommonJS parsers (extractJs.ts shared, per-p…

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -980,3 +980,32 @@ changes pushed near a chat context limit. Confirm before relying on them:
 **Also still open from earlier**: GraphFocusView (two-column
 dependencies/dependents panel) was also pushed without visual
 verification in a previous update — still needs confirming.
+
+## Update -- JavaScript parser: parseJs/parseJsx/parseCommonJs written and registered
+
+packages/parser/javascript/extractJs.ts (shared) + parseJs.ts + parseJsx.ts
++ parseCommonJs.ts implemented and registered in packages/engine/pipeline.ts.
+Reuses TypeScript Compiler API with ScriptKind.JS/JSX (NOT reusing
+parseTs.ts's extractors directly -- those detect TS-only syntax like
+"import type" that plain JS can never have). Detects ES import/export,
+dynamic import(), require(), and per-property CommonJS
+(module.exports.x = / exports.x =).
+
+KNOWN GAP, NOT YET FIXED: whole-object exports
+(module.exports = { a, b }) are NOT detected -- only per-property
+assignment is. This under-reports exports for a lot of real-world
+CommonJS. Confirmed common via nodejs/cjs-module-lexer's own test fixtures
+(~/research/cjs-module-lexer/test/_unit.js) during research for this
+work. Follow-up PR needed for extractWholeObjectExports() (shorthand
+props, renamed props, string-literal keys, getter exports -- spread
+props and computed keys can stay unsupported/silently skipped for now).
+
+parseCommonJs.ts is currently behavior-identical to parseJs.ts (kept
+separate on purpose -- see its own file comment -- because the
+whole-object-exports follow-up is scoped to CommonJS specifically, not
+plain JS).
+
+NOT YET DONE: no playground fixture, no end-to-end verification via
+scripts/testPlayground.ts or CLI doctor -- only tsc --noEmit passed so
+far. Next session should build playground/commonjs-demo/ using patterns
+from cjs-module-lexer's test file before trusting this beyond typecheck.

--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -14,6 +14,9 @@ import { buildDependencyGraph } from "../graph/buildDependencyGraph";
 import { parserRegistry } from "../parser/core/ParserRegistry";
 import { parseTs } from "../parser/typescript/parseTs";
 import { parsePython } from "../parser/python/parsePython";
+import { parseJs } from "../parser/javascript/parseJs";
+import { parseJsx } from "../parser/javascript/parseJsx";
+import { parseCommonJs } from "../parser/javascript/parseCommonJs";
 import { detectFrameworks, detectPackageManager } from "./detectRepositoryMeta";
 import { ArcluxError, isArcluxError } from "../shared/errors";
 import type { DependencyGraph, RepositoryMeta } from "../shared/types";
@@ -26,6 +29,9 @@ function ensureParsersRegistered() {
   if (parsersRegistered) return;
   parserRegistry.register(parseTs);
   parserRegistry.register(parsePython);
+parserRegistry.register(parseJs);
+parserRegistry.register(parseJsx);
+parserRegistry.register(parseCommonJs);
   parsersRegistered = true;
 }
 

--- a/packages/parser/javascript/extractJs.ts
+++ b/packages/parser/javascript/extractJs.ts
@@ -1,0 +1,227 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import ts from "typescript";
+import type { RawImport, RawExport, ImportKind } from "../../shared/types";
+
+// Shared by parseJs.ts, parseJsx.ts, parseCommonJs.ts. Deliberately NOT
+// reusing packages/parser/typescript/parseTs.ts's extractImports/
+// extractExports -- the TS version detects TS-only syntax ("import type",
+// interfaces) that plain JS/CJS files can never actually have. Reusing it
+// would silently overclaim features these files don't support. The two
+// implementations share structure on purpose (easier to compare/audit
+// side by side) but are kept as separate functions.
+
+function getLine(sourceFile: ts.SourceFile, pos: number): number {
+  return sourceFile.getLineAndCharacterOfPosition(pos).line + 1;
+}
+
+export function extractImportsJs(sourceFile: ts.SourceFile): RawImport[] {
+  const imports: RawImport[] = [];
+
+  function visit(node: ts.Node) {
+    // Static: import x, { y } from "z"
+    // (No "import type" here -- that's TS-only syntax, plain JS can't have it.)
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const namedImports: string[] = [];
+      let hasDefaultImport = false;
+      let hasNamespaceImport = false;
+      const kind: ImportKind = "static";
+
+      if (node.importClause) {
+        if (node.importClause.name) hasDefaultImport = true;
+        const bindings = node.importClause.namedBindings;
+        if (bindings && ts.isNamedImports(bindings)) {
+          for (const el of bindings.elements) {
+            namedImports.push(el.name.text);
+          }
+        } else if (bindings && ts.isNamespaceImport(bindings)) {
+          hasNamespaceImport = true;
+        }
+      }
+
+      imports.push({
+        source: node.moduleSpecifier.text,
+        kind,
+        namedImports,
+        hasDefaultImport,
+        hasNamespaceImport,
+        line: getLine(sourceFile, node.getStart()),
+      });
+    }
+
+    // Dynamic: await import("z")
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      imports.push({
+        source: node.arguments[0].text,
+        kind: "dynamic",
+        namedImports: [],
+        hasDefaultImport: false,
+        hasNamespaceImport: false,
+        line: getLine(sourceFile, node.getStart()),
+      });
+    }
+
+    // require("z")
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "require" &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      imports.push({
+        source: node.arguments[0].text,
+        kind: "require",
+        namedImports: [],
+        hasDefaultImport: false,
+        hasNamespaceImport: false,
+        line: getLine(sourceFile, node.getStart()),
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return imports;
+}
+
+/**
+ * Recognizes `module.exports.NAME = ...` and `exports.NAME = ...`
+ * (per-property CommonJS assignment). Deliberately does NOT handle
+ * whole-object exports (`module.exports = { a, b }`) -- that's a known
+ * gap, tracked as follow-up work (see PROGRES.md). Real-world CommonJS
+ * uses whole-object assignment extremely often, so this alone
+ * under-reports exports for many packages until that follow-up lands.
+ */
+function matchCommonJsExportTarget(expr: ts.Expression): string | null {
+  // exports.NAME
+  if (
+    ts.isPropertyAccessExpression(expr) &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "exports"
+  ) {
+    return expr.name.text;
+  }
+
+  // module.exports.NAME
+  if (
+    ts.isPropertyAccessExpression(expr) &&
+    ts.isPropertyAccessExpression(expr.expression) &&
+    ts.isIdentifier(expr.expression.expression) &&
+    expr.expression.expression.text === "module" &&
+    expr.expression.name.text === "exports"
+  ) {
+    return expr.name.text;
+  }
+
+  return null;
+}
+
+export function extractExportsJs(sourceFile: ts.SourceFile): RawExport[] {
+  const exports: RawExport[] = [];
+
+  function visit(node: ts.Node) {
+    // export default ...
+    const isDefaultExport =
+      (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword);
+
+    if (isDefaultExport) {
+      exports.push({
+        name: (node as ts.FunctionDeclaration | ts.ClassDeclaration).name?.text ?? "default",
+        kind: "default",
+        line: getLine(sourceFile, node.getStart()),
+      });
+    }
+
+    // See parseTs.ts's identical guard for why !isDefaultExport matters:
+    // "export default function X()" carries both Default and Export
+    // modifiers on the same node, so without this it gets double-counted.
+    const hasExportModifier =
+      !isDefaultExport &&
+      (node as ts.Node & { modifiers?: ts.NodeArray<ts.ModifierLike> })
+        .modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+
+    if (hasExportModifier) {
+      if (ts.isVariableStatement(node)) {
+        for (const decl of node.declarationList.declarations) {
+          if (ts.isIdentifier(decl.name)) {
+            exports.push({
+              name: decl.name.text,
+              kind: "named",
+              line: getLine(sourceFile, node.getStart()),
+            });
+          }
+        }
+      } else if (
+        (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) &&
+        node.name
+      ) {
+        exports.push({
+          name: node.name.text,
+          kind: "named",
+          line: getLine(sourceFile, node.getStart()),
+        });
+      }
+    }
+
+    // export { a, b } from "./x"  /  export * from "./x"
+    if (ts.isExportDeclaration(node)) {
+      const reExportSource =
+        node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)
+          ? node.moduleSpecifier.text
+          : undefined;
+
+      if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+        for (const el of node.exportClause.elements) {
+          exports.push({
+            name: el.name.text,
+            kind: reExportSource ? "re-export" : "named",
+            reExportSource,
+            line: getLine(sourceFile, node.getStart()),
+          });
+        }
+      } else if (reExportSource) {
+        exports.push({
+          name: "*",
+          kind: "re-export",
+          reExportSource,
+          line: getLine(sourceFile, node.getStart()),
+        });
+      }
+    }
+
+    // CommonJS: module.exports.NAME = ... / exports.NAME = ...
+    if (
+      ts.isExpressionStatement(node) &&
+      ts.isBinaryExpression(node.expression) &&
+      node.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken
+    ) {
+      const target = matchCommonJsExportTarget(node.expression.left);
+      if (target !== null) {
+        exports.push({
+          name: target,
+          kind: "named",
+          line: getLine(sourceFile, node.getStart()),
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return exports;
+}

--- a/packages/parser/javascript/parseCommonJs.ts
+++ b/packages/parser/javascript/parseCommonJs.ts
@@ -6,3 +6,43 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Currently identical behavior to parseJs.ts -- extractJs.ts already
+// detects require()/module.exports.x/exports.x regardless of ScriptKind.
+// Kept as a separate named parser (rather than folding into parseJs.ts)
+// because CommonJS-specific handling (whole-object exports, the
+// stop-at-first-unsafe-value scanning behavior cjs-module-lexer uses) is
+// planned as follow-up work scoped to this file specifically -- see
+// PROGRES.md. Do not delete this file as "duplicate of parseJs.ts" without
+// checking PROGRES.md first.
+import ts from "typescript";
+import type { LanguageParser } from "../core/ParserInterface";
+import type { FileInfo, ParsedFile } from "../../shared/types";
+import { extractImportsJs, extractExportsJs } from "./extractJs";
+
+export const parseCommonJs: LanguageParser = {
+  supportedLanguages: ["javascript"],
+  extensions: [".cjs"],
+
+  async parse(file: FileInfo, content: string): Promise<ParsedFile> {
+    const warnings: string[] = [];
+    let sourceFile: ts.SourceFile;
+    try {
+      sourceFile = ts.createSourceFile(
+        file.absolutePath,
+        content,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.JS
+      );
+    } catch (err) {
+      warnings.push(`Failed to parse: ${(err as Error).message}`);
+      return { file, imports: [], exports: [], warnings };
+    }
+    return {
+      file,
+      imports: extractImportsJs(sourceFile),
+      exports: extractExportsJs(sourceFile),
+      warnings,
+    };
+  },
+};

--- a/packages/parser/javascript/parseJs.ts
+++ b/packages/parser/javascript/parseJs.ts
@@ -6,3 +6,35 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import ts from "typescript";
+import type { LanguageParser } from "../core/ParserInterface";
+import type { FileInfo, ParsedFile } from "../../shared/types";
+import { extractImportsJs, extractExportsJs } from "./extractJs";
+
+export const parseJs: LanguageParser = {
+  supportedLanguages: ["javascript"],
+  extensions: [".js", ".mjs", ".cjs"],
+
+  async parse(file: FileInfo, content: string): Promise<ParsedFile> {
+    const warnings: string[] = [];
+    let sourceFile: ts.SourceFile;
+    try {
+      sourceFile = ts.createSourceFile(
+        file.absolutePath,
+        content,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.JS
+      );
+    } catch (err) {
+      warnings.push(`Failed to parse: ${(err as Error).message}`);
+      return { file, imports: [], exports: [], warnings };
+    }
+    return {
+      file,
+      imports: extractImportsJs(sourceFile),
+      exports: extractExportsJs(sourceFile),
+      warnings,
+    };
+  },
+};

--- a/packages/parser/javascript/parseJsx.ts
+++ b/packages/parser/javascript/parseJsx.ts
@@ -6,3 +6,35 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import ts from "typescript";
+import type { LanguageParser } from "../core/ParserInterface";
+import type { FileInfo, ParsedFile } from "../../shared/types";
+import { extractImportsJs, extractExportsJs } from "./extractJs";
+
+export const parseJsx: LanguageParser = {
+  supportedLanguages: ["jsx"],
+  extensions: [".jsx"],
+
+  async parse(file: FileInfo, content: string): Promise<ParsedFile> {
+    const warnings: string[] = [];
+    let sourceFile: ts.SourceFile;
+    try {
+      sourceFile = ts.createSourceFile(
+        file.absolutePath,
+        content,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.JSX
+      );
+    } catch (err) {
+      warnings.push(`Failed to parse: ${(err as Error).message}`);
+      return { file, imports: [], exports: [], warnings };
+    }
+    return {
+      file,
+      imports: extractImportsJs(sourceFile),
+      exports: extractExportsJs(sourceFile),
+      warnings,
+    };
+  },
+};


### PR DESCRIPTION
…roperty CommonJS only, whole-object exports gap tracked in PROGRES.md)

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
