### PR TITLE
docs: session summary + collaborator file-marking decision

### DIFF
--- a/progres/PROGRES-decisions.md
+++ b/progres/PROGRES-decisions.md
@@ -167,3 +167,30 @@ parallel case).
 it's a JVM library, not directly adaptable to TypeScript, but worth
 reading for how a mature tool structures scope resolution before
 designing ARCLUX's own pass.
+
+## Decision — issues assigned to a collaborator must also be marked in-file
+
+**Context**: packages/parser/php/parsePhp.ts and
+packages/parser/php/parsePhpRoutes.ts sit right next to each other.
+parsePhpRoutes.ts is assigned to Alitindrawan24 via issue #53.
+Someone Browse-ing packages/parser/php/ without first checking the
+GitHub issues list has no way to know parsePhpRoutes.ts is spoken for
+- it just looks like another empty file waiting to be filled in,
+identical in appearance to a genuinely unclaimed stub.
+
+**Decision**: whenever an issue is filed that assigns a SPECIFIC file
+or narrowly-scoped task to a collaborator, also add a short comment in
+that file (or, if the file doesn't exist yet, in the most relevant
+existing sibling file) stating the issue number and assignee. Do not
+rely on the GitHub issue tracker alone to communicate this - anyone
+working directly in the codebase (a session reading files, not
+Browse-ing issues first) needs the signal to be visible at the file
+level too.
+
+Minimum content for the marker comment: issue number, assignee
+username, one line on what's being built there. See
+packages/parser/php/parsePhp.ts's comment (referencing issue #53 /
+Alitindrawan24 / parsePhpRoutes.ts) as the template to follow.
+
+This does not replace filing the GitHub issue - both are required, the
+file comment is an addition for discoverability, not a substitute.

--- a/progres/PROGRES-status.md
+++ b/progres/PROGRES-status.md
@@ -1053,3 +1053,32 @@ Python patch script heredoc failed with "No such file or directory"
 when targeting /tmp/patch_types2.py. Fix: write the script into the
 repo directory itself (~/arclux/patch_types2.py) and delete it after
 running, instead of using /tmp.
+
+## Update - documented 3 previously-mysterious empty stub files
+
+Investigated 3 files that were 0-line-except-license-header stubs with
+no obvious purpose from surrounding code, and documented each with an
+in-file comment explaining its actual status, so future sessions don't
+re-investigate the same files from scratch:
+
+- packages/parser/typescript/parseTsConfig.ts — INTENTIONALLY EMPTY
+  permanently. Superseded by resolveAliases.ts, which already handles
+  tsconfig.json/jsconfig.json parsing for path alias resolution. Do not
+  implement a config parser here.
+- packages/parser/core/parseImports.ts — intentionally empty for now,
+  not confirmed dead. Every language parser (parseGo.ts, parseJava.ts,
+  extractJs.ts, parsePython.ts, parseTs.ts) implements its own
+  extractImports() independently since each language's import syntax
+  differs too much for an obvious shared generic version. Could be
+  revisited if a genuinely shared pattern emerges later.
+- packages/parser/php/parsePhp.ts — deliberately DEFERRED (not
+  abandoned, not intentionally-empty-forever). Waiting on issue #53's
+  parsePhpRoutes.ts (assigned to Alitindrawan24) to land first, so this
+  general-purpose PHP parser follows whatever regex/extraction
+  convention emerges from that PR instead of establishing a second,
+  inconsistent PHP-parsing style in parallel. Merged via PR #70.
+
+Also confirmed: not every empty-looking file in this repo is
+unfinished work. Before investigating an empty stub, `cat` the whole
+file first (not just `wc -l`) — some are marked intentionally empty in
+a comment, which immediately answers the question.


### PR DESCRIPTION
Documents parseTsConfig.ts/parseImports.ts/parsePhp.ts investigation, and records a new process decision: issues assigned to a collaborator for a specific file must also get an in-file comment (issue number + assignee), not just a GitHub issue, since browsing the codebase directly gives no signal otherwise.