### PR TITLE
chore: assign issue #147 to mwakidenis, mark files in-file

### DIFF
--- a/apps/web/hooks/useClipboard.ts
+++ b/apps/web/hooks/useClipboard.ts
@@ -5,4 +5,8 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
+// ASSIGNED: issue #147 has mwakidenis implementing this hook. See the
+// issue for context/notes specific to this file before writing anything
+// here yourself -- if you're picking this up instead, check the issue
+// first to avoid duplicate/conflicting work.

--- a/apps/web/hooks/useCommandPalette.ts
+++ b/apps/web/hooks/useCommandPalette.ts
@@ -5,4 +5,8 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
+// ASSIGNED: issue #147 has mwakidenis implementing this hook. See the
+// issue for context/notes specific to this file before writing anything
+// here yourself -- if you're picking this up instead, check the issue
+// first to avoid duplicate/conflicting work.

--- a/apps/web/hooks/useMediaQuery.ts
+++ b/apps/web/hooks/useMediaQuery.ts
@@ -5,4 +5,8 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-
+//
+// ASSIGNED: issue #147 has mwakidenis implementing this hook. See the
+// issue for context/notes specific to this file before writing anything
+// here yourself -- if you're picking this up instead, check the issue
+// first to avoid duplicate/conflicting work.

--- a/progres/PROGRES-collaborators.md
+++ b/progres/PROGRES-collaborators.md
@@ -29,6 +29,13 @@
 - **Assigned**: date
 -->
 
+### mwakidenis — issue #147
+- **Task**: Implement 3 remaining apps/web/hooks stubs
+- **Files**: `apps/web/hooks/useClipboard.ts`, `useCommandPalette.ts`, `useMediaQuery.ts`
+- **Status**: not started
+- **Assigned**: 2026-08-07
+- **Note**: 4th active collaborator, first assignment. Also independently added CITATION.cff (unprompted, unassigned contribution) before this. Profile suggests frontend/React-heavy background, picked this task to match.
+
 ## Completed
 
 <!-- Move entries here once merged, keep the same format, add:


### PR DESCRIPTION
4th active collaborator (also independently contributed CITATION.cff before this). Assigned the 3 remaining apps/web/hooks stubs (useClipboard, useCommandPalette, useMediaQuery) -- picked to match their apparent frontend/React-heavy GitHub profile. Logged to PROGRES-collaborators.md and marked each file per the in-file marking rule from PROGRES-decisions.md.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
