### PR TITLE
feat(graph): add buildImportGraph — weighted import graph using Resol…

### DIFF
--- a/packages/graph/buildImportGraph.ts
+++ b/packages/graph/buildImportGraph.ts
@@ -6,3 +6,69 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { Repository } from "../repository/Repository";
+import type { DependencyGraph, GraphNode, GraphEdge } from "../shared/types";
+
+/**
+ * Weighted variant of buildDependencyGraph.ts. That function answers
+ * "does A depend on B" (one deduped edge per pair, no weight).  This one
+ * answers "how HEAVILY does A depend on B" by using ModuleInfo.resolvedImports
+ * (identifier-level detail — one entry per import statement) instead of the
+ * flattened `imports: string[]`, and setting GraphEdge.weight to the number
+ * of distinct import statements from A that resolve to B.
+ *
+ * IMPORTANT: GraphEdge has no metadata field, only `weight?: number` — so
+ * the kind breakdown (static/dynamic/require/type-only) and named-import
+ * lists on ResolvedImport are intentionally NOT preserved here. A consumer
+ * that needs that level of detail (e.g. a detector or a tooltip) should
+ * read repository.getModule(id).resolvedImports directly rather than rely
+ * on this graph; folding that detail into `weight` would collapse
+ * meaningfully different information into one number.
+ *
+ * Node shape mirrors buildDependencyGraph.ts exactly — same modules, same
+ * "file" type — only the edges differ.
+ */
+export function buildImportGraph(repository: Repository): DependencyGraph {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+
+  const modules = repository.getAllModules();
+  const moduleIds = new Set(modules.map((m) => m.id));
+
+  for (const module of modules) {
+    nodes.push({
+      id: module.id,
+      type: "file",
+      label: module.file.relativePath.split("/").pop() ?? module.id,
+      filePath: module.file.relativePath,
+      metadata: {
+        language: module.file.language,
+        exportCount: module.exports.length,
+      },
+    });
+
+    const weightByTarget = new Map<string, number>();
+    for (const resolvedImport of module.resolvedImports) {
+      if (!moduleIds.has(resolvedImport.moduleId)) continue;
+      const current = weightByTarget.get(resolvedImport.moduleId) ?? 0;
+      weightByTarget.set(resolvedImport.moduleId, current + 1);
+    }
+
+    for (const [targetId, weight] of weightByTarget) {
+      edges.push({
+        id: `${module.id}->${targetId}`,
+        source: module.id,
+        target: targetId,
+        type: "import",
+        weight,
+      });
+    }
+  }
+
+  return {
+    repositoryId: repository.meta.id,
+    nodes,
+    edges,
+    builtAt: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
…vedImport detail

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
