### PR TITLE
docs: restore Contributors section, fix npm->pnpm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Run CLI commands via: `npx tsx apps/cli/index.ts <command>`
 Web dashboard:
 
     cd apps/web
-    npm run dev
+    pnpm run dev
 
 ## How it works
 
@@ -98,5 +98,11 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions, and [`PROGRES.md`](PRO
 ## License
 
 Apache License 2.0 (c) ARCLUX Contributors
+
+## Contributors
+
+<a href="https://github.com/GSF-001/ARCLUX/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=GSF-001/ARCLUX" />
+</a>
 
 


### PR DESCRIPTION
Contributors section was accidentally dropped in commit f6debcf6 (a generic 'Update README.md' commit made directly via GitHub's browser editor, same pattern as the GSF-001-patch-1/-2 stray branches). Also caught one leftover 'npm run dev' instruction that the earlier npm->pnpm cleanup missed (only 'npm install' was caught then, this is a different command).

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
