### PR TITLE
feat: implement lib/api.ts + lib/graph.ts, refactor duplicated fetch

### DIFF
--- a/apps/web/components/explorer/DependencyList.tsx
+++ b/apps/web/components/explorer/DependencyList.tsx
@@ -4,31 +4,13 @@ import { useEffect, useState } from "react";
 import { LoadingState } from "@/components/patterns/LoadingState";
 import { ErrorState } from "@/components/patterns/ErrorState";
 import { EmptyState } from "@/components/patterns/EmptyState";
+import { fetchGraph } from "@/lib/graph";
+import type { DependencyGraph, GraphNode } from "@/packages/shared/types";
 
-// Response shape didefinisiin lokal, sama pola kayak FileDetails.tsx
-// (FileResponse) dan ImpactSummary.tsx (ImpactResponse) -- bukan import
-// dari packages/shared/types karena apps/web ke packages/ cross-boundary
-// import path belum dikonfirmasi (workspace alias / relative path belum
-// dicek). Kalau nanti ada @arclux/shared alias, field-field ini harus
-// sama persis kayak GraphNode/GraphEdge di packages/shared/types.ts.
-interface GraphNodeResponse {
-  id: string;
-  type: string;
-  label: string;
-  filePath?: string;
-}
-
-interface GraphEdgeResponse {
-  id: string;
-  source: string;
-  target: string;
-  type: string;
-}
-
-interface GraphResponse {
-  nodes: GraphNodeResponse[];
-  edges: GraphEdgeResponse[];
-}
+// Verified against app/api/graph/route.ts: DependencyGraph.nodes/edges
+// match GraphNode/GraphEdge exactly. The local GraphResponse type that
+// used to live here (a guess made before this was confirmed) is gone --
+// this now imports the real shared types via lib/graph.ts's fetchGraph().
 
 export interface DependencyListProps {
   repoUrl: string;
@@ -52,7 +34,7 @@ export interface DependencyListProps {
  * graph yang beda hidup berdampingan.
  */
 export function DependencyList({ repoUrl, moduleId, branch }: DependencyListProps) {
-  const [data, setData] = useState<GraphResponse | null>(null);
+  const [data, setData] = useState<DependencyGraph | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -63,14 +45,8 @@ export function DependencyList({ repoUrl, moduleId, branch }: DependencyListProp
       setIsLoading(true);
       setError(null);
       try {
-        const params = new URLSearchParams({ repoUrl });
-        if (branch) params.set("branch", branch);
-
-        const res = await fetch(`/api/graph?${params.toString()}`);
-        const json = await res.json();
-
-        if (!res.ok) throw new Error(json.error ?? `Request failed with status ${res.status}`);
-        if (!cancelled) setData(json as GraphResponse);
+        const graph = await fetchGraph(repoUrl, branch);
+        if (!cancelled) setData(graph);
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load dependencies");
       } finally {
@@ -93,12 +69,12 @@ export function DependencyList({ repoUrl, moduleId, branch }: DependencyListProp
   const imports = data.edges
     .filter((e) => e.type === "import" && e.source === moduleId)
     .map((e) => nodesById.get(e.target))
-    .filter((n): n is GraphNodeResponse => Boolean(n));
+    .filter((n): n is GraphNode => Boolean(n));
 
   const importedBy = data.edges
     .filter((e) => e.type === "import" && e.target === moduleId)
     .map((e) => nodesById.get(e.source))
-    .filter((n): n is GraphNodeResponse => Boolean(n));
+    .filter((n): n is GraphNode => Boolean(n));
 
   return (
     <div className="space-y-6 p-4">
@@ -114,7 +90,7 @@ function DependencySection({
   emptyMessage,
 }: {
   title: string;
-  nodes: GraphNodeResponse[];
+  nodes: GraphNode[];
   emptyMessage: string;
 }) {
   return (

--- a/apps/web/components/graph/GraphProvider.tsx
+++ b/apps/web/components/graph/GraphProvider.tsx
@@ -9,6 +9,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react";
+import { fetchGraph as fetchGraphData } from "@/lib/graph";
 import type { DependencyGraph, GraphNode as GraphNodeData } from "@/packages/shared/types";
 import type { GraphNodePosition } from "./GraphNode";
 
@@ -74,21 +75,13 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
   useEffect(() => {
     let cancelled = false;
 
-    async function fetchGraph() {
+    async function loadGraph() {
       setIsLoading(true);
       setError(null);
       try {
-        const params = new URLSearchParams({ repoUrl });
-        if (branch) params.set("branch", branch);
-
-        const res = await fetch(`/api/graph?${params.toString()}`);
-        const data = await res.json();
-
-        if (!res.ok) {
-          throw new Error(data.error ?? `Request failed with status ${res.status}`);
-        }
+        const data = await fetchGraphData(repoUrl, branch);
         if (!cancelled) {
-          setGraph(data as DependencyGraph);
+          setGraph(data);
         }
       } catch (err) {
         if (!cancelled) {
@@ -99,7 +92,7 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
       }
     }
 
-    fetchGraph();
+    loadGraph();
     return () => {
       cancelled = true;
     };

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -6,3 +6,39 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Shared fetch helper for the /api/* routes. Extracted from the
+// duplicated fetch+parse pattern found in ImpactSummary.tsx and
+// GlobalSearch.tsx: build query params, fetch, check res.ok, parse
+// JSON, throw a readable Error on failure.
+//
+// Callers still own their own loading/error state and AbortController
+// cancellation flag (see ImpactSummary.tsx for that pattern) -- this
+// helper only replaces the fetch+parse boilerplate, not the React
+// lifecycle around it.
+
+export async function fetchJson<T>(
+  path: string,
+  params?: Record<string, string | undefined>
+): Promise<T> {
+  const query = new URLSearchParams();
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) query.set(key, value);
+    }
+  }
+  const qs = query.toString();
+  const url = qs ? `${path}?${qs}` : path;
+
+  const res = await fetch(url);
+  const json = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    const message =
+      json && typeof json === "object" && "error" in json
+        ? String((json as { error: unknown }).error)
+        : `Request failed with status ${res.status}`;
+    throw new Error(message);
+  }
+
+  return json as T;
+}

--- a/apps/web/lib/graph.ts
+++ b/apps/web/lib/graph.ts
@@ -6,3 +6,21 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Client fetch helper for /api/graph. Extracted from the duplicated
+// fetch+parse pattern in GraphProvider.tsx and DependencyList.tsx.
+//
+// This only wraps the /api/graph request/response shape -- it does not
+// own graph state (transform, positions, selection). That's
+// GraphProvider.tsx's job via React Context; see
+// progres/PROGRES-decisions.md (2026-08-03) for why those two concerns
+// stay separate.
+
+import { fetchJson } from "@/lib/api";
+import type { DependencyGraph } from "@/packages/shared/types";
+
+export async function fetchGraph(
+  repoUrl: string,
+  branch?: string
+): Promise<DependencyGraph> {
+  return fetchJson<DependencyGraph>("/api/graph", { repoUrl, branch });
+}


### PR DESCRIPTION
- lib/api.ts: shared fetchJson() helper (query params, res.ok check, error parsing), extracted from the pattern duplicated across ImpactSummary.tsx and GlobalSearch.tsx
- lib/graph.ts: fetchGraph() wrapping /api/graph, built on fetchJson()
- GraphProvider.tsx, DependencyList.tsx: refactored to use fetchGraph() instead of each having their own inline fetch+parse block
- DependencyList.tsx also now imports DependencyGraph/GraphNode from packages/shared/types instead of a local guessed-at type -- verified against app/api/graph/route.ts, the shapes match exactly. This resolves the 'not yet confirmed' note that was in the file's header comment.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
