### PR TITLE
Feat/manifest parsers

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -1048,3 +1048,60 @@ fix this for Go/Java specifically — not yet built, not scoped.
 (multi-package Go with actual cross-package imports, Java with actual
 `import demo.other.Thing;` statements) — only the same-package-only
 fixture has been verified so far.
+
+## Update — Manifest parsers built (parseGoMod, parseCargoToml, parsePackageJson, parseComposer, parseGemfile, parseGradle/parsePom, parseCsproj) + ManifestParser interface
+
+New packages/parser/core/ManifestParserInterface.ts (ManifestDependency:
+name/versionRange/kind runtime|dev; ManifestParser: filename + sync parse()).
+Distinct from LanguageParser/ParserRegistry — manifests are single
+well-known files read directly, not scanned. Generic format primitives
+added: config/parseJson.ts, config/parseToml.ts (parseTomlSections, NOT
+spec-complete TOML), config/parseYaml.ts (parseFlatYaml, unused so far).
+
+Verified against REAL manifests from public repos (gin, tokio, laravel,
+rails, spring-petclinic — downloaded to ~/manifest-samples, outside the
+repo) via scripts/testManifests.ts, not hand-written fixtures:
+- parseGoMod: 35/35 deps correct (gin's go.mod)
+- parseCargoToml: found and FIXED a real bug — first version only handled
+  flat [dependencies]/[dev-dependencies], missed tokio's many
+  [target.'cfg(...)'.dependencies] conditional sections and
+  single-dep-per-section form ([target.'cfg(windows)'.dependencies.windows-sys]).
+  Fixed via classifySection() suffix matching + SINGLE_DEP_SECTION_PATTERN.
+  13 -> 36 deps after fix, matches tokio's Cargo.toml.
+- parseComposer: 8/8 correct, php/ext-*/lib-* platform entries correctly filtered
+- parseGemfile: 82 deps found, all reported "runtime" — KNOWN LIMITATION,
+  doesn't read `group :test do...end` blocks, so gems only ever declared
+  inside a group (rubocop, mdl, sdoc group etc in rails' real Gemfile)
+  are mis-classified as runtime. Not fixed, documented in file comment.
+- parsePom (Maven): 30 found but 2 are WRONG — regex matches every
+  <dependency> in the file including ones nested inside
+  <plugin><dependencies> (checkstyle plugin's own deps), which aren't
+  real project dependencies. NOT FIXED — would need real XML tree
+  parsing to scope to the top-level <dependencies> block only, not a
+  regex. Known false-positive, documented in file comment.
+- parseGradle (Groovy DSL) — NOT yet tested against a real build.gradle,
+  only pom.xml side was verified.
+
+**Also fixed while building this**: packages/graph/buildFolderGraph.ts
+was failing tsc with "Cannot find module 'd3-hierarchy'" — dependency was
+used but never installed. Fixed with `pnpm add d3-hierarchy -w` +
+`pnpm add -D @types/d3-hierarchy -w` (-w needed because packages/* isn't
+a pnpm workspace member, only apps/* is — deps go to root package.json).
+
+**STILL NOT DONE**: nothing calls these manifest parsers from
+detectRepositoryMeta.ts or anywhere else in the pipeline yet — they exist
+and are verified standalone (via testManifests.ts) but aren't wired into
+analyzeRepository()'s framework/dependency detection. detectRepositoryMeta.ts's
+own readDependencyNames() (package.json only, flat Set<string>) still runs
+separately and hasn't been merged with this new ManifestDependency-based
+system — that's a follow-up, not done here.
+
+**Gotcha hit while building this**: a `cat > file << EOF` heredoc run
+while `cd`'d into ~/manifest-samples instead of ~/arclux silently created
+packages/parser/rust/parseCargoToml.ts under ~/manifest-samples/packages/...
+instead of overwriting the real file — the real ~/arclux file kept its
+old (buggy, pre-fix) content even though the terminal showed no error.
+Caught only because testManifests.ts's output (13 deps) didn't match the
+expected fix. Lesson: always `pwd` before a `cat > path << EOF` if you've
+`cd`'d anywhere else in the same session — a wrong-directory heredoc
+fails silently, it doesn't error.

--- a/packages/parser/config/parsePackageJson.ts
+++ b/packages/parser/config/parsePackageJson.ts
@@ -6,3 +6,36 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { parseJson } from "./parseJson";
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+interface PackageJsonShape {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+// Note: packages/engine/detectRepositoryMeta.ts already has its own
+// lightweight inline package.json reader (readDependencyNames) for
+// framework/package-manager detection specifically — that one intentionally
+// stays separate since it only needs a flat Set<string> of names, not full
+// ManifestDependency objects with version + runtime/dev distinction. Don't
+// merge them without checking both call sites first.
+export const parsePackageJson: ManifestParser = {
+  filename: "package.json",
+
+  parse(content: string): ManifestDependency[] {
+    const parsed = parseJson<PackageJsonShape>(content);
+    if (!parsed) return [];
+
+    const dependencies: ManifestDependency[] = [];
+
+    for (const [name, versionRange] of Object.entries(parsed.dependencies ?? {})) {
+      dependencies.push({ name, versionRange, kind: "runtime" });
+    }
+    for (const [name, versionRange] of Object.entries(parsed.devDependencies ?? {})) {
+      dependencies.push({ name, versionRange, kind: "dev" });
+    }
+
+    return dependencies;
+  },
+};

--- a/packages/parser/csharp/parseCsproj.ts
+++ b/packages/parser/csharp/parseCsproj.ts
@@ -6,3 +6,34 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+// .csproj is XML, but this uses a regex scan rather than a full XML parser —
+// no XML parsing dependency exists anywhere else in ARCLUX yet (see
+// packages/parser/config/*, none of them are XML), and PackageReference
+// elements have a small, consistent enough shape
+// (<PackageReference Include="Name" Version="1.2.3" />) that a targeted
+// regex is sufficient without pulling in a new dependency for one file
+// type. Self-closing and open/close tag forms are both handled.
+// .csproj has no dev/runtime distinction the way npm/Cargo do (that's a
+// solution-level concept in .NET via project references, not per-package),
+// so every PackageReference is reported as "runtime".
+export const parseCsproj: ManifestParser = {
+  filename: ".csproj",
+
+  parse(content: string): ManifestDependency[] {
+    const dependencies: ManifestDependency[] = [];
+    const pattern = /<PackageReference\s+Include="([^"]+)"(?:\s+Version="([^"]*)")?/g;
+
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(content)) !== null) {
+      dependencies.push({
+        name: match[1],
+        versionRange: match[2] || undefined,
+        kind: "runtime",
+      });
+    }
+
+    return dependencies;
+  },
+};

--- a/packages/parser/go/parseGoMod.ts
+++ b/packages/parser/go/parseGoMod.ts
@@ -6,3 +6,63 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+// go.mod has its own line-based syntax, not JSON/TOML/YAML — can't reuse
+// the generic config/* parsers. Handles both single-line "require x v1.2.3"
+// and parenthesized "require (...)" blocks. Everything in go.mod is a
+// runtime dependency — Go has no separate dev-dependency concept the way
+// npm/Cargo/Bundler do, so `kind` is always "runtime" here.
+//
+// Does NOT parse "replace" or "exclude" directives — those modify/override
+// requirements rather than declare new ones, out of scope for a flat
+// dependency list.
+
+function stripLineComment(line: string): string {
+  const idx = line.indexOf("//");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+function toDependency(modulePath: string, version: string): ManifestDependency {
+  return { name: modulePath, versionRange: version || undefined, kind: "runtime" };
+}
+
+export const parseGoMod: ManifestParser = {
+  filename: "go.mod",
+
+  parse(content: string): ManifestDependency[] {
+    const dependencies: ManifestDependency[] = [];
+    const lines = content.split("\n");
+    let inRequireBlock = false;
+
+    for (const rawLine of lines) {
+      const line = stripLineComment(rawLine).trim();
+      if (!line) continue;
+
+      if (!inRequireBlock) {
+        if (/^require\s*\(\s*$/.test(line)) {
+          inRequireBlock = true;
+          continue;
+        }
+
+        const singleMatch = line.match(/^require\s+(\S+)\s+(\S+)/);
+        if (singleMatch) {
+          dependencies.push(toDependency(singleMatch[1], singleMatch[2]));
+        }
+        continue;
+      }
+
+      if (line === ")") {
+        inRequireBlock = false;
+        continue;
+      }
+
+      const entryMatch = line.match(/^(\S+)\s+(\S+)/);
+      if (entryMatch) {
+        dependencies.push(toDependency(entryMatch[1], entryMatch[2]));
+      }
+    }
+
+    return dependencies;
+  },
+};

--- a/packages/parser/java/parseGradlePom.ts
+++ b/packages/parser/java/parseGradlePom.ts
@@ -6,3 +6,71 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+// Java has 2 unrelated manifest formats depending on the build tool — both
+// live in this one file since both produce the same ManifestDependency
+// shape and neither is complex enough alone to warrant a separate file
+// (unlike e.g. parseGo.ts vs parseGoMod.ts, which are source vs manifest).
+//
+// Gradle (build.gradle, Groovy DSL): matches
+// implementation/api/testImplementation/compileOnly 'group:artifact:version'
+// (single or double-quoted). Does NOT handle build.gradle.kts (Kotlin DSL,
+// different call syntax) or version catalogs (libs.versions.toml).
+//
+// Maven (pom.xml): matches <dependency> blocks with <groupId>/<artifactId>/
+// <version>, via regex rather than real XML parsing — same rationale as
+// parseCsproj.ts. <scope>test</scope> maps to "dev", anything else (or no
+// scope, which defaults to "compile") maps to "runtime".
+
+function parseGradle(content: string): ManifestDependency[] {
+  const dependencies: ManifestDependency[] = [];
+  const pattern =
+    /\b(?:implementation|api|compileOnly|runtimeOnly|testImplementation)\s*[(]?\s*['"]([^:'"]+):([^:'"]+):([^'"]+)['"]/g;
+
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(content)) !== null) {
+    const [, group, artifact, version] = match;
+    dependencies.push({
+      name: `${group}:${artifact}`,
+      versionRange: version,
+      kind: /testImplementation/.test(match[0]) ? "dev" : "runtime",
+    });
+  }
+
+  return dependencies;
+}
+
+function parseMaven(content: string): ManifestDependency[] {
+  const dependencies: ManifestDependency[] = [];
+  const blockPattern = /<dependency>([\s\S]*?)<\/dependency>/g;
+
+  let blockMatch: RegExpExecArray | null;
+  while ((blockMatch = blockPattern.exec(content)) !== null) {
+    const block = blockMatch[1];
+    const groupId = block.match(/<groupId>([^<]+)<\/groupId>/)?.[1];
+    const artifactId = block.match(/<artifactId>([^<]+)<\/artifactId>/)?.[1];
+    const version = block.match(/<version>([^<]+)<\/version>/)?.[1];
+    const scope = block.match(/<scope>([^<]+)<\/scope>/)?.[1];
+
+    if (!groupId || !artifactId) continue;
+
+    dependencies.push({
+      name: `${groupId}:${artifactId}`,
+      versionRange: version,
+      kind: scope === "test" ? "dev" : "runtime",
+    });
+  }
+
+  return dependencies;
+}
+
+export const parseGradle_: ManifestParser = {
+  filename: "build.gradle",
+  parse: parseGradle,
+};
+
+export const parsePom: ManifestParser = {
+  filename: "pom.xml",
+  parse: parseMaven,
+};

--- a/packages/parser/php/parseComposer.ts
+++ b/packages/parser/php/parseComposer.ts
@@ -6,3 +6,40 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { parseJson } from "../config/parseJson";
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+interface ComposerJsonShape {
+  require?: Record<string, string>;
+  "require-dev"?: Record<string, string>;
+}
+
+// composer.json's "require" often includes PHP itself and ext-* entries
+// (e.g. "php": "^8.1", "ext-mbstring": "*") alongside real packages — these
+// are platform requirements, not installable dependencies, so they're
+// filtered out here rather than left for callers to filter themselves.
+function isPlatformRequirement(name: string): boolean {
+  return name === "php" || name.startsWith("ext-") || name.startsWith("lib-");
+}
+
+export const parseComposer: ManifestParser = {
+  filename: "composer.json",
+
+  parse(content: string): ManifestDependency[] {
+    const parsed = parseJson<ComposerJsonShape>(content);
+    if (!parsed) return [];
+
+    const dependencies: ManifestDependency[] = [];
+
+    for (const [name, versionRange] of Object.entries(parsed.require ?? {})) {
+      if (isPlatformRequirement(name)) continue;
+      dependencies.push({ name, versionRange, kind: "runtime" });
+    }
+    for (const [name, versionRange] of Object.entries(parsed["require-dev"] ?? {})) {
+      if (isPlatformRequirement(name)) continue;
+      dependencies.push({ name, versionRange, kind: "dev" });
+    }
+
+    return dependencies;
+  },
+};

--- a/packages/parser/ruby/parseGemfile.ts
+++ b/packages/parser/ruby/parseGemfile.ts
@@ -6,3 +6,41 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+// Gemfile is Ruby source, not a data format — this handles the common
+// `gem "name", "version"` / `gem "name", "~> version"` call form line by
+// line via regex, NOT a real Ruby parser. Does not evaluate conditionals
+// (if/group blocks), so a gem declared only inside `group :test do ... end`
+// is still reported as unconditional — acceptable for dependency-listing
+// purposes, not for determining exactly when a gem loads.
+//
+// `:group` and other trailing symbol options (`require: false`, etc.) are
+// ignored, only the name + first version-like string argument are kept.
+function stripLineComment(line: string): string {
+  const idx = line.indexOf("#");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+export const parseGemfile: ManifestParser = {
+  filename: "Gemfile",
+
+  parse(content: string): ManifestDependency[] {
+    const dependencies: ManifestDependency[] = [];
+    const gemPattern = /^\s*gem\s+["']([^"']+)["'](?:\s*,\s*["']([^"']+)["'])?/;
+
+    for (const rawLine of content.split("\n")) {
+      const line = stripLineComment(rawLine);
+      const match = line.match(gemPattern);
+      if (!match) continue;
+
+      dependencies.push({
+        name: match[1],
+        versionRange: match[2] || undefined,
+        kind: "runtime",
+      });
+    }
+
+    return dependencies;
+  },
+};

--- a/packages/parser/rust/parseCargoToml.ts
+++ b/packages/parser/rust/parseCargoToml.ts
@@ -6,3 +6,37 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { parseTomlSections } from "../config/parseToml";
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+function classifySection(name: string): "runtime" | "dev" | undefined {
+  if (name === "dependencies" || name === "build-dependencies") return "runtime";
+  if (name === "dev-dependencies") return "dev";
+  if (name.endsWith(".dependencies") || name.endsWith(".build-dependencies")) return "runtime";
+  if (name.endsWith(".dev-dependencies")) return "dev";
+  return undefined;
+}
+
+const SINGLE_DEP_SECTION_PATTERN = /\.(dependencies|dev-dependencies)\.([\w-]+)$/;
+
+export const parseCargoToml: ManifestParser = {
+  filename: "Cargo.toml",
+  parse(content: string): ManifestDependency[] {
+    const sections = parseTomlSections(content);
+    const dependencies: ManifestDependency[] = [];
+    for (const section of sections) {
+      const singleDepMatch = section.name.match(SINGLE_DEP_SECTION_PATTERN);
+      if (singleDepMatch) {
+        const kind: ManifestDependency["kind"] = singleDepMatch[1] === "dev-dependencies" ? "dev" : "runtime";
+        dependencies.push({ name: singleDepMatch[2], versionRange: section.entries.version || undefined, kind });
+        continue;
+      }
+      const kind = classifySection(section.name);
+      if (!kind) continue;
+      for (const [name, versionRange] of Object.entries(section.entries)) {
+        dependencies.push({ name, versionRange: versionRange || undefined, kind });
+      }
+    }
+    return dependencies;
+  },
+};

--- a/packages/parser/rust/parseCargoToml.ts
+++ b/packages/parser/rust/parseCargoToml.ts
@@ -21,22 +21,31 @@ const SINGLE_DEP_SECTION_PATTERN = /\.(dependencies|dev-dependencies)\.([\w-]+)$
 
 export const parseCargoToml: ManifestParser = {
   filename: "Cargo.toml",
+
   parse(content: string): ManifestDependency[] {
     const sections = parseTomlSections(content);
     const dependencies: ManifestDependency[] = [];
+
     for (const section of sections) {
       const singleDepMatch = section.name.match(SINGLE_DEP_SECTION_PATTERN);
       if (singleDepMatch) {
         const kind: ManifestDependency["kind"] = singleDepMatch[1] === "dev-dependencies" ? "dev" : "runtime";
-        dependencies.push({ name: singleDepMatch[2], versionRange: section.entries.version || undefined, kind });
+        dependencies.push({
+          name: singleDepMatch[2],
+          versionRange: section.entries.version || undefined,
+          kind,
+        });
         continue;
       }
+
       const kind = classifySection(section.name);
       if (!kind) continue;
+
       for (const [name, versionRange] of Object.entries(section.entries)) {
         dependencies.push({ name, versionRange: versionRange || undefined, kind });
       }
     }
+
     return dependencies;
   },
 };

--- a/scripts/testManifests.ts
+++ b/scripts/testManifests.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Manual verification script — runs each manifest parser against a REAL
+// manifest file downloaded from a real public repo (see ~/manifest-samples,
+// deliberately outside ~/arclux per PROGRES.md's "don't clone reference
+// repos inside the project" rule), not a hand-written fixture. Prints every
+// extracted dependency so output can be spot-checked against the source
+// file by eye.
+//
+// Run with: npx tsx scripts/testManifests.ts
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { parseGoMod } from "../packages/parser/go/parseGoMod";
+import { parseCargoToml } from "../packages/parser/rust/parseCargoToml";
+import { parseComposer } from "../packages/parser/php/parseComposer";
+import { parseGemfile } from "../packages/parser/ruby/parseGemfile";
+import { parsePom } from "../packages/parser/java/parseGradlePom";
+import type { ManifestParser, ManifestDependency } from "../packages/parser/core/ManifestParserInterface";
+
+const SAMPLES_DIR = join(homedir(), "manifest-samples");
+
+function run(label: string, filename: string, parser: ManifestParser) {
+  const filePath = join(SAMPLES_DIR, filename);
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch {
+    console.log(`\n--- ${label} (${filename}) ---`);
+    console.log(`SKIPPED — file not found at ${filePath}`);
+    return;
+  }
+
+  const deps = parser.parse(content);
+  console.log(`\n--- ${label} (${filename}) — ${deps.length} dependencies ---`);
+  const runtime = deps.filter((d: ManifestDependency) => d.kind === "runtime");
+  const dev = deps.filter((d: ManifestDependency) => d.kind === "dev");
+  console.log(`  runtime: ${runtime.length}, dev: ${dev.length}`);
+  for (const dep of deps) {
+    console.log(`  [${dep.kind}] ${dep.name}${dep.versionRange ? ` @ ${dep.versionRange}` : ""}`);
+  }
+}
+
+run("Go (gin)", "go.mod", parseGoMod);
+run("Rust (tokio)", "Cargo.toml", parseCargoToml);
+run("PHP (laravel)", "composer.json", parseComposer);
+run("Ruby (rails)", "Gemfile", parseGemfile);
+run("Java/Maven (spring-petclinic)", "pom.xml", parsePom);

--- a/scripts/testManifests.ts
+++ b/scripts/testManifests.ts
@@ -5,15 +5,6 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Manual verification script — runs each manifest parser against a REAL
-// manifest file downloaded from a real public repo (see ~/manifest-samples,
-// deliberately outside ~/arclux per PROGRES.md's "don't clone reference
-// repos inside the project" rule), not a hand-written fixture. Prints every
-// extracted dependency so output can be spot-checked against the source
-// file by eye.
-//
-// Run with: npx tsx scripts/testManifests.ts
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";


### PR DESCRIPTION
## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
