### PR TITLE
docs: document status field + set-status mode in TOOLING.md

### DIFF
--- a/TOOLING.md
+++ b/TOOLING.md
@@ -70,6 +70,43 @@ Script ini otomatis:
 hook (lihat bagian 4) yang bakal nolak commit kalau ada entry baru tanpa
 tanggal di header-nya. Script ini jamin format-nya selalu bener.
 
+### Nandain progress entry pakai status -- Not Started / In Progress / Done
+
+Tiap entry sekarang bisa punya status, biar collaborator lain gampang
+liat sekilas mana yang masih ide, mana yang lagi dikerjain, mana yang
+udah kelar -- tanpa perlu baca isi lengkap tiap entry.
+
+Nambah entry baru dengan status:
+
+```bash
+scripts/log-progress.sh <kategori> "judul" "isi" "Not Started"
+```
+
+Argumen status itu opsional -- kalau gak diisi, default-nya "Not
+Started". Status yang dipakai konsisten cuma 3: `Not Started`, `In
+Progress`, `Done`.
+
+Update status entry yang UDAH ADA (misal mulai ngerjain sesuatu, atau
+baru kelar), tanpa perlu bikin entry baru:
+
+```bash
+scripts/log-progress.sh set-status <kategori> "<judul entry>" "<status baru>"
+```
+
+Ini nyari entry berdasarkan potongan judulnya (harus unik), terus ganti
+baris `**Status:** ...`-nya di tempat -- isi entry yang lain gak
+kesentuh. Kalau entry itu belum punya baris status (entry lama sebelum
+fitur ini ada), baris status bakal otomatis ditambahin.
+
+Contoh alur kerja:
+```bash
+# Mulai ngerjain sesuatu
+scripts/log-progress.sh decisions "Refactor X" "Rencana refactor X karena Y" "In Progress"
+
+# ...beberapa jam kemudian, udah kelar...
+scripts/log-progress.sh set-status decisions "Refactor X" "Done"
+```
+
 ---
 
 ## 2. Git workflow — branch protection


### PR DESCRIPTION
Follow-up to the log-progress.sh status feature -- was missing from TOOLING.md, which would've left collaborators unaware the feature exists.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
