### PR TITLE
fix: remove fake 'Fix parser crash' entry from PROGRES-bugs.md

### DIFF
--- a/progres/PROGRES-bugs.md
+++ b/progres/PROGRES-bugs.md
@@ -233,7 +233,3 @@ package.json's typecheck script ran plain 'tsc --noEmit' from repo root, breakin
 ## 2026-08-07 — Dead theme/globals.css, stale PROGRES.md.bak, duplicate lockfile
 
 Found and removed 3 leftover files during a routine check: apps/web/theme/globals.css (0 bytes, never imported anywhere -- app/globals.css at a different path is the one actually wired into layout.tsx), PROGRES.md.bak (outdated pre-split/pre-translate backup, superseded by progres/PROGRES-*.md), and package-lock.json (project uses pnpm per pnpm-workspace.yaml, having both lockfiles risks dependency drift -- added package-lock.json to .gitignore).
-
-## 2026-08-07 — Fix parser crash
-
-Parser crash kalau file kosong. Ditambah early return...


### PR DESCRIPTION
This entry was an example command accidentally executed for real in an earlier session (verified: no actual parser crash bug exists or was fixed). It was removed once already, but got re-added by commit b731d062 ('commit pending bugfix log entry') which mistook the leftover uncommitted change for real pending work. Removing again.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
