### PR TITLE
feat: implement useGraph.ts as re-export, document other stubs

### DIFF
--- a/apps/web/features/graph/graphEvents.ts
+++ b/apps/web/features/graph/graphEvents.ts
@@ -6,3 +6,10 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Deliberately left empty. GraphProvider.tsx (components/graph/) already
+// owns all graph state (transform, positions, dimensions, selection) via
+// React Context. Do NOT implement a separate store/hooks layer here --
+// it would create two sources of truth for the same state. See
+// progres/PROGRES-decisions.md (2026-08-03) for the full reasoning.
+// If you need graph state in features/graph/, import useGraph from
+// ./useGraph.ts instead.

--- a/apps/web/features/graph/graphStore.ts
+++ b/apps/web/features/graph/graphStore.ts
@@ -6,3 +6,10 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Deliberately left empty. GraphProvider.tsx (components/graph/) already
+// owns all graph state (transform, positions, dimensions, selection) via
+// React Context. Do NOT implement a separate store/hooks layer here --
+// it would create two sources of truth for the same state. See
+// progres/PROGRES-decisions.md (2026-08-03) for the full reasoning.
+// If you need graph state in features/graph/, import useGraph from
+// ./useGraph.ts instead.

--- a/apps/web/features/graph/useGraph.ts
+++ b/apps/web/features/graph/useGraph.ts
@@ -6,4 +6,14 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Thin re-export of GraphProvider's context hook. See
+// progres/PROGRES-decisions.md (2026-08-03) for why this file exists as
+// a re-export instead of its own store: GraphProvider.tsx already owns
+// all graph state via React Context, and this just gives callers in
+// features/graph/ a shorter import path without creating a second
+// source of truth.
+
+"use client";
+
 export { useGraphContext as useGraph } from "@/components/graph/GraphProvider";
+export type { GraphTransform, CanvasDimensions } from "@/components/graph/GraphProvider";

--- a/apps/web/features/graph/useGraphLayout.ts
+++ b/apps/web/features/graph/useGraphLayout.ts
@@ -6,3 +6,10 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Deliberately left empty. GraphProvider.tsx (components/graph/) already
+// owns all graph state (transform, positions, dimensions, selection) via
+// React Context. Do NOT implement a separate store/hooks layer here --
+// it would create two sources of truth for the same state. See
+// progres/PROGRES-decisions.md (2026-08-03) for the full reasoning.
+// If you need graph state in features/graph/, import useGraph from
+// ./useGraph.ts instead.

--- a/apps/web/features/graph/useGraphSelection.ts
+++ b/apps/web/features/graph/useGraphSelection.ts
@@ -6,3 +6,10 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Deliberately left empty. GraphProvider.tsx (components/graph/) already
+// owns all graph state (transform, positions, dimensions, selection) via
+// React Context. Do NOT implement a separate store/hooks layer here --
+// it would create two sources of truth for the same state. See
+// progres/PROGRES-decisions.md (2026-08-03) for the full reasoning.
+// If you need graph state in features/graph/, import useGraph from
+// ./useGraph.ts instead.


### PR DESCRIPTION
Per progres/PROGRES-decisions.md (2026-08-03): useGraph.ts is now a thin re-export of GraphProvider's useGraphContext(). The other 4 files (graphStore, graphEvents, useGraphLayout, useGraphSelection) stay deliberately empty but now have an explanatory comment so nobody mistakes them for unfinished stubs and tries to implement a competing state layer.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
