### PR TITLE
feat: add Go and Java parsers, register in pipeline and testPlayground

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -1009,3 +1009,42 @@ NOT YET DONE: no playground fixture, no end-to-end verification via
 scripts/testPlayground.ts or CLI doctor -- only tsc --noEmit passed so
 far. Next session should build playground/commonjs-demo/ using patterns
 from cjs-module-lexer's test file before trusting this beyond typecheck.
+
+## Update — Go & Java parsers written and verified (parseGo.ts, parseJava.ts)
+
+packages/parser/go/parseGo.ts and packages/parser/java/parseJava.ts
+implemented (regex/line-based, not tree-sitter — no grammar wired up for
+either language yet, unlike Python). Registered in both
+packages/engine/pipeline.ts AND scripts/testPlayground.ts (the latter had
+been silently only registering parseTs+parsePython — same class of bug as
+files getting skipped in buildIndex.ts's "no parser registered, skip
+silently" path, worth remembering next time a new parser is added
+anywhere).
+
+**Verified via scripts/testPlayground.ts against playground/go-demo and
+playground/java-demo (not just tsc --noEmit)**:
+- 6/6 modules indexed in both fixtures (previously 0, confirming parsers
+  are now actually registered and running)
+- Export extraction confirmed correct: Go's uppercase-first-letter
+  convention (HelperA, User, Product, Slugify, UnusedHelper) and Java's
+  `public` modifier convention (class/method/field level) both extract
+  the expected names, matching what each fixture file was written to
+  contain — including the deliberately-unused UnusedHelper/unusedHelper
+  in each
+
+**EXPECTED LIMITATION, confirmed empirically, NOT a bug**: both fixtures
+show 0 graph edges despite real cross-file calls existing (cyclic_a.go
+calls HelperB in cyclic_b.go, Main.java calls Service/Models/Utils) —
+this is because Go and Java don't require any import statement between
+files in the same package/directory, so there's nothing for
+resolvePath.ts to resolve. This makes every file/export in both fixtures
+show up as a false positive in detectOrphanFiles/detectUnusedExports/
+detectUnusedFiles, same root cause class as the already-documented
+Python/main.py false positive from resolveRoutes.ts being empty. A
+"same-package implicit dependency" resolution pass would be needed to
+fix this for Go/Java specifically — not yet built, not scoped.
+
+**NOT yet tested**: real-world Go/Java repos beyond the playground fixture
+(multi-package Go with actual cross-package imports, Java with actual
+`import demo.other.Thing;` statements) — only the same-package-only
+fixture has been verified so far.

--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -17,6 +17,8 @@ import { parsePython } from "../parser/python/parsePython";
 import { parseJs } from "../parser/javascript/parseJs";
 import { parseJsx } from "../parser/javascript/parseJsx";
 import { parseCommonJs } from "../parser/javascript/parseCommonJs";
+import { parseGo } from "../parser/go/parseGo";
+import { parseJava } from "../parser/java/parseJava";
 import { detectFrameworks, detectPackageManager } from "./detectRepositoryMeta";
 import { ArcluxError, isArcluxError } from "../shared/errors";
 import type { DependencyGraph, RepositoryMeta } from "../shared/types";
@@ -29,9 +31,11 @@ function ensureParsersRegistered() {
   if (parsersRegistered) return;
   parserRegistry.register(parseTs);
   parserRegistry.register(parsePython);
-parserRegistry.register(parseJs);
-parserRegistry.register(parseJsx);
-parserRegistry.register(parseCommonJs);
+  parserRegistry.register(parseJs);
+  parserRegistry.register(parseJsx);
+  parserRegistry.register(parseCommonJs);
+  parserRegistry.register(parseGo);
+  parserRegistry.register(parseJava);
   parsersRegistered = true;
 }
 

--- a/packages/parser/go/parseGo.ts
+++ b/packages/parser/go/parseGo.ts
@@ -6,3 +6,155 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { LanguageParser } from "../core/ParserInterface";
+import type { FileInfo, ParsedFile, RawImport, RawExport } from "../../shared/types";
+
+// Regex/line-based, not a full Go grammar (no tree-sitter-go grammar wired up
+// yet, unlike Python — see PROGRES.md gotchas for why that's non-trivial to
+// add). Handles the common cases: single-line imports, parenthesized import
+// blocks, and top-level func/type/var/const declarations. Does NOT handle
+// multi-line generic type params or declarations split across lines in
+// unusual ways.
+//
+// IMPORTANT LIMITATION: Go has no relative-import syntax between files in the
+// same package — all .go files in one directory implicitly share scope, so a
+// function in cyclic_a.go can call one in cyclic_b.go with zero import
+// statements (see playground/go-demo). This parser only extracts what's
+// actually written, so same-package cross-file calls will NOT show up as
+// graph edges via resolvePath.ts today. That requires a separate
+// "same-package implicit dependency" resolution pass, not yet built — same
+// class of gap as resolveRoutes.ts being empty for Next.js route awareness.
+
+function stripLineComment(line: string): string {
+  const idx = line.indexOf("//");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+function makeImport(source: string, line: number): RawImport {
+  return {
+    source,
+    kind: "static",
+    namedImports: [],
+    hasDefaultImport: false,
+    hasNamespaceImport: false,
+    line,
+  };
+}
+
+function extractImports(content: string): RawImport[] {
+  const imports: RawImport[] = [];
+  const lines = content.split("\n");
+  let inBlock = false;
+  let blockStartLine = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = stripLineComment(lines[i]).trim();
+    if (!line) continue;
+
+    if (!inBlock) {
+      if (/^import\s*\(\s*$/.test(line)) {
+        inBlock = true;
+        blockStartLine = i + 1;
+        continue;
+      }
+
+      const singleMatch = line.match(/^import\s+(?:(_|\.|\w+)\s+)?"([^"]+)"/);
+      if (singleMatch) {
+        imports.push(makeImport(singleMatch[2], i + 1));
+      }
+      continue;
+    }
+
+    if (line === ")") {
+      inBlock = false;
+      continue;
+    }
+
+    const entryMatch = line.match(/^(?:(_|\.|\w+)\s+)?"([^"]+)"/);
+    if (entryMatch) {
+      imports.push(makeImport(entryMatch[2], blockStartLine));
+    }
+  }
+
+  return imports;
+}
+
+// Go has no `export` keyword — an identifier is exported iff its first letter
+// is uppercase. This applies to func, type, var, and const declarations.
+function extractExports(content: string): RawExport[] {
+  const exports: RawExport[] = [];
+  const lines = content.split("\n");
+
+  const funcPattern = /^func\s+(?:\([^)]*\)\s+)?([A-Z]\w*)\s*[[(]/;
+  const typePattern = /^type\s+([A-Z]\w*)\b/;
+  const varConstPattern = /^(?:var|const)\s+([A-Z]\w*)\b/;
+  const varConstBlockEntryPattern = /^([A-Z]\w*)\b/;
+
+  let inVarConstBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = stripLineComment(lines[i]).trim();
+    if (!line) continue;
+
+    if (inVarConstBlock) {
+      if (line === ")") {
+        inVarConstBlock = false;
+        continue;
+      }
+      const entryMatch = line.match(varConstBlockEntryPattern);
+      if (entryMatch) {
+        exports.push({ name: entryMatch[1], kind: "named", line: i + 1 });
+      }
+      continue;
+    }
+
+    if (/^(?:var|const)\s*\(\s*$/.test(line)) {
+      inVarConstBlock = true;
+      continue;
+    }
+
+    const funcMatch = line.match(funcPattern);
+    if (funcMatch) {
+      exports.push({ name: funcMatch[1], kind: "named", line: i + 1 });
+      continue;
+    }
+
+    const typeMatch = line.match(typePattern);
+    if (typeMatch) {
+      exports.push({ name: typeMatch[1], kind: "named", line: i + 1 });
+      continue;
+    }
+
+    const varConstMatch = line.match(varConstPattern);
+    if (varConstMatch) {
+      exports.push({ name: varConstMatch[1], kind: "named", line: i + 1 });
+    }
+  }
+
+  return exports;
+}
+
+export const parseGo: LanguageParser = {
+  supportedLanguages: ["go"],
+  extensions: [".go"],
+
+  async parse(file: FileInfo, content: string): Promise<ParsedFile> {
+    const warnings: string[] = [];
+    let imports: RawImport[] = [];
+    let exportsList: RawExport[] = [];
+
+    try {
+      imports = extractImports(content);
+    } catch (err) {
+      warnings.push(`Import extraction failed: ${(err as Error).message}`);
+    }
+
+    try {
+      exportsList = extractExports(content);
+    } catch (err) {
+      warnings.push(`Export extraction failed: ${(err as Error).message}`);
+    }
+
+    return { file, imports, exports: exportsList, warnings };
+  },
+};

--- a/packages/parser/java/parseJava.ts
+++ b/packages/parser/java/parseJava.ts
@@ -6,3 +6,114 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { LanguageParser } from "../core/ParserInterface";
+import type { FileInfo, ParsedFile, RawImport, RawExport } from "../../shared/types";
+
+// Regex/line-based, not a full Java grammar. Handles import statements
+// (including `static` and wildcard `.*` imports) and public-modifier
+// class/interface/enum/record, method, and field declarations. Does NOT
+// handle multi-line method signatures, annotations spread across lines,
+// or generics with nested angle brackets containing commas.
+//
+// IMPORTANT LIMITATION: like Go, Java classes in the same package don't need
+// an import statement to reference each other (see playground/java-demo —
+// Main.java calls Service/Models/Utils with zero imports). This parser only
+// extracts what's actually written, so same-package cross-file references
+// will NOT show up as graph edges via resolvePath.ts today — same gap as
+// documented in parseGo.ts.
+
+function stripLineComment(line: string): string {
+  const idx = line.indexOf("//");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+function extractImports(content: string): RawImport[] {
+  const imports: RawImport[] = [];
+  const lines = content.split("\n");
+  const importPattern = /^import\s+(static\s+)?([\w.]+(?:\.\*)?)\s*;/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = stripLineComment(lines[i]).trim();
+    const match = line.match(importPattern);
+    if (!match) continue;
+
+    const isWildcard = match[2].endsWith(".*");
+    imports.push({
+      source: match[2],
+      kind: "static",
+      namedImports: isWildcard ? ["*"] : [],
+      hasDefaultImport: false,
+      hasNamespaceImport: isWildcard,
+      line: i + 1,
+    });
+  }
+
+  return imports;
+}
+
+// Only `public` members are treated as exports — `protected`/package-private
+// are visible within the package (relevant given the same-package limitation
+// above) but not truly "exported" in the cross-module sense this codebase
+// otherwise means by RawExport.
+function extractExports(content: string): RawExport[] {
+  const exports: RawExport[] = [];
+  const lines = content.split("\n");
+
+  const classPattern =
+    /^public\s+(?:static\s+)?(?:final\s+)?(?:abstract\s+)?(?:class|interface|enum|record)\s+(\w+)/;
+  const methodPattern = /^public\s+(?:static\s+)?(?:final\s+)?(?:synchronized\s+)?[\w<>[\],.]+\s+(\w+)\s*\(/;
+  const fieldPattern = /^public\s+(?:static\s+)?(?:final\s+)?[\w<>[\],.]+\s+(\w+)\s*(?:=.*)?;/;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = stripLineComment(lines[i]).trim();
+    if (!line) continue;
+
+    const classMatch = line.match(classPattern);
+    if (classMatch) {
+      exports.push({ name: classMatch[1], kind: "named", line: i + 1 });
+      continue;
+    }
+
+    if (line.includes("(")) {
+      const methodMatch = line.match(methodPattern);
+      if (methodMatch) {
+        exports.push({ name: methodMatch[1], kind: "named", line: i + 1 });
+        continue;
+      }
+    }
+
+    if (line.endsWith(";")) {
+      const fieldMatch = line.match(fieldPattern);
+      if (fieldMatch) {
+        exports.push({ name: fieldMatch[1], kind: "named", line: i + 1 });
+      }
+    }
+  }
+
+  return exports;
+}
+
+export const parseJava: LanguageParser = {
+  supportedLanguages: ["java"],
+  extensions: [".java"],
+
+  async parse(file: FileInfo, content: string): Promise<ParsedFile> {
+    const warnings: string[] = [];
+    let imports: RawImport[] = [];
+    let exportsList: RawExport[] = [];
+
+    try {
+      imports = extractImports(content);
+    } catch (err) {
+      warnings.push(`Import extraction failed: ${(err as Error).message}`);
+    }
+
+    try {
+      exportsList = extractExports(content);
+    } catch (err) {
+      warnings.push(`Export extraction failed: ${(err as Error).message}`);
+    }
+
+    return { file, imports, exports: exportsList, warnings };
+  },
+};

--- a/scripts/testPlayground.ts
+++ b/scripts/testPlayground.ts
@@ -40,10 +40,20 @@ import { detectRepositoryPattern } from "../packages/detectors/detectRepositoryP
 import { parserRegistry } from "../packages/parser/core/ParserRegistry";
 import { parseTs } from "../packages/parser/typescript/parseTs";
 import { parsePython } from "../packages/parser/python/parsePython";
+import { parseJs } from "../packages/parser/javascript/parseJs";
+import { parseJsx } from "../packages/parser/javascript/parseJsx";
+import { parseCommonJs } from "../packages/parser/javascript/parseCommonJs";
+import { parseGo } from "../packages/parser/go/parseGo";
+import { parseJava } from "../packages/parser/java/parseJava";
 import type { RepositoryMeta } from "../packages/shared/types";
 
 parserRegistry.register(parseTs);
 parserRegistry.register(parsePython);
+parserRegistry.register(parseJs);
+parserRegistry.register(parseJsx);
+parserRegistry.register(parseCommonJs);
+parserRegistry.register(parseGo);
+parserRegistry.register(parseJava);
 
 function printList<T>(label: string, items: T[], format: (item: T) => string) {
   console.log(`\n--- ${label} ---`);


### PR DESCRIPTION
## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
