### PR TITLE
feat: add status field + set-status mode to log-progress.sh

### DIFF
--- a/scripts/log-progress.sh
+++ b/scripts/log-progress.sh
@@ -1,12 +1,21 @@
 #!/usr/bin/env bash
-# Usage: scripts/log-progress.sh <category> "<title>" "<body text>"
+# Usage: scripts/log-progress.sh <category> "<title>" "<body text>" ["<status>"]
 # category: status-core | status-detectors | status-web | status-infra
 #           | status-backlog | bugs | decisions | gotchas | collaborators
+# status (optional, 4th arg): Not Started | In Progress | Done -- defaults
+#           to "Not Started" if omitted. Only meaningful for decisions/status
+#           entries that describe planned work, but allowed on any category.
 #
 # Usage: scripts/log-progress.sh close-plan <category> "<old title substring>" "<new update title>" "<update body>"
 # Closes out an old "planned/next step" entry: inserts a status-update
 # pointer at the top of the old entry, then appends a new dated
-# "UPDATE: ... — implemented" entry at the end of the file.
+# "UPDATE: ... — implemented" entry (Status: Done) at the end of the file.
+#
+# Usage: scripts/log-progress.sh set-status <category> "<title substring>" "<new status>"
+# Updates the Status: line of an existing entry in place, without touching
+# the rest of the entry. Use this to move something from "Not Started" to
+# "In Progress" to "Done" as work happens, instead of writing new entries
+# each time.
 set -euo pipefail
 
 if [ "${1:-}" = "close-plan" ]; then
@@ -64,6 +73,8 @@ PYEOF
     echo ""
     echo "## ${DATE} — ${FULL_NEW_TITLE}"
     echo ""
+    echo "**Status:** Done"
+    echo ""
     echo "$BODY"
   } >> "$FILE"
 
@@ -73,9 +84,77 @@ PYEOF
   exit 0
 fi
 
+if [ "${1:-}" = "set-status" ]; then
+  if [ "$#" -lt 4 ]; then
+    echo "Usage: $0 set-status <category> \"<title substring>\" \"<new status>\""
+    echo "Status biasanya salah satu dari: Not Started | In Progress | Done"
+    exit 1
+  fi
+
+  CATEGORY="$2"
+  TITLE_MATCH="$3"
+  NEW_STATUS="$4"
+
+  FILE="progres/PROGRES-${CATEGORY}.md"
+
+  if [ ! -f "$FILE" ]; then
+    echo "ERROR: $FILE nggak ada. Cek nama kategori."
+    exit 1
+  fi
+
+  MATCH_LINE=$(grep -n "^## .*${TITLE_MATCH}" "$FILE" | head -1 | cut -d: -f1 || true)
+
+  if [ -z "$MATCH_LINE" ]; then
+    echo "ERROR: Nggak ketemu entry dengan judul mengandung: $TITLE_MATCH"
+    echo "Cek dulu: grep '^## ' $FILE"
+    exit 1
+  fi
+
+  STATUS_FILE="$FILE" STATUS_LINE="$MATCH_LINE" STATUS_NEW="$NEW_STATUS" python3 << 'PYEOF'
+import os
+import re
+
+file_path = os.environ["STATUS_FILE"]
+header_idx = int(os.environ["STATUS_LINE"]) - 1
+new_status = os.environ["STATUS_NEW"]
+
+with open(file_path, "r") as f:
+    lines = f.readlines()
+
+# Look for an existing "**Status:** ..." line within the next 5 lines after
+# the header (skipping blank lines and blockquote pointers).
+found_status_line = None
+for i in range(header_idx + 1, min(header_idx + 6, len(lines))):
+    if re.match(r"^\*\*Status:\*\*", lines[i]):
+        found_status_line = i
+        break
+
+if found_status_line is not None:
+    lines[found_status_line] = "**Status:** " + new_status + "\n"
+else:
+    # No status line yet -- insert one right after the header (and after
+    # a blank line if present, and after any blockquote pointer block).
+    insert_at = header_idx + 1
+    if insert_at < len(lines) and lines[insert_at].strip() == "":
+        insert_at += 1
+    while insert_at < len(lines) and lines[insert_at].startswith(">"):
+        insert_at += 1
+        if insert_at < len(lines) and lines[insert_at].strip() == "":
+            insert_at += 1
+    lines.insert(insert_at, "**Status:** " + new_status + "\n\n")
+
+with open(file_path, "w") as f:
+    f.writelines(lines)
+PYEOF
+
+  echo "Status di-update jadi \"$NEW_STATUS\" untuk entry di line ~$MATCH_LINE di $FILE"
+  exit 0
+fi
+
 if [ "$#" -lt 3 ]; then
-  echo "Usage: $0 <category> \"<title>\" \"<body>\""
+  echo "Usage: $0 <category> \"<title>\" \"<body>\" [\"<status>\"]"
   echo "   or: $0 close-plan <category> \"<old title>\" \"<new title>\" \"<body>\""
+  echo "   or: $0 set-status <category> \"<title>\" \"<new status>\""
   echo "Categories: status-core status-detectors status-web status-infra status-backlog bugs decisions gotchas collaborators"
   exit 1
 fi
@@ -83,6 +162,7 @@ fi
 CATEGORY="$1"
 TITLE="$2"
 BODY="$3"
+STATUS="${4:-Not Started}"
 
 FILE="progres/PROGRES-${CATEGORY}.md"
 
@@ -97,8 +177,11 @@ DATE=$(date +%Y-%m-%d)
   echo ""
   echo "## ${DATE} — ${TITLE}"
   echo ""
+  echo "**Status:** ${STATUS}"
+  echo ""
   echo "$BODY"
 } >> "$FILE"
 
 echo "Ditambahkan ke $FILE:"
 echo "## ${DATE} — ${TITLE}"
+echo "Status: ${STATUS}"


### PR DESCRIPTION
- New entries can take an optional 4th arg for status (Not Started | In Progress | Done), defaults to Not Started if omitted
- New set-status subcommand updates an existing entry's Status line in place without touching the rest of the entry, for moving work through Not Started -> In Progress -> Done as it happens
- close-plan mode now also stamps Status: Done on the UPDATE entry it creates, consistent with the new field

Tested all three modes (log with status, close-plan, set-status) against gotchas.md, reverted the test entries before this commit.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
