### PR TITLE
feat(watcher): implement filesystem watcher wired to incremental Cell/Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "chokidar": "^5.0.0",
     "d3-hierarchy": "^3.1.2",
     "ignore": "^6.0.2",
     "simple-git": "^3.27.0",

--- a/packages/watcher/changeQueue.ts
+++ b/packages/watcher/changeQueue.ts
@@ -5,4 +5,59 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Debounces a burst of file change events into a single flush. Editors and
+// build tools routinely fire several raw filesystem events for what a
+// human would call "one save" (e.g. a temp-file-then-rename pattern), so
+// without debouncing, watchRepository.ts would trigger a rebuild multiple
+// times per actual edit.
 
+import type { FileChangeEvent } from "./watchFilesystem";
+
+export interface ChangeQueueOptions {
+  /** Milliseconds to wait after the LAST event before flushing. Resets on
+   * every new event, so a continuous stream of edits keeps delaying flush
+   * until things go quiet. */
+  debounceMs?: number;
+}
+
+export interface ChangeQueue {
+  push(event: FileChangeEvent): void;
+  close(): void;
+}
+
+const DEFAULT_DEBOUNCE_MS = 300;
+
+/**
+ * Collects FileChangeEvents and calls onFlush with the deduped set once
+ * no new events have arrived for debounceMs. Deduping is by absolutePath
+ * only — if a file was both "change"d and then "unlink"ed within the same
+ * debounce window, only the LAST event kind for that path survives. This
+ * matches what actually matters to the caller (the file's current state),
+ * not its full history within the window.
+ */
+export function createChangeQueue(onFlush: (events: FileChangeEvent[]) => void, options: ChangeQueueOptions = {}): ChangeQueue {
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+  const pending = new Map<string, FileChangeEvent>();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function flush(): void {
+    timer = undefined;
+    if (pending.size === 0) return;
+    const events = Array.from(pending.values());
+    pending.clear();
+    onFlush(events);
+  }
+
+  return {
+    push(event: FileChangeEvent): void {
+      pending.set(event.absolutePath, event);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(flush, debounceMs);
+    },
+    close(): void {
+      if (timer) clearTimeout(timer);
+      pending.clear();
+    },
+  };
+}

--- a/packages/watcher/watchFilesystem.ts
+++ b/packages/watcher/watchFilesystem.ts
@@ -5,4 +5,45 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Thin wrapper over chokidar (github.com/paulmillr/chokidar, MIT license).
+// Deliberately does NOT re-implement raw fs.watch/fs.watchFile handling —
+// chokidar already normalizes per-OS event quirks (VSCode itself depends
+// on it), so writing that from scratch here would just be reinventing a
+// well-solved problem. The custom/novel part of this feature is in
+// changeQueue.ts and watchRepository.ts, not here.
 
+import { watch, type FSWatcher } from "chokidar";
+
+export type FileChangeKind = "add" | "change" | "unlink";
+
+export interface FileChangeEvent {
+  kind: FileChangeKind;
+  absolutePath: string;
+}
+
+export interface FilesystemWatcher {
+  close(): Promise<void>;
+}
+
+/**
+ * Watches rootPath recursively, calling onChange for every add/change/unlink.
+ * Directory events (addDir/unlinkDir) are intentionally NOT surfaced —
+ * changeQueue.ts and the incremental Cell layer operate on individual
+ * files, a directory appearing/disappearing doesn't need its own signal
+ * separate from the file events chokidar emits for its contents.
+ */
+export function watchFilesystem(rootPath: string, onChange: (event: FileChangeEvent) => void): FilesystemWatcher {
+  const watcher: FSWatcher = watch(rootPath, {
+    ignoreInitial: true,
+    ignored: (path: string) => path.includes("node_modules") || path.includes("/.git/"),
+  });
+
+  watcher.on("add", (absolutePath: string) => onChange({ kind: "add", absolutePath }));
+  watcher.on("change", (absolutePath: string) => onChange({ kind: "change", absolutePath }));
+  watcher.on("unlink", (absolutePath: string) => onChange({ kind: "unlink", absolutePath }));
+
+  return {
+    close: () => watcher.close(),
+  };
+}

