### PR TITLE
feat: graph node impact halo (zoom-gated)

### DIFF
--- a/apps/web/components/graph/GraphCanvas.tsx
+++ b/apps/web/components/graph/GraphCanvas.tsx
@@ -44,6 +44,7 @@ export function GraphCanvas() {
     setPositions,
     dimensions,
     setDimensions,
+    importCounts,
   } = useGraphContext();
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -313,6 +314,8 @@ export function GraphCanvas() {
                 isHovered={node.id === hoveredNodeId}
                 onClick={selectNode}
                 onHoverChange={setHoveredNodeId}
+                importCount={importCounts.get(node.id) ?? 0}
+                zoomScale={transform.scale}
               />
             );
           })}

--- a/apps/web/components/graph/GraphNode.tsx
+++ b/apps/web/components/graph/GraphNode.tsx
@@ -24,13 +24,44 @@ export interface GraphNodeProps {
   isHovered: boolean;
   onClick: (id: string) => void;
   onHoverChange: (id: string | null) => void;
+  /** Number of edges targeting this node (computed client-side from
+   * DependencyGraph.edges in GraphProvider.tsx). Drives the impact halo. */
+  importCount?: number;
+  /** Current viewport zoom scale from GraphTransform. The impact halo
+   * only renders past MIN_ZOOM_FOR_HALO to avoid clutter when zoomed
+   * out on dense graphs -- see progres/PROGRES-decisions.md. */
+  zoomScale?: number;
 }
 
 const BASE_RADIUS = 6;
 
-export function GraphNode({ node, position, isSelected, isHovered, onHoverChange }: GraphNodeProps) {
+// Fan-in tiers for the impact halo. Starting thresholds, not yet tuned
+// against a wide variety of real repos -- see progres/PROGRES-decisions.md.
+const IMPACT_HIGH_THRESHOLD = 100;
+const IMPACT_MEDIUM_THRESHOLD = 20;
+
+// Halo only renders once zoomed in past this scale, so overview/zoomed-out
+// views of dense graphs don't get cluttered with overlapping halos.
+const MIN_ZOOM_FOR_HALO = 1;
+
+function getImpactHaloRadius(importCount: number): number | null {
+  if (importCount > IMPACT_HIGH_THRESHOLD) return 14;
+  if (importCount >= IMPACT_MEDIUM_THRESHOLD) return 9;
+  return null;
+}
+
+export function GraphNode({
+  node,
+  position,
+  isSelected,
+  isHovered,
+  onHoverChange,
+  importCount = 0,
+  zoomScale = 1,
+}: GraphNodeProps) {
   const color = getGraphNodeColor(node.type, "dark");
   const radius = isSelected ? BASE_RADIUS + 3 : isHovered ? BASE_RADIUS + 1.5 : BASE_RADIUS;
+  const impactHaloRadius = zoomScale >= MIN_ZOOM_FOR_HALO ? getImpactHaloRadius(importCount) : null;
 
   return (
     <g
@@ -40,6 +71,16 @@ export function GraphNode({ node, position, isSelected, isHovered, onHoverChange
       onMouseLeave={() => onHoverChange(null)}
       className="cursor-pointer"
     >
+      {impactHaloRadius !== null && (
+        <circle
+          r={radius + impactHaloRadius}
+          fill="none"
+          stroke={color}
+          strokeWidth={1}
+          strokeOpacity={0.25}
+          className="pointer-events-none"
+        />
+      )}
       {isSelected && (
         <circle r={radius + 5} fill="none" stroke={color} strokeWidth={1} strokeOpacity={0.4} />
       )}

--- a/apps/web/components/graph/GraphProvider.tsx
+++ b/apps/web/components/graph/GraphProvider.tsx
@@ -8,7 +8,7 @@
 
 "use client";
 
-import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react";
+import { createContext, useContext, useEffect, useState, useCallback, useMemo, type ReactNode } from "react";
 import { fetchGraph as fetchGraphData } from "@/lib/graph";
 import type { DependencyGraph, GraphNode as GraphNodeData } from "@/packages/shared/types";
 import type { GraphNodePosition } from "./GraphNode";
@@ -50,6 +50,11 @@ interface GraphContextValue {
   setPositions: (p: Map<string, GraphNodePosition>) => void;
   dimensions: CanvasDimensions;
   setDimensions: (d: CanvasDimensions) => void;
+  /** Fan-in count per node id, computed from graph.edges (how many edges
+   * target this node). Drives the impact halo in GraphNode.tsx -- see
+   * progres/PROGRES-decisions.md for why this is computed client-side
+   * instead of added to the backend GraphNode type. */
+  importCounts: Map<string, number>;
 }
 
 const GraphContext = createContext<GraphContextValue | null>(null);
@@ -123,6 +128,15 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
     setTransform(DEFAULT_TRANSFORM);
   }, []);
 
+  const importCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    if (!graph) return counts;
+    for (const edge of graph.edges) {
+      counts.set(edge.target, (counts.get(edge.target) ?? 0) + 1);
+    }
+    return counts;
+  }, [graph]);
+
   const value: GraphContextValue = {
     graph,
     isLoading,
@@ -144,6 +158,7 @@ export function GraphProvider({ repoUrl, branch, children }: GraphProviderProps)
     setPositions,
     dimensions,
     setDimensions,
+    importCounts,
   };
 
   return <GraphContext.Provider value={value}>{children}</GraphContext.Provider>;

--- a/progres/PROGRES-decisions.md
+++ b/progres/PROGRES-decisions.md
@@ -47,6 +47,12 @@ resolved/documented).
 
 ## 2026-08-04 — Update -- PLANNED (not yet built): graph node visual impact indicator
 
