### PR TITLE
feat: add close-plan mode to log-progress.sh

### DIFF
--- a/scripts/log-progress.sh
+++ b/scripts/log-progress.sh
@@ -2,10 +2,80 @@
 # Usage: scripts/log-progress.sh <category> "<title>" "<body text>"
 # category: status-core | status-detectors | status-web | status-infra
 #           | status-backlog | bugs | decisions | gotchas | collaborators
+#
+# Usage: scripts/log-progress.sh close-plan <category> "<old title substring>" "<new update title>" "<update body>"
+# Closes out an old "planned/next step" entry: inserts a status-update
+# pointer at the top of the old entry, then appends a new dated
+# "UPDATE: ... — implemented" entry at the end of the file.
 set -euo pipefail
+
+if [ "${1:-}" = "close-plan" ]; then
+  if [ "$#" -lt 5 ]; then
+    echo "Usage: $0 close-plan <category> \"<old title substring>\" \"<new update title>\" \"<update body>\""
+    exit 1
+  fi
+
+  CATEGORY="$2"
+  OLD_TITLE="$3"
+  NEW_TITLE="$4"
+  BODY="$5"
+
+  FILE="progres/PROGRES-${CATEGORY}.md"
+
+  if [ ! -f "$FILE" ]; then
+    echo "ERROR: $FILE nggak ada. Cek nama kategori."
+    exit 1
+  fi
+
+  DATE=$(date +%Y-%m-%d)
+  FULL_NEW_TITLE="UPDATE: ${NEW_TITLE} — implemented"
+
+  OLD_LINE=$(grep -n "^## .*${OLD_TITLE}" "$FILE" | head -1 | cut -d: -f1 || true)
+
+  if [ -z "$OLD_LINE" ]; then
+    echo "ERROR: Nggak ketemu entry dengan judul mengandung: $OLD_TITLE"
+    echo "Cek dulu: grep '^## ' $FILE"
+    exit 1
+  fi
+
+  POINTER_FILE="$FILE" POINTER_LINE="$OLD_LINE" POINTER_DATE="$DATE" POINTER_TITLE="$FULL_NEW_TITLE" python3 << 'PYEOF'
+import os
+
+file_path = os.environ["POINTER_FILE"]
+old_line_idx = int(os.environ["POINTER_LINE"]) - 1
+date = os.environ["POINTER_DATE"]
+title = os.environ["POINTER_TITLE"]
+
+with open(file_path, "r") as f:
+    lines = f.readlines()
+
+insert_at = old_line_idx + 1
+if insert_at < len(lines) and lines[insert_at].strip() == "":
+    insert_at += 1
+
+pointer_line = '> **[STATUS UPDATE, ' + date + ']: this plan is now implemented.** See "' + title + '" below.\n\n'
+lines.insert(insert_at, pointer_line)
+
+with open(file_path, "w") as f:
+    f.writelines(lines)
+PYEOF
+
+  {
+    echo ""
+    echo "## ${DATE} — ${FULL_NEW_TITLE}"
+    echo ""
+    echo "$BODY"
+  } >> "$FILE"
+
+  echo "Pointer ditambahin di atas entry lama (line ~$OLD_LINE) di $FILE"
+  echo "Entry baru ditambahin di akhir $FILE:"
+  echo "## ${DATE} — ${FULL_NEW_TITLE}"
+  exit 0
+fi
 
 if [ "$#" -lt 3 ]; then
   echo "Usage: $0 <category> \"<title>\" \"<body>\""
+  echo "   or: $0 close-plan <category> \"<old title>\" \"<new title>\" \"<body>\""
   echo "Categories: status-core status-detectors status-web status-infra status-backlog bugs decisions gotchas collaborators"
   exit 1
 fi


### PR DESCRIPTION
Companion to the new decisions.md rule (previous commit): closing out an old plan/next-step used to mean manually writing a python heredoc to insert a status-update pointer, which was slow and error-prone (hit two bugs while doing it by hand this session: em-dash breaking shell quoting, then nested quotes breaking a python heredoc).

New usage: scripts/log-progress.sh close-plan <category> "<old title substring>" "<new update title>" "<body>" -- finds the old entry's header by substring match, inserts a blockquote pointer right below it, then appends a new dated UPDATE entry at the end of the file. Tested against gotchas.md (inserted + reverted cleanly) before this commit.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
