### PR TITLE
feat(indexer): resolve same-scope implicit dependencies (Go/Java)

### DIFF
--- a/packages/indexer/buildIndex.ts
+++ b/packages/indexer/buildIndex.ts
@@ -10,6 +10,7 @@ import { scanFiles } from "../parser/core/scanFiles";
 import { parserRegistry } from "../parser/core/ParserRegistry";
 import { resolvePath } from "../graph/resolvePath";
 import { loadAliasConfig } from "./resolveAliases";
+import { resolveSameScopeDependencies, type ScopedFile } from "./resolveSameScopeDependencies";
 import { Repository } from "../repository/Repository";
 import { readFileSync } from "node:fs";
 import { ArcluxError } from "../shared/errors";
@@ -24,9 +25,12 @@ export interface BuildIndexOptions {
  * Full indexing pass over a repository:
  * 1. scanFiles      -> list every relevant file
  * 2. parserRegistry  -> parse each file with the right language parser
- * 3. resolvePath     -> turn raw import strings into module ids (using tsconfig
+ * 3. resolveSameScopeDependencies -> for languages where scopeId is set
+ *    (Go, Java - see their parsers' doc comments), find implicit same-scope
+ *    references that never appear as an import statement at all
+ * 4. resolvePath     -> turn raw import strings into module ids (using tsconfig
  *                       path aliases from resolveAliases.ts, plus relative resolution)
- * 4. Repository      -> populated with ModuleInfo, importedBy back-references filled in
+ * 5. Repository      -> populated with ModuleInfo, importedBy back-references filled in
  *
  * This is a full rebuild. For incremental updates see watcher/changeQueue.ts + updateIndex.ts.
  */
@@ -38,8 +42,11 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
   const aliasConfig = loadAliasConfig(rootPath);
   const repository = new Repository({ ...meta, analyzedAt: new Date().toISOString() });
 
-  // Pass 1: parse every file
+  // Pass 1: parse every file. Content is kept around (contentByPath) purely
+  // for resolveSameScopeDependencies's regex scan below — pass 2 doesn't
+  // need it, only the already-extracted imports/exports.
   const parsedByPath = new Map<string, ParsedFile>();
+  const contentByPath = new Map<string, string>();
   for (const file of files) {
     const parser = parserRegistry.getParserForExtension(file.extension);
     if (!parser) continue; // no parser registered yet for this language — skip, don't crash
@@ -58,9 +65,25 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
 
     const parsed = await parser.parse(file, content);
     parsedByPath.set(file.relativePath, parsed);
+    contentByPath.set(file.relativePath, content);
   }
 
-  // Pass 2: build ModuleInfo with resolved import ids (but importedBy not filled yet)
+  // Pass 2: implicit same-scope dependencies (Go/Java files with no import
+  // statement between siblings — see resolveSameScopeDependencies.ts).
+  // Only files with a scopeId set (currently: Go, Java) participate.
+  const scopedFiles: ScopedFile[] = [];
+  for (const [relativePath, parsed] of parsedByPath) {
+    if (!parsed.scopeId) continue;
+    scopedFiles.push({
+      moduleId: relativePath,
+      scopeId: parsed.scopeId,
+      exports: parsed.exports,
+      content: contentByPath.get(relativePath) ?? "",
+    });
+  }
+  const implicitDepsByPath = resolveSameScopeDependencies(scopedFiles);
+
+  // Pass 3: build ModuleInfo with resolved import ids (but importedBy not filled yet)
   const modulesByPath = new Map<string, ModuleInfo>();
   for (const [relativePath, parsed] of parsedByPath) {
     const resolvedImportIds: string[] = [];
@@ -99,11 +122,12 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
       resolvedReExports,
       imports: resolvedImportIds,
       resolvedImports,
-      importedBy: [], // filled in pass 3
+      importedBy: [], // filled in pass 4
+      implicitDependencies: implicitDepsByPath.get(relativePath) ?? [],
     });
   }
 
-  // Pass 3: back-fill importedBy so consumers can be queried in O(1)
+  // Pass 4: back-fill importedBy so consumers can be queried in O(1)
   for (const module of modulesByPath.values()) {
     for (const importedId of module.imports) {
       const target = modulesByPath.get(importedId);

--- a/packages/indexer/resolveSameScopeDependencies.ts
+++ b/packages/indexer/resolveSameScopeDependencies.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Generic pass for languages where files sharing a scope (a directory for
+// Go, a directory for Java too by convention - see parseGo.ts and
+// parseJava.ts's matching doc comments for why this is ONE shared gap, not
+// two separate language bugs) can reference each other with ZERO import
+// statements. resolvePath.ts only ever resolves something that exists as
+// an actual import token - this pass exists because that token never
+// shows up in the source at all for same-scope references.
+//
+// LIMITATION (documented, not a bug to "fix" later without redesigning
+// the approach entirely): this is a regex whole-word scan, not an AST-
+// aware usage check. A name mentioned in a comment or string literal
+// inside `content` will false-positive as a "dependency". Kept separate
+// from ModuleInfo.imports specifically because of this - see that field's
+// doc comment in shared/types.ts.
+
+import type { RawExport } from "../shared/types";
+
+export interface ScopedFile {
+  moduleId: string;
+  scopeId: string;
+  exports: RawExport[];
+  content: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Groups files by scopeId, then for each file checks whether its content
+ * contains a whole-word match for any OTHER same-scope file's exported
+ * names. Returns a map of moduleId -> array of moduleIds it appears to
+ * implicitly depend on. Deduped, and a file never depends on itself.
+ */
+export function resolveSameScopeDependencies(files: ScopedFile[]): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+
+  const byScope = new Map<string, ScopedFile[]>();
+  for (const file of files) {
+    const group = byScope.get(file.scopeId) ?? [];
+    group.push(file);
+    byScope.set(file.scopeId, group);
+  }
+
+  for (const group of byScope.values()) {
+    if (group.length < 2) continue; // nothing else in this scope to depend on
+
+    for (const file of group) {
+      const deps = new Set<string>();
+
+      for (const other of group) {
+        if (other.moduleId === file.moduleId) continue;
+
+        for (const exp of other.exports) {
+          if (!exp.name || exp.name === "*") continue;
+          const pattern = new RegExp(`\\b${escapeRegExp(exp.name)}\\b`);
+          if (pattern.test(file.content)) {
+            deps.add(other.moduleId);
+            break; // one match against `other` is enough, move to next candidate
+          }
+        }
+      }
+
+      if (deps.size > 0) {
+        result.set(file.moduleId, Array.from(deps));
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/parser/go/parseGo.ts
+++ b/packages/parser/go/parseGo.ts
@@ -8,6 +8,7 @@
 
 import type { LanguageParser } from "../core/ParserInterface";
 import type { FileInfo, ParsedFile, RawImport, RawExport } from "../../shared/types";
+import { posix } from "node:path";
 
 // Regex/line-based, not a full Go grammar (no tree-sitter-go grammar wired up
 // yet, unlike Python — see PROGRES.md gotchas for why that's non-trivial to
@@ -155,6 +156,6 @@ export const parseGo: LanguageParser = {
       warnings.push(`Export extraction failed: ${(err as Error).message}`);
     }
 
-    return { file, imports, exports: exportsList, warnings };
+    return { file, imports, exports: exportsList, warnings, scopeId: posix.dirname(file.relativePath) };
   },
 };

--- a/packages/parser/java/parseJava.ts
+++ b/packages/parser/java/parseJava.ts
@@ -8,6 +8,7 @@
 
 import type { LanguageParser } from "../core/ParserInterface";
 import type { FileInfo, ParsedFile, RawImport, RawExport } from "../../shared/types";
+import { posix } from "node:path";
 
 // Regex/line-based, not a full Java grammar. Handles import statements
 // (including `static` and wildcard `.*` imports) and public-modifier
@@ -114,6 +115,6 @@ export const parseJava: LanguageParser = {
       warnings.push(`Export extraction failed: ${(err as Error).message}`);
     }
 
-    return { file, imports, exports: exportsList, warnings };
+    return { file, imports, exports: exportsList, warnings, scopeId: posix.dirname(file.relativePath) };
   },
 };

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -79,6 +79,14 @@ export interface ParsedFile {
   file: FileInfo;
   imports: RawImport[];
   exports: RawExport[];
+  /**
+   * For languages where files sharing a directory (Go) or package
+   * declaration (Java, by convention - package must match directory per
+   * the language spec) implicitly share scope and can reference each
+   * other with ZERO import statements. Only set by parseGo.ts and
+   * parseJava.ts today. Consumed by resolveSameScopeDependencies.ts.
+   */
+  scopeId?: string;
   /** Parser-specific extras (e.g. React components found, hooks used) go here, not in the base shape */
   meta?: Record<string, unknown>;
   /** Non-fatal parse warnings (e.g. "could not parse dynamic require") */
@@ -133,6 +141,15 @@ export interface ModuleInfo {
   importedBy: string[]; // module ids that import this module
   imports: string[]; // module ids this module imports (resolved, not raw strings)
   resolvedImports: ResolvedImport[]; // identifier-level detail of `imports`
+  /**
+   * Dependencies found via resolveSameScopeDependencies.ts's regex-based
+   * whole-word scan, NOT from an actual import statement. Kept SEPARATE
+   * from `imports` on purpose: imports[] is 100 percent certain (literal
+   * from source), this is a guess that can false-positive (e.g. a name
+   * mentioned in a comment or string literal). Not yet wired into any
+   * graph builder - see PROGRES.md decisions entry.
+   */
+  implicitDependencies: string[];
 }
 
 // ─────────────────────────────────────────────

--- a/tests/indexer/resolveSameScopeDependencies.test.ts
+++ b/tests/indexer/resolveSameScopeDependencies.test.ts
@@ -1,0 +1,96 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { resolveSameScopeDependencies, type ScopedFile } from "../../packages/indexer/resolveSameScopeDependencies"
+
+// Uses the REAL fixtures already committed at playground/go-demo/ (not a
+// copy) - these exist specifically to demonstrate the same-package
+// implicit-dependency gap documented in parseGo.ts and parseJava.ts.
+const FIXTURE_DIR = join(process.cwd(), "playground/go-demo")
+
+function readFixture(name: string): string {
+  return readFileSync(join(FIXTURE_DIR, name), "utf-8")
+}
+
+describe("resolveSameScopeDependencies", () => {
+  const files: ScopedFile[] = [
+    {
+      moduleId: "playground/go-demo/main.go",
+      scopeId: "playground/go-demo",
+      exports: [],
+      content: readFixture("main.go"),
+    },
+    {
+      moduleId: "playground/go-demo/service.go",
+      scopeId: "playground/go-demo",
+      exports: [{ name: "CreateUserProfile", kind: "named", line: 1 }],
+      content: readFixture("service.go"),
+    },
+    {
+      moduleId: "playground/go-demo/models.go",
+      scopeId: "playground/go-demo",
+      exports: [
+        { name: "User", kind: "named", line: 1 },
+        { name: "Product", kind: "named", line: 1 },
+      ],
+      content: readFixture("models.go"),
+    },
+    {
+      moduleId: "playground/go-demo/utils.go",
+      scopeId: "playground/go-demo",
+      exports: [
+        { name: "Slugify", kind: "named", line: 1 },
+        { name: "UnusedHelper", kind: "named", line: 1 },
+      ],
+      content: readFixture("utils.go"),
+    },
+  ]
+
+  const result = resolveSameScopeDependencies(files)
+
+  it("finds main.go depends on models.go (uses User) and service.go (uses CreateUserProfile)", () => {
+    const deps = result.get("playground/go-demo/main.go") ?? []
+    expect(deps).toContain("playground/go-demo/models.go")
+    expect(deps).toContain("playground/go-demo/service.go")
+    expect(deps).toHaveLength(2)
+  })
+
+  it("finds service.go depends on models.go (User param type) and utils.go (calls Slugify)", () => {
+    const deps = result.get("playground/go-demo/service.go") ?? []
+    expect(deps).toContain("playground/go-demo/models.go")
+    expect(deps).toContain("playground/go-demo/utils.go")
+    expect(deps).toHaveLength(2)
+  })
+
+  it("finds no dependencies for models.go (only type definitions, calls nothing)", () => {
+    expect(result.has("playground/go-demo/models.go")).toBe(false)
+  })
+
+  it("finds no dependencies for utils.go (UnusedHelper is genuinely unused, Slugify only calls external strings package)", () => {
+    expect(result.has("playground/go-demo/utils.go")).toBe(false)
+  })
+
+  it("does not create a self-dependency", () => {
+    // Sanity check on the whole-word matching: service.go itself contains
+    // "CreateUserProfile" (its own function name in the signature), this
+    // must NOT show up as service.go depending on itself.
+    const deps = result.get("playground/go-demo/service.go") ?? []
+    expect(deps).not.toContain("playground/go-demo/service.go")
+  })
+
+  it("returns empty deps for a lone file with no scope siblings", () => {
+    const lonely: ScopedFile[] = [
+      { moduleId: "solo/only.go", scopeId: "solo", exports: [{ name: "Foo", kind: "named", line: 1 }], content: "package solo" },
+    ]
+    const soloResult = resolveSameScopeDependencies(lonely)
+    expect(soloResult.size).toBe(0)
+  })
+})


### PR DESCRIPTION
Adds ModuleInfo.implicitDependencies, populated by a new generic pass (resolveSameScopeDependencies.ts) that groups files by scopeId (directory) and does a regex whole-word scan for exported names from sibling files.

Root cause: Go and Java both let files in the same package/directory reference each other with ZERO import statements — resolvePath.ts only ever resolves an actual import token, which never exists for these references. This was the reason ARCLUX's graph view showed near-empty graphs (just scattered nodes, no edges) when tested against kubernetes/kubernetes and spring-projects/spring-boot.

Deliberately kept separate from ModuleInfo.imports (heuristic regex match, can false-positive on comments/strings — imports[] stays 100% certain). Not yet wired into any graph builder — that's a follow-up, scoped out here to keep this PR reviewable. See PROGRES.md decisions entry for the full reasoning on building one generic pass instead of per-language fixes.

Tested against the real playground/go-demo fixtures, 6 new tests covering the main.go/service.go/models.go/utils.go dependency chain plus edge cases (no self-dependency, lone file).