### PR TITLE
feat(web): add AnalyzingProgress stage indicator (simulated, not real…

### DIFF
--- a/TOOLING.md
+++ b/TOOLING.md
@@ -43,6 +43,24 @@ Contoh:
 scripts/log-progress.sh bugs "Fix parser crash on empty file" "Parser TypeScript crash kalau file kosong (cuma license header). Fixed dengan nambahin early-return check di parseTs.ts."
 ```
 
+### Nutup plan lama yang udh dikerjain -- pakai close-plan
+
+Kalau progres/PROGRES-decisions.md punya entry lama yang isinya "planned",
+"not yet built", atau "next step", dan lo baru aja selesai ngerjain itu,
+jangan cuma nambah entry status baru -- entry lama bakal kelihatan masih
+pending selamanya kalau gak disentuh.
+
+Pakai mode close-plan:
+
+```bash
+scripts/log-progress.sh close-plan <kategori> "<judul entry lama>" "<judul update baru>" "<isi update>"
+```
+
+Ini otomatis nyari entry lama berdasarkan potongan judulnya, nyisipin
+pointer status di bawah header lama, dan nambahin entry baru berjudul
+UPDATE: <judul> -- implemented di akhir file. Entry lama tidak dihapus,
+histori tetep uteh.
+
 Script ini otomatis:
 - Ambil tanggal hari ini dari device
 - Bikin header `## YYYY-MM-DD — judul`

--- a/apps/web/components/graph/AnalyzingProgress.tsx
+++ b/apps/web/components/graph/AnalyzingProgress.tsx
@@ -1,0 +1,72 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Addresses the "no progress feedback during analysis" gap flagged in
+// PROGRES-status.md. IMPORTANT — this is NOT real progress. The pipeline
+// runs synchronously server-side with no intermediate events streamed to
+// the client. This shows cycling stage labels + an indeterminate bar to
+// communicate "still happening", not a measurement of actual progress.
+// A real fix needs the backend to stream stage events (e.g. SSE) — not
+// done here, this is a stopgap for the UX gap only.
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STAGES = [
+  "Cloning repository…",
+  "Scanning files…",
+  "Parsing source…",
+  "Resolving imports…",
+  "Building dependency graph…",
+] as const;
+
+const STAGE_DURATION_MS = 2500;
+
+export function AnalyzingProgress() {
+  const [stageIndex, setStageIndex] = useState(0);
+  const [elapsedMs, setElapsedMs] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsedMs((prev) => prev + 100);
+    }, 100);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    const nextIndex = Math.min(STAGES.length - 1, Math.floor(elapsedMs / STAGE_DURATION_MS));
+    setStageIndex(nextIndex);
+  }, [elapsedMs]);
+
+  const isTakingAWhile = elapsedMs > STAGES.length * STAGE_DURATION_MS + 5000;
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-sm text-neutral-500">
+      <div className="w-64">
+        <div className="h-1 overflow-hidden rounded-full bg-neutral-800">
+          <div
+            className="h-full animate-pulse rounded-full bg-blue-500 transition-all duration-500"
+            style={{
+              width: `${Math.min(95, ((stageIndex + 1) / STAGES.length) * 100)}%`,
+            }}
+          />
+        </div>
+      </div>
+
+      <p>{STAGES[stageIndex]}</p>
+
+      {isTakingAWhile && (
+        <p className="max-w-xs text-center text-xs text-neutral-600">
+          This is taking longer than usual — large repositories can take
+          several minutes to clone and parse, especially on slower devices.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/graph/GraphCanvas.tsx
+++ b/apps/web/components/graph/GraphCanvas.tsx
@@ -7,6 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 "use client";
+import { AnalyzingProgress } from "./AnalyzingProgress";
 
 import { useEffect, useRef, useCallback } from "react";
 import {
@@ -214,11 +215,7 @@ export function GraphCanvas() {
   }
 
   if (isLoading) {
-    return (
-      <div className="flex h-full w-full items-center justify-center text-sm text-neutral-500">
-        Analyzing repository…
-      </div>
-    );
+    return <AnalyzingProgress />;
   }
 
   if (error) {

--- a/patch.py
+++ b/patch.py
@@ -1,0 +1,37 @@
+with open('TOOLING.md', 'r') as f:
+    content = f.read()
+old = '''Contoh:
+```bash
+scripts/log-progress.sh bugs "Fix parser crash on empty file" "Parser TypeScript crash kalau file kosong (cuma license header). Fixed dengan nambahin early-return check di parseTs.ts."
+```
+
+Script ini otomatis:'''
+new = '''Contoh:
+```bash
+scripts/log-progress.sh bugs "Fix parser crash on empty file" "Parser TypeScript crash kalau file kosong (cuma license header). Fixed dengan nambahin early-return check di parseTs.ts."
+```
+
+### Nutup plan lama yang udh dikerjain -- pakai close-plan
+
+Kalau progres/PROGRES-decisions.md punya entry lama yang isinya "planned",
+"not yet built", atau "next step", dan lo baru aja selesai ngerjain itu,
+jangan cuma nambah entry status baru -- entry lama bakal kelihatan masih
+pending selamanya kalau gak disentuh.
+
+Pakai mode close-plan:
+
+```bash
+scripts/log-progress.sh close-plan <kategori> "<judul entry lama>" "<judul update baru>" "<isi update>"
+```
+
+Ini otomatis nyari entry lama berdasarkan potongan judulnya, nyisipin
+pointer status di bawah header lama, dan nambahin entry baru berjudul
+UPDATE: <judul> -- implemented di akhir file. Entry lama tidak dihapus,
+histori tetep uteh.
+
+Script ini otomatis:'''
+assert old in content
+content = content.replace(old, new, 1)
+with open('TOOLING.md', 'w') as f:
+    f.write(content)
+print("done")

--- a/patch_tooling.py
+++ b/patch_tooling.py
@@ -1,0 +1,37 @@
+with open('TOOLING.md', 'r') as f:
+    content = f.read()
+old = '''Contoh:
+```bash
+scripts/log-progress.sh bugs "Fix parser crash on empty file" "Parser TypeScript crash kalau file kosong (cuma license header). Fixed dengan nambahin early-return check di parseTs.ts."
+```
+
+Script ini otomatis:'''
+new = '''Contoh:
+```bash
+scripts/log-progress.sh bugs "Fix parser crash on empty file" "Parser TypeScript crash kalau file kosong (cuma license header). Fixed dengan nambahin early-return check di parseTs.ts."
+```
+
+### Nutup plan lama yang udh dikerjain -- pakai close-plan
+
+Kalau progres/PROGRES-decisions.md punya entry lama yang isinya "planned",
+"not yet built", atau "next step", dan lo baru aja selesai ngerjain itu,
+jangan cuma nambah entry status baru -- entry lama bakal kelihatan masih
+pending selamanya kalau gak disentuh.
+
+Pakai mode close-plan:
+
+```bash
+scripts/log-progress.sh close-plan <kategori> "<judul entry lama>" "<judul update baru>" "<isi update>"
+```
+
+Ini otomatis nyari entry lama berdasarkan potongan judulnya, nyisipin
+pointer status di bawah header lama, dan nambahin entry baru berjudul
+UPDATE: <judul> -- implemented di akhir file. Entry lama tidak dihapus,
+histori tetep uteh.
+
+Script ini otomatis:'''
+assert old in content
+content = content.replace(old, new, 1)
+with open('TOOLING.md', 'w') as f:
+    f.write(content)
+print("done")

--- a/progres/PROGRES-decisions.md
+++ b/progres/PROGRES-decisions.md
@@ -229,3 +229,35 @@ Resolved an open question from the original halo-ring plan: halos only render wh
 ## 2026-08-07 — UPDATE: Graph impact halo — implemented
 
 The halo-ring plan described in the 2026-08-0X entry above (and listed as a next step in 'Next steps priority for future sessions') is now implemented: GraphNode.tsx renders an impact halo circle gated by zoomScale >= MIN_ZOOM_FOR_HALO, importCount computed via useMemo in GraphProvider.tsx from graph.edges, passed through GraphCanvas.tsx. Tier thresholds (High >100, Medium 20-100) are still unverified against real repos -- that part of the original plan remains open. Not yet visually verified in-browser as of this entry. If you're reading the older halo entries above, they're outdated -- this is the current status.
+
+## 2026-08-07 — Simulated stage progress instead of real backend streaming
+
+`apps/web/components/graph/AnalyzingProgress.tsx` (new) replaces the
+static "Analyzing repository…" text in GraphCanvas.tsx's `isLoading`
+branch. Cycles through 5 stage labels (Cloning/Scanning/Parsing/
+Resolving/Building) on a fixed timer + shows an indeterminate progress
+bar, with a "taking longer than usual" message after ~17s.
+
+**Chose client-only simulated progress over backend SSE streaming**:
+the correct fix (backend emits real stage events, e.g. via
+Server-Sent Events on /api/graph) would need analyzeRepository()'s
+pipeline to become event-emitting instead of a single synchronous
+return — a much larger change. This is a stopgap: the labels/timing are
+tuned by feel, NOT derived from real pipeline telemetry. Large repos will
+sit on the last stage indefinitely since there's no real signal to
+advance further. Documented as such in the component's own comment so
+nobody later mistakes this for actual progress reporting.
+
+Addresses the UX gap noted in status-backlog.md's large-repo dogfooding
+entry (microsoft/TypeScript's "Indexing failed" was indistinguishable
+from vercel/next.js's "just slow" until it errored, because there was no
+feedback at all).
+
+Verified: `tsc --noEmit -p apps/web/tsconfig.json` clean. NOT yet
+visually verified in-browser — pushed near a chat context limit.
+
+**Coordination note**: `git pull` before this session started fast-forwarded
+in unrelated changes to GraphCanvas.tsx/GraphNode.tsx/GraphProvider.tsx
+from another session (fan-in halo indicator feature, matches an earlier
+decisions.md plan) — merged cleanly, no conflict with this change since
+they touch different parts of the same files.


### PR DESCRIPTION
… backend progress) - see PROGRES-decisions.md

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
