### PR TITLE
docs: mark parsePhp.ts as deliberately deferred

### DIFF
--- a/packages/parser/php/parsePhp.ts
+++ b/packages/parser/php/parsePhp.ts
@@ -5,4 +5,23 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
+// DELIBERATELY DEFERRED, not abandoned — do not implement without reading
+// this comment first.
+//
+// PHP currently has a manifest parser (parseComposer.ts, reads
+// composer.json) but no general-purpose language parser for .php file
+// content itself — unlike Go/Java/Python/JS/TS, which all have both. This
+// file is meant to be that general parser (imports/use statements,
+// class/function exports across ALL .php files), once written.
+//
+// NOT written yet on purpose: issue #53 has Alitindrawan24 building
+// packages/parser/php/parsePhpRoutes.ts, a narrowly-scoped parser that
+// only reads routes/web.php and routes/api.php to extract controller
+// references (see the issue for the exact syntax it handles). That's a
+// DIFFERENT file with a DIFFERENT purpose (routes-only vs all-PHP), so it
+// won't directly conflict with this one - but writing a general parsePhp.ts
+// in parallel risks establishing a different PHP-parsing style/convention
+// than whatever pattern emerges from issue #53's PR. Wait for that to land
+// first, then write this one following the same regex/extraction
+// conventions for consistency, rather than inventing a second style.


### PR DESCRIPTION
No functional change — documents why this file stays empty for now (waiting on issue #53 to establish PHP parsing conventions first).