### PR TITLE
feat: LOD step 1 -- gate node icon render on zoom level

### DIFF
--- a/apps/web/components/graph/GraphNode.tsx
+++ b/apps/web/components/graph/GraphNode.tsx
@@ -44,6 +44,12 @@ const IMPACT_MEDIUM_THRESHOLD = 20;
 // views of dense graphs don't get cluttered with overlapping halos.
 const MIN_ZOOM_FOR_HALO = 1;
 
+// Below this zoom, node icons are too small to read and just cost a
+// render -- skip them. Part of a lightweight LOD (level-of-detail)
+// pass; see progres/PROGRES-decisions.md (2026-08-07 LOD entry) for
+// the fuller plan this is step 1 of.
+const MIN_ZOOM_FOR_ICON = 0.5;
+
 function getImpactHaloRadius(importCount: number): number | null {
   if (importCount > IMPACT_HIGH_THRESHOLD) return 14;
   if (importCount >= IMPACT_MEDIUM_THRESHOLD) return 9;
@@ -91,16 +97,18 @@ export function GraphNode({
         strokeWidth={1.5}
         opacity={isSelected || isHovered ? 1 : 0.85}
       />
-      <path
-        d={getNodeIconPath(node.type)}
-        fill="none"
-        stroke="#fff"
-        strokeWidth={0.6}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        opacity={isSelected || isHovered ? 0.95 : 0.65}
-        className="pointer-events-none"
-      />
+      {zoomScale >= MIN_ZOOM_FOR_ICON && (
+        <path
+          d={getNodeIconPath(node.type)}
+          fill="none"
+          stroke="#fff"
+          strokeWidth={0.6}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          opacity={isSelected || isHovered ? 0.95 : 0.65}
+          className="pointer-events-none"
+        />
+      )}
       {(isSelected || isHovered) && (
         <text
           x={radius + 6}


### PR DESCRIPTION
Below zoomScale 0.5, node icons are too small to read and just cost a render. First step of the level-of-detail pass discussed in progres/PROGRES-decisions.md (2026-08-07 LOD entry) -- reuses the same zoomScale-gating pattern already established for the impact halo.

Not yet visually verified in-browser -- typecheck only so far.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