+> **[STATUS UPDATE, 2026-08-07]: this plan is now implemented.** See the
+> "UPDATE: Graph impact halo — implemented" entry near the bottom of this
+> file for what actually got built and what's still open (tier thresholds
+> not yet tuned, not yet visually verified). The plan below is kept as-is
+> for historical context -- don't re-implement it.
+
 **Goal**: in the dependency graph view, high-impact nodes (files with
 many consumers, e.g. logService.ts in a VS Code-scale repo with 430
 importers) should be visually distinguishable WITHOUT clicking each node
@@ -210,8 +216,16 @@ DependencyList.tsx previously had a local GraphResponse/GraphNodeResponse/GraphE
 
 ## 2026-08-07 — Next steps priority for future sessions
 
+> **[STATUS UPDATE, 2026-08-07 later same day]: item (1) below is now
+> implemented** -- see "UPDATE: Graph impact halo — implemented" near
+> the end of this file. Item (2) is still open.
+
 Two concrete next steps identified this session, in suggested order: (1) Graph node visual impact indicator (halo ring for high-fan-in nodes) -- full implementation plan already documented in an earlier entry in this file (client-side importCounts via useMemo in GraphProvider.tsx, passed as importCount prop through GraphCanvas.tsx to GraphNode.tsx, rendered as an extra halo circle). Zero code written yet, ready to start from step 1. (2) Remaining inline fetch() calls that duplicate the pattern lib/api.ts's fetchJson() now centralizes -- ImpactSummary.tsx and GlobalSearch.tsx were the two examples that motivated building fetchJson() in the first place but were NOT themselves refactored to use it. Worth a follow-up pass to actually consume the helper there, plus check FileDetails.tsx and app/api/file/route.ts for the same duplicated pattern.
 
 ## 2026-08-07 — Graph impact halo: zoom-gated to avoid clutter
 
 Resolved an open question from the original halo-ring plan: halos only render when zoom level is past a threshold (not always-on), avoiding visual clutter/overlap when zoomed out on dense graphs. Rejected alternatives: always-on halo (overlaps neighboring nodes in dense graphs), thicker border/stroke instead of halo (loses the 'grows with importance' visual cue that a halo radius gives). Implementation-wise this means GraphNode.tsx's halo render needs access to the current transform.scale (already available via useGraphContext()) and a MIN_ZOOM_FOR_HALO constant to gate on.
+
+## 2026-08-07 — UPDATE: Graph impact halo — implemented
+
+The halo-ring plan described in the 2026-08-0X entry above (and listed as a next step in 'Next steps priority for future sessions') is now implemented: GraphNode.tsx renders an impact halo circle gated by zoomScale >= MIN_ZOOM_FOR_HALO, importCount computed via useMemo in GraphProvider.tsx from graph.edges, passed through GraphCanvas.tsx. Tier thresholds (High >100, Medium 20-100) are still unverified against real repos -- that part of the original plan remains open. Not yet visually verified in-browser as of this entry. If you're reading the older halo entries above, they're outdated -- this is the current status.


### PR DESCRIPTION
Implements the plan from progres/PROGRES-decisions.md (2026-08-04):

- GraphProvider.tsx: importCounts Map<nodeId, count> computed via useMemo from graph.edges (counts edge.target occurrences), exposed on GraphContextValue
- GraphCanvas.tsx: passes importCount and zoomScale (from transform.scale) down to each GraphNode
- GraphNode.tsx: renders an extra halo circle behind the node when importCount crosses a tier threshold (High >100, Medium 20-100, unverified against real repos yet) AND zoomScale >= 1, so the overview stays uncluttered when zoomed out on dense graphs

Also updates progres/PROGRES-decisions.md: added status-update notes to the two earlier entries that referenced this as an open plan/next step, pointing to this implementation instead of leaving them looking stale. History kept intact, nothing deleted.

NOT YET visually verified in-browser -- tier thresholds still need tuning against a real large repo per the original plan's step 4.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
