### PR TITLE
feat(search): implement hooks/useDebounce.ts and components/search/Gl…

### DIFF
--- a/apps/web/components/search/GlobalSearch.tsx
+++ b/apps/web/components/search/GlobalSearch.tsx
@@ -6,3 +6,119 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+"use client"
+
+import { useEffect, useState } from "react"
+import { SearchInput } from "@/components/patterns/SearchInput"
+import { EmptyState } from "@/components/patterns/EmptyState"
+import { useDebounce } from "@/hooks/useDebounce"
+
+interface SearchResult {
+  filePath: string
+  moduleId: string
+  score: number
+}
+
+interface SearchResponse {
+  results: SearchResult[]
+}
+
+export interface GlobalSearchProps {
+  repoUrl: string
+  branch?: string
+  onSelect?: (moduleId: string) => void
+}
+
+/**
+ * Standalone search component hitting GET /api/search (fuzzyScore.ts
+ * stopgap, file-path-only -- see that route's own comment for caveats:
+ * no caching, re-indexes the whole repo per call).
+ *
+ * This intentionally overlaps with components/workspace/WorkspaceSearch.tsx
+ * (same API, same debounce-then-fetch shape) -- that one is scoped
+ * specifically to the workspace header and inlines its own debounce
+ * logic. This one is the general-purpose version, meant for use outside
+ * the workspace context (e.g. a global navbar search), and uses the
+ * shared useDebounce hook instead of an inline setTimeout. Not merged
+ * into one component because their trigger UI differs (WorkspaceSearch
+ * always shows an inline dropdown; this one shows an EmptyState for the
+ * zero-results case, which WorkspaceSearch does not need since it's a
+ * compact header widget). If this divergence becomes a maintenance
+ * burden, consider extracting a shared useRepoSearch(repoUrl, branch,
+ * query) hook that both components call.
+ *
+ * IMPORTANT: earlier draft of this file (never committed) hardcoded
+ * `items: SearchItem[] = []` with a "nanti ini bakal dari SearchProvider
+ * / API" comment -- meaning search always silently returned zero results
+ * while looking fully functional. That version is NOT what's implemented
+ * here; this one actually calls the API.
+ */
+export function GlobalSearch({ repoUrl, branch, onSelect }: GlobalSearchProps) {
+  const [query, setQuery] = useState("")
+  const debouncedQuery = useDebounce(query, 200)
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [hasSearched, setHasSearched] = useState(false)
+
+  useEffect(() => {
+    if (!debouncedQuery.trim()) {
+      setResults([])
+      setHasSearched(false)
+      return
+    }
+
+    let cancelled = false
+    async function run() {
+      try {
+        const params = new URLSearchParams({ repoUrl, q: debouncedQuery })
+        if (branch) params.set("branch", branch)
+        const res = await fetch(`/api/search?${params.toString()}`)
+        if (!res.ok) return
+        const json: SearchResponse = await res.json()
+        if (!cancelled) {
+          setResults(json.results ?? [])
+          setHasSearched(true)
+        }
+      } catch {
+        // Silently drop failed requests -- same tradeoff as
+        // WorkspaceSearch.tsx, not worth an ErrorState for a lightweight
+        // search box.
+      }
+    }
+    run()
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedQuery, repoUrl, branch])
+
+  return (
+    <div className="w-full max-w-xl">
+      <SearchInput
+        value={query}
+        onChange={setQuery}
+        placeholder="Search files, modules..."
+      />
+
+      {hasSearched && results.length === 0 && (
+        <div className="mt-2">
+          <EmptyState title="No results" message={`Nothing matched "${debouncedQuery}".`} />
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <div className="mt-2 rounded-md border">
+          {results.slice(0, 20).map((r) => (
+            <button
+              key={r.moduleId}
+              type="button"
+              onClick={() => onSelect?.(r.moduleId)}
+              className="block w-full cursor-pointer px-3 py-2 text-left text-sm hover:bg-muted"
+            >
+              <div className="font-medium">{r.filePath.split("/").pop()}</div>
+              <div className="text-xs text-muted-foreground">{r.filePath}</div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/hooks/useDebounce.ts
+++ b/apps/web/hooks/useDebounce.ts
@@ -6,3 +6,27 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+"use client"
+
+import { useEffect, useState } from "react"
+
+/**
+ * Returns `value`, delayed by `delayMs` after it stops changing. Standard
+ * debounce-a-value hook -- used by GlobalSearch.tsx to avoid firing
+ * /api/search on every keystroke. WorkspaceSearch.tsx (components/
+ * workspace/) implements the same debounce pattern inline via
+ * setTimeout/clearTimeout rather than this hook -- that's pre-existing,
+ * not something this hook replaces retroactively. If touching
+ * WorkspaceSearch.tsx again, consider migrating it to use this hook
+ * instead, to avoid two debounce implementations in the codebase.
+ */
+export function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/progres/PROGRES-status.md
+++ b/progres/PROGRES-status.md
@@ -972,3 +972,39 @@ placeholder). Wiring it in and browser-testing is deliberately left as
 separate follow-up work, to keep this change's review surface to "the
 workspace components exist and typecheck" rather than also redoing the
 main repo page.
+
+## Update -- hooks/useDebounce.ts + components/search/GlobalSearch.tsx implemented
+
+useDebounce.ts: generic debounce-a-value hook (standard setTimeout/
+clearTimeout pattern). GlobalSearch.tsx: standalone search component
+hitting GET /api/search, using this hook.
+
+IMPORTANT CONTEXT: an earlier draft of GlobalSearch.tsx was floated (via
+external chat, never committed to this repo) that hardcoded
+`items: SearchItem[] = []` with a comment saying data would come from
+"SearchProvider / API" later -- meaning the search box would render and
+accept input but silently return zero results forever, looking
+functional while doing nothing. That draft was never written to disk and
+is NOT what's implemented here. This version actually calls /api/search
+and returns real results (same fuzzyScore.ts stopgap backing
+WorkspaceSearch.tsx and CommandPalette-adjacent search, with the same
+caveats -- file-path-only, no caching, re-indexes the whole repo per
+call).
+
+Deliberate overlap with components/workspace/WorkspaceSearch.tsx: both
+hit the same API with the same debounce-then-fetch shape.
+WorkspaceSearch.tsx is scoped to the workspace header (compact inline
+dropdown) and inlines its own debounce logic rather than using this new
+hook. GlobalSearch.tsx is the general-purpose version (e.g. for a global
+navbar), shows an EmptyState on zero results, and uses useDebounce. Not
+merged into one component since their result-UI differs. If this
+divergence becomes annoying to maintain, consider extracting a shared
+useRepoSearch(repoUrl, branch, query) hook both could call -- not done
+here to keep this change scoped.
+
+NOT yet wired into any page/navbar -- same status as most workspace
+components, exists and typechecks but has no real consumer yet.
+
+Verification: npx tsc --noEmit -p apps/web/tsconfig.json clean (only the
+2 pre-existing file-tree.tsx errors, unrelated). Not yet visually
+verified in-browser.


### PR DESCRIPTION
…obalSearch.tsx (real /api/search integration, not the hardcoded-empty-array draft that was floated but never committed)

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
