### PR TITLE
fix(scripts): checkCollaboratorMarkers.ts title-detection bug

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -1,0 +1,13 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Issue #75, assignee: GSF-001. Measures how long analyzeLocalDirectory()
+// takes on repos of varying size, so performance regressions are caught
+// with numbers instead of vibes. Not yet implemented — this is currently
+// a self-test of the collaborator marking system, not real benchmark
+// logic yet.

--- a/scripts/checkCollaboratorMarkers.ts
+++ b/scripts/checkCollaboratorMarkers.ts
@@ -37,13 +37,14 @@ import { readFileSync, existsSync } from "node:fs";
 interface GhIssue {
   number: number;
   assignees: { login: string }[];
+  title: string;
   body: string;
 }
 
 const FILE_PATH_PATTERN = /(?:packages|apps|scripts|tests)\/[A-Za-z0-9_\-/]+\.(?:ts|tsx)/g;
 
 function getOpenAssignedIssues(): GhIssue[] {
-  const raw = execSync("gh issue list --state open --json number,assignees,body --limit 200", {
+  const raw = execSync("gh issue list --state open --json number,assignees,title,body --limit 200", {
     encoding: "utf-8",
   });
   const issues: GhIssue[] = JSON.parse(raw);
@@ -67,7 +68,7 @@ function main() {
 
   for (const issue of issues) {
     const assignee = issue.assignees.map((a) => a.login).join(", ");
-    const filePaths = extractFilePaths(issue.body);
+    const filePaths = extractFilePaths(`${issue.title}\n${issue.body}`);
 
     for (const filePath of filePaths) {
       if (!existsSync(filePath)) {


### PR DESCRIPTION
Found via self-test — see issue #75. Script only scanned issue body for file paths, missing anything mentioned only in the title. Fixed, and confirmed it also fixes a real miss (buildCallGraph.ts, issue #50).