### PR TITLE
docs: add Documentation section to README, fix npm->pnpm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Dependency graph, impact analysis, and structural convention checking for your c
 
 [](#status)
 
+
+## Documentation
+
+- [`TOOLING.md`](TOOLING.md) — all repo config/tooling explained (PROGRES system, git workflow, pre-commit hook, CI, CODEOWNERS, etc.)
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions for contributing code
+- [`PROGRES.md`](PROGRES.md) (+ [`progres/`](progres/)) — up-to-date project status: what works, what's a stub, decisions, known bugs/gotchas
+
 ## Status: alpha
 
 This project is under active development with a small team. Expect breaking changes, missing pieces, and stubs that are not wired up yet. See [`PROGRES.md`](PROGRES.md) (and the linked files in [`progres/`](progres/)) for a detailed, honest breakdown of what works today vs. what is still a stub — that's the up-to-date source of truth, this README is a summary.
@@ -44,7 +51,7 @@ Not yet published to npm. Clone and build locally:
 
     git clone https://github.com/GSF-001/ARCLUX.git
     cd ARCLUX
-    npm install
+    pnpm install
 
 Run CLI commands via: `npx tsx apps/cli/index.ts <command>`
 
@@ -83,7 +90,7 @@ Each stage is an independent package: parser, graph, impact, detectors, rules, e
 We use GitHub Issues to track open work. `main` is protected; all changes go through a pull request.
 
     git clone https://github.com/GSF-001/ARCLUX.git
-    cd ARCLUX && npm install
+    cd ARCLUX && pnpm install
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions, and [`PROGRES.md`](PROGRES.md) (plus [`progres/`](progres/)) for current project status before picking up work.
 


### PR DESCRIPTION
README linked no docs (TOOLING.md, CONTRIBUTING.md, PROGRES.md) even though they'd become hard to find as the repo grew. Also fixed two leftover 'npm install' instructions -- project uses pnpm.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
