### PR TITLE
feat: add ManifestParser interface, generic JSON/TOML/YAML config par…

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "d3-hierarchy": "^3.1.2",
     "ignore": "^6.0.2",
     "simple-git": "^3.27.0",
     "tree-sitter-wasms": "^0.1.13",
     "web-tree-sitter": "0.25.0"
   },
   "devDependencies": {
+    "@types/d3-hierarchy": "^3.1.7",
     "@types/node": "^20",
     "tsx": "^4.23.1",
     "turbo": "^2.3.0",

--- a/packages/parser/config/parseJson.ts
+++ b/packages/parser/config/parseJson.ts
@@ -6,3 +6,17 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+/**
+ * Thin wrapper around JSON.parse that never throws — malformed JSON in a
+ * manifest file (package.json, composer.json) should degrade to "no
+ * dependencies found", not crash the whole detection pass. Manifest parsers
+ * that are JSON-shaped (parsePackageJson.ts, parseComposer.ts) call this
+ * instead of JSON.parse directly.
+ */
+export function parseJson<T = unknown>(content: string): T | undefined {
+  try {
+    return JSON.parse(content) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/parser/config/parseToml.ts
+++ b/packages/parser/config/parseToml.ts
@@ -6,3 +6,53 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+/**
+ * Minimal TOML reader — NOT a full spec-compliant TOML parser (no arrays of
+ * tables, no inline tables, no multi-line strings). Handles exactly what
+ * Cargo.toml's [dependencies]/[dev-dependencies] sections need:
+ * `[section]` headers and `key = "value"` / `key = { version = "value", ... }`
+ * lines. Sufficient for parseCargoToml.ts; do not reuse this for a TOML file
+ * with more advanced syntax without extending it first.
+ */
+export interface TomlSection {
+  name: string;
+  entries: Record<string, string>;
+}
+
+export function parseTomlSections(content: string): TomlSection[] {
+  const sections: TomlSection[] = [];
+  let current: TomlSection | undefined;
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const sectionMatch = line.match(/^\[([^\]]+)\]$/);
+    if (sectionMatch) {
+      current = { name: sectionMatch[1], entries: {} };
+      sections.push(current);
+      continue;
+    }
+
+    if (!current) continue;
+
+    const kvMatch = line.match(/^([\w.-]+)\s*=\s*(.+)$/);
+    if (!kvMatch) continue;
+
+    const key = kvMatch[1];
+    let value = kvMatch[2].trim();
+
+    // Inline table like { version = "1.2.0", features = [...] } — pull out
+    // just the "version" field, since that's all callers need so far.
+    const inlineTableMatch = value.match(/version\s*=\s*"([^"]*)"/);
+    if (value.startsWith("{") && inlineTableMatch) {
+      value = inlineTableMatch[1];
+    } else {
+      value = value.replace(/^"(.*)"$/, "$1");
+    }
+
+    current.entries[key] = value;
+  }
+
+  return sections;
+}

--- a/packages/parser/config/parseYaml.ts
+++ b/packages/parser/config/parseYaml.ts
@@ -6,3 +6,26 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+/**
+ * Minimal flat-YAML key: value reader — NOT a full YAML parser (no nested
+ * mappings beyond one level of indentation, no anchors/aliases, no flow
+ * style). Currently unused by any manifest parser (no ARCLUX-supported
+ * language manifest is YAML-shaped), kept as a primitive for a future one
+ * (e.g. pubspec.yaml for Dart, if that's ever added).
+ */
+export function parseFlatYaml(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.replace(/#.*$/, "").trimEnd();
+    if (!line.trim()) continue;
+
+    const match = line.match(/^(\w[\w.-]*)\s*:\s*(.*)$/);
+    if (!match) continue;
+
+    const [, key, rawValue] = match;
+    result[key] = rawValue.trim().replace(/^["'](.*)["']$/, "$1");
+  }
+
+  return result;
+}

--- a/packages/parser/core/ManifestParserInterface.ts
+++ b/packages/parser/core/ManifestParserInterface.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+/**
+ * One dependency entry extracted from a manifest file (package.json,
+ * go.mod, Cargo.toml, Gemfile, composer.json, .csproj, build.gradle/pom.xml).
+ * Intentionally much thinner than ParsedFile/LanguageParser — a manifest is
+ * a flat declaration, not source code with imports/exports/warnings.
+ */
+export interface ManifestDependency {
+  name: string;
+  /** Version range/spec as written in the manifest, e.g. "^1.2.0" or "v1.2.0". Absent if unversioned. */
+  versionRange?: string;
+  kind: "runtime" | "dev";
+}
+
+/**
+ * Every manifest parser (parsePackageJson, parseGoMod, parseCargoToml, ...)
+ * implements this. Synchronous and content-only (no FileInfo) since manifest
+ * files are small, single, well-known filenames read directly by
+ * detectRepositoryMeta.ts — no repo-wide scan/registry involved, unlike
+ * LanguageParser/ParserRegistry which cover arbitrary source files.
+ */
+export interface ManifestParser {
+  /** Exact filename this parser handles, e.g. "go.mod", "Cargo.toml" */
+  readonly filename: string;
+
+  /**
+   * Parses manifest content into a flat dependency list. Must NOT throw on
+   * malformed input — return [] instead, so one broken manifest doesn't
+   * fail framework/package-manager detection for the whole repo.
+   */
+  parse(content: string): ManifestDependency[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      d3-hierarchy:
+        specifier: ^3.1.2
+        version: 3.1.2
       ignore:
         specifier: ^6.0.2
         version: 6.0.2
@@ -21,6 +24,9 @@ importers:
         specifier: 0.25.0
         version: 0.25.0
     devDependencies:
+      '@types/d3-hierarchy':
+        specifier: ^3.1.7
+        version: 3.1.7
       '@types/node':
         specifier: ^20
         version: 20.19.43
@@ -35,6 +41,13 @@ importers:
         version: 5.9.3
 
   apps/cli:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^1.7.0
+        version: 1.7.0
+      commander:
+        specifier: ^15.0.0
+        version: 15.0.0
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -290,6 +303,14 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
 
   '@dotenvx/dotenvx@1.75.1':
     resolution: {integrity: sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ==}
@@ -1533,6 +1554,10 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1969,8 +1994,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.4:
     resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3677,6 +3711,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
   '@dotenvx/dotenvx@1.75.1':
     dependencies:
       '@dotenvx/primitives': 0.8.0
@@ -4769,6 +4815,8 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@15.0.0: {}
+
   concat-map@0.0.1: {}
 
   conf@10.2.0:
@@ -5396,7 +5444,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.4: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
…sers, fix d3-hierarchy dependency

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