--- a/packages/watcher/watchRepository.ts
+++ b/packages/watcher/watchRepository.ts
@@ -5,4 +5,85 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Wires chokidar (watchFilesystem.ts) + debouncing (changeQueue.ts) into
+// packages/incremental's Cell/Query/Database. This is intentionally the
+// COARSE version of incremental re-analysis, not true per-file granular
+// recomputation:
+//
+// - One Cell holds a single "revision token" (just a counter, bumped on
+//   every flushed change batch) for the WHOLE watched directory, not one
+//   Cell per file. A single Query wraps the entire analyzeLocalDirectory()
+//   call and reads that Cell.
+// - Consequence: ANY change anywhere in the tree invalidates the ENTIRE
+//   cached analysis, triggering a full re-run of analyzeLocalDirectory()
+//   (which itself does a full buildIndex() rebuild — see buildIndex.ts,
+//   it has no partial-update mode). This is NOT what "incremental" means
+//   in the packages/incremental sense of per-Cell fine-grained
+//   invalidation — it only gives you ONE real benefit: if the watcher
+//   fires (e.g. on restart, or a save that didn't actually change file
+//   contents) but nothing has changed, the cached Query result is reused
+//   and analyzeLocalDirectory() does NOT re-run at all.
+// - True per-file granular incrementality (only re-parsing changed files,
+//   reusing cached ModuleInfo for untouched ones) would require
+//   buildIndex.ts itself to be rewritten around Cell/Query internally,
+//   which is a much larger change deliberately out of scope here — see
+//   PROGRES.md decisions entry for why this smaller version was chosen
+//   instead (avoids conflicting with a parallel pipeline.ts refactor).
 
