### PR TITLE
docs: add progres/README.md, short per-file explainer

### DIFF
--- a/progres/README.md
+++ b/progres/README.md
@@ -1,0 +1,25 @@
+# progres/
+
+Isinya histori dan status project ARCLUX, dipecah per kategori biar
+gampang dicari. Kalau males baca semua, ini penjelasan singkat tiap
+file:
+
+| File | Isinya |
+|---|---|
+| `PROGRES-status-core.md` | Status pipeline: parser, indexer, graph, impact, incremental |
+| `PROGRES-status-detectors.md` | Status 18 detector (circular deps, dead code, dll) |
+| `PROGRES-status-web.md` | Status apps/web: dashboard, graph viewer, komponen UI |
+| `PROGRES-status-infra.md` | Status CLI, tooling collaborator, testing, cleanup |
+| `PROGRES-status-backlog.md` | Kerjaan yang belum diambil siapa-siapa |
+| `PROGRES-bugs.md` | Bug yang ketemu di kode ARCLUX sendiri + cara fix-nya |
+| `PROGRES-decisions.md` | Keputusan desain: "kita pilih X daripada Y, karena..." |
+| `PROGRES-gotchas.md` | Jebakan tooling/environment (Termux, tsconfig, dll) -- bukan bug di kode ARCLUX |
+| `PROGRES-collaborators.md` | Siapa pegang tugas apa |
+
+Setiap entry di file-file ini sekarang bisa punya status
+(`Not Started` / `In Progress` / `Done`) -- cek `TOOLING.md` di root
+buat cara nambah/update entry pakai `scripts/log-progress.sh`.
+
+Buat gambaran lengkap kondisi project sebelum mulai kerja, baca
+`PROGRES.md` di root repo -- itu index-nya, sekaligus panduan nentuin
+update baru masuk file mana.


### PR DESCRIPTION
For anyone who doesn't want to open PROGRES.md's full index/decision-guide just to know what each progres/PROGRES-*.md file is for.

## What changed

<!-- Ringkas apa yang diubah dan kenapa -->

## How was this verified

<!-- tsc --noEmit doang TIDAK cukup untuk perubahan logic.
Jelaskan cara verifikasi nyata: dijalankan lawan playground/* fixture mana,
atau dev server + curl, dst. Lihat PROGRES.md untuk contoh pola verifikasi
yang dipakai di project ini. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (kalau nyentuh apps/web)
- [ ] Dites lawan minimal 1 fixture di `playground/` (kalau nyentuh parser/detector/pipeline)
- [ ] PROGRES.md diupdate kalau ini mengubah status file yang sebelumnya kosong/stub
- [ ] Tidak menduplikasi file/logic yang sudah ada (cek dulu dengan `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
