### PR TITLE
docs: add rule for closing out old decisions.md plans

### DIFF
--- a/PROGRES.md
+++ b/PROGRES.md
@@ -68,6 +68,18 @@ Ask in this order, stop at the first "yes":
 5. Are you assigning a task to a collaborator, or updating the status of
    one already assigned? -> **collaborators**
 
+**Closing out an old plan/next-step**: if you just finished something
+that an EARLIER entry in `decisions.md` described as "planned", "not yet
+built", or a "next step", don't just log a new status entry and move on
+-- that leaves the old entry looking unfinished forever. Instead:
+1. Add a new dated entry titled `UPDATE: <old title> — implemented` (or
+   `— resolved`) describing what actually got built and what's still open.
+2. Go back to the OLD entry and add a one-line blockquote pointer at the
+   top: `> **[STATUS UPDATE, YYYY-MM-DD]: this plan is now implemented.**
+   See "<new entry title>" below.` Don't delete or shorten the old entry
+   -- the plan/reasoning stays as historical context, the pointer just
+   stops it from being mistaken for still-pending work.
+
 **Still not sure which status file? Put it in PROGRES-status-core.md.**
 A slightly-misfiled status entry costs nothing; agonizing over the perfect
 category wastes a turn. Nobody needs to re-sort these files -- they're


### PR DESCRIPTION
New sessions kept finding stale-looking 'planned/not yet built' entries in decisions.md even after the work was done, because closing out an old plan only ever added a new status entry -- never touched the old entry itself. Documented the fix as a rule: when finishing something tracked as a plan/next-step, add an UPDATE entry AND go back to add a one-line pointer at the top of the old entry, without deleting/shortening the original reasoning.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