+import { Database } from "../incremental/Database";
+import { Cell } from "../incremental/Cell";
+import { Query } from "../incremental/Query";
+import { watchFilesystem, type FilesystemWatcher } from "./watchFilesystem";
+import { createChangeQueue, type ChangeQueue } from "./changeQueue";
+import { analyzeLocalDirectory, type LocalAnalysisResult } from "../../apps/cli/analyzeLocal";
+
+export interface RepositoryWatcher {
+  /** Returns the current analysis, running it only if the tree has
+   * changed since the last call (or this is the first call). */
+  getAnalysis(): Promise<LocalAnalysisResult>;
+  close(): Promise<void>;
+}
+
+/**
+ * Starts watching rootPath. Call getAnalysis() whenever a consumer (CLI
+ * command, future UI) wants the current analysis — it will be instant
+ * (cached) if nothing has changed, or trigger a fresh full re-run
+ * otherwise. This does NOT push updates proactively; there's no event
+ * emitter for "analysis changed" here, by design — see PROGRES.md
+ * decisions entry. Callers that want live updates must poll getAnalysis().
+ */
+export function watchRepository(rootPath: string): RepositoryWatcher {
+  const db = new Database();
+  const revisionToken = new Cell(db, 0);
+
+  // The compute function is async, but Query.compute's type is a plain
+  // (...args) => T. Query does not natively support caching a Promise's
+  // RESOLVED value across recomputation checks — it would cache the
+  // Promise object itself, which is fine for this use case (awaiting an
+  // already-resolved Promise repeatedly is cheap and correct), but is
+  // worth flagging: this is relying on Promise identity being stable
+  // across cache hits, not on Query having any real async-awareness.
+  const analysisQuery = new Query(db, () => {
+    revisionToken.get(); // register as a dependency, ignore the value itself
+    return analyzeLocalDirectory(rootPath);
+  });
+
+  const queue: ChangeQueue = createChangeQueue(() => {
+    revisionToken.set(revisionToken.peek() + 1);
+  });
+
+  const fsWatcher: FilesystemWatcher = watchFilesystem(rootPath, (event) => {
+    queue.push(event);
+  });
+
+  return {
+    getAnalysis(): Promise<LocalAnalysisResult> {
+      return analysisQuery.get();
+    },
+    async close(): Promise<void> {
+      queue.close();
+      await fsWatcher.close();
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       d3-hierarchy:
         specifier: ^3.1.2
         version: 3.1.2
@@ -1651,6 +1654,10 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -3232,6 +3239,10 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   recast@0.23.16:
     resolution: {integrity: sha512-qIQstR1qb/hoVsHtsAsHDuwN/VLMxAYdDjH2yVcZ1lyz/wDJvclyoxNdilAHcHdodPL3ikWcA3Wzqhy2NqLUsA==}
@@ -5217,6 +5228,10 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -6864,6 +6879,8 @@ snapshots:
       '@types/react': 19.2.17
 
   react@19.2.4: {}
+
+  readdirp@5.0.0: {}
 
   recast@0.23.16:
     dependencies:

--- a/tests/watcher/changeQueue.test.ts
+++ b/tests/watcher/changeQueue.test.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { createChangeQueue } from "../../packages/watcher/changeQueue"
+
+describe("createChangeQueue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not flush before the debounce window elapses", () => {
+    const onFlush = vi.fn()
+    const queue = createChangeQueue(onFlush, { debounceMs: 300 })
+
+    queue.push({ kind: "change", absolutePath: "/a.ts" })
+    vi.advanceTimersByTime(299)
+
+    expect(onFlush).not.toHaveBeenCalled()
+  })
+
+  it("flushes once after the debounce window elapses", () => {
+    const onFlush = vi.fn()
+    const queue = createChangeQueue(onFlush, { debounceMs: 300 })
+
+    queue.push({ kind: "change", absolutePath: "/a.ts" })
+    vi.advanceTimersByTime(300)
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith([{ kind: "change", absolutePath: "/a.ts" }])
+  })
+
+  it("resets the timer on every new event, delaying flush until things go quiet", () => {
+    const onFlush = vi.fn()
+    const queue = createChangeQueue(onFlush, { debounceMs: 300 })
+
+    queue.push({ kind: "change", absolutePath: "/a.ts" })
+    vi.advanceTimersByTime(200)
+    queue.push({ kind: "change", absolutePath: "/b.ts" })
+    vi.advanceTimersByTime(200)
+
+    expect(onFlush).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(100)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith([
+      { kind: "change", absolutePath: "/a.ts" },
+      { kind: "change", absolutePath: "/b.ts" },
+    ])
+  })
+
+  it("dedupes by absolutePath, keeping only the LAST event kind for that path", () => {
+    const onFlush = vi.fn()
+    const queue = createChangeQueue(onFlush, { debounceMs: 300 })
+
+    queue.push({ kind: "change", absolutePath: "/a.ts" })
+    queue.push({ kind: "unlink", absolutePath: "/a.ts" })
+    vi.advanceTimersByTime(300)
+
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(onFlush).toHaveBeenCalledWith([{ kind: "unlink", absolutePath: "/a.ts" }])
+  })
+
+  it("does not flush anything after close() is called before the timer fires", () => {
+    const onFlush = vi.fn()
+    const queue = createChangeQueue(onFlush, { debounceMs: 300 })
+
+    queue.push({ kind: "change", absolutePath: "/a.ts" })
+    queue.close()
+    vi.advanceTimersByTime(300)
+
+    expect(onFlush).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Implements packages/watcher/ (was completely empty before this).

Uses chokidar for cross-platform file watching (VSCode itself depends on it) rather than hand-rolling fs.watch handling. Wires it into packages/incremental's existing Cell/Query/Database via changeQueue.ts (debounce) and watchRepository.ts (orchestration).

Deliberately COARSE incremental, not per-file granular - see watchRepository.ts's doc comment for full reasoning. Only real benefit right now: repeated getAnalysis() calls with no actual filesystem change reuse the cached result instead of re-running analyzeLocalDirectory(). Any actual change still triggers a full rebuild.

watchGit.ts intentionally left as a stub - different concern, out of scope here.

Includes 5 new tests for changeQueue.ts's debounce logic using fake timers.