### PR TITLE
feat: LOD step 2 -- gate label visibility on zoom level

### DIFF
--- a/apps/web/components/graph/GraphNode.tsx
+++ b/apps/web/components/graph/GraphNode.tsx
@@ -50,6 +50,16 @@ const MIN_ZOOM_FOR_HALO = 1;
 // the fuller plan this is step 1 of.
 const MIN_ZOOM_FOR_ICON = 0.5;
 
+// LOD step 2: below this zoom, labels never render even on hover/select
+// -- matches the icon threshold so a fully zoomed-out node is just a
+// plain dot with no text. Above MIN_ZOOM_FOR_ALWAYS_LABEL, high-importance
+// nodes (same threshold as the impact halo's medium tier) show their
+// label always, not just on hover/select, since at that zoom level
+// there's room and it helps scanning for important files without
+// clicking each node.
+const MIN_ZOOM_FOR_LABEL = 0.5;
+const MIN_ZOOM_FOR_ALWAYS_LABEL = 1.5;
+
 function getImpactHaloRadius(importCount: number): number | null {
   if (importCount > IMPACT_HIGH_THRESHOLD) return 14;
   if (importCount >= IMPACT_MEDIUM_THRESHOLD) return 9;
@@ -109,18 +119,24 @@ export function GraphNode({
           className="pointer-events-none"
         />
       )}
-      {(isSelected || isHovered) && (
-        <text
-          x={radius + 6}
-          y={4}
-          fontSize={11}
-          fontFamily="monospace"
-          fill="#EDEDED"
-          className="pointer-events-none select-none"
-        >
-          {node.label}
-        </text>
-      )}
+      {(() => {
+        if (zoomScale < MIN_ZOOM_FOR_LABEL) return null;
+        const alwaysShow =
+          zoomScale >= MIN_ZOOM_FOR_ALWAYS_LABEL && importCount >= IMPACT_MEDIUM_THRESHOLD;
+        if (!isSelected && !isHovered && !alwaysShow) return null;
+        return (
+          <text
+            x={radius + 6}
+            y={4}
+            fontSize={11}
+            fontFamily="monospace"
+            fill="#EDEDED"
+            className="pointer-events-none select-none"
+          >
+            {node.label}
+          </text>
+        );
+      })()}
     </g>
   );
 }


### PR DESCRIPTION
Labels now follow the same LOD tiers as icons:
- Below MIN_ZOOM_FOR_LABEL (0.5): never render, even on hover/select (matches icon gating so a fully zoomed-out node is just a plain dot)
- At/above MIN_ZOOM_FOR_ALWAYS_LABEL (1.5): high-importance nodes (importCount >= IMPACT_MEDIUM_THRESHOLD, same tier as the impact halo) show their label always, not just on hover/select -- helps scanning for important files at that zoom level without clicking each node
- Between those, unchanged: label only on hover/select

NOT YET visually verified in-browser -- typecheck only so far, per progres/PROGRES-decisions.md's LOD entry (2026-08-07). User will verify visually separately.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
