### PR TITLE
docs: mark parseTsx.ts/parseTsConfig.ts as intentionally empty

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -1162,3 +1162,23 @@ Planned but not implemented yet. Design decided:
   backfill calledBy same pattern as importedBy), and finally
   buildCallGraph.ts itself (weighted, same pattern as buildImportGraph.ts,
   edge type "call").
+
+## Update — parseTsx.ts and parseTsConfig.ts confirmed intentionally empty
+
+Verified, not just assumed: `packages/parser/typescript/parseTsx.ts` and
+`parseTsConfig.ts` will stay empty stubs permanently, not because they're
+"not done yet" but because their functionality already lives elsewhere:
+
+- `.tsx` parsing: handled inside `parseTs.ts` itself via
+  `ts.ScriptKind.TSX` (checked its `extensions` field and ScriptKind
+  selection logic directly).
+- tsconfig.json parsing: handled inside
+  `packages/indexer/resolveAliases.ts`, which reads tsconfig.json /
+  jsconfig.json directly (with comment/trailing-comma stripping) for
+  path-alias resolution.
+
+Both files now have a comment explaining this, so a future session
+doesn't attempt to implement duplicate logic in either of them — same
+class of risk previously flagged for `packages/ui/graphColor.ts` vs
+`theme/graphColors.ts` (that one is still an open risk; these two are now
+resolved/documented).

--- a/packages/parser/typescript/parseTsConfig.ts
+++ b/packages/parser/typescript/parseTsConfig.ts
@@ -5,4 +5,10 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
+// INTENTIONALLY EMPTY — superseded by
+// packages/indexer/resolveAliases.ts, which already reads tsconfig.json /
+// jsconfig.json directly (including comment/trailing-comma stripping) to
+// resolve path aliases. This file was likely planned to go through
+// ParserRegistry like other parsers, but the actual implementation lives
+// in resolveAliases.ts instead. Do not implement a config parser here.

--- a/packages/parser/typescript/parseTsx.ts
+++ b/packages/parser/typescript/parseTsx.ts
@@ -5,4 +5,9 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
+// INTENTIONALLY EMPTY — superseded by packages/parser/typescript/parseTs.ts,
+// which already handles .tsx via ts.ScriptKind.TSX (see its `extensions`
+// field and ScriptKind selection logic). Do not implement a separate
+// parser here; it would duplicate parseTs.ts's logic and risk drifting
+// out of sync with it.


### PR DESCRIPTION
Verified their functionality already lives in parseTs.ts (TSX via ScriptKind) and resolveAliases.ts (tsconfig reading). Adds explanatory comments so nobody implements duplicate logic here later.