### PR TITLE
feat: implement repositoryCache.ts and graphCache.ts

### DIFF
--- a/packages/cache/graphCache.ts
+++ b/packages/cache/graphCache.ts
@@ -6,3 +6,65 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Caches a built DependencyGraph (packages/graph/buildDependencyGraph.ts),
+// keyed the same way as repositoryCache.ts: repoUrl + branch + a
+// repo-level content fingerprint (see repositoryCache.ts's
+// computeRepositoryFingerprint for how that's derived).
+//
+// DependencyGraph is derived entirely from a Repository
+// (buildDependencyGraph(repository) -> DependencyGraph, see
+// packages/engine/pipeline.ts), so it becomes stale under exactly the
+// same condition a cached Repository would -- reusing the same
+// fingerprint here means both caches invalidate together, rather than
+// maintaining two separate (and potentially inconsistent) notions of
+// "has this repo changed".
+//
+// In-memory only, same as fileCache.ts/repositoryCache.ts.
+
+import type { DependencyGraph } from "../shared/types";
+
+interface GraphCacheEntry {
+  fingerprint: string;
+  graph: DependencyGraph;
+}
+
+// Keyed by "repoUrl@branch", same convention as repositoryCache.ts.
+const cache = new Map<string, GraphCacheEntry>();
+
+function cacheKey(repoUrl: string, branch: string): string {
+  return `${repoUrl}@${branch}`;
+}
+
+/**
+ * Returns the cached DependencyGraph IF the given fingerprint matches
+ * what it was cached with (use repositoryCache.ts's
+ * computeRepositoryFingerprint to compute it -- both caches should be
+ * fed the same fingerprint for a given repo state). Returns undefined
+ * on a cache miss.
+ */
+export function getCachedGraph(repoUrl: string, branch: string, fingerprint: string): DependencyGraph | undefined {
+  const entry = cache.get(cacheKey(repoUrl, branch));
+  if (!entry) return undefined;
+  if (entry.fingerprint !== fingerprint) return undefined;
+  return entry.graph;
+}
+
+/** Stores a DependencyGraph in the cache, keyed by repoUrl + branch + fingerprint. */
+export function setCachedGraph(repoUrl: string, branch: string, fingerprint: string, graph: DependencyGraph): void {
+  cache.set(cacheKey(repoUrl, branch), { fingerprint, graph });
+}
+
+/** Removes a single repoUrl+branch entry from the cache. */
+export function invalidateCachedGraph(repoUrl: string, branch: string): void {
+  cache.delete(cacheKey(repoUrl, branch));
+}
+
+/** Clears the entire cache. See fileCache.ts's clearFileCache() for why this matters in a long-running process. */
+export function clearGraphCache(): void {
+  cache.clear();
+}
+
+/** Current number of cached entries. Useful for tests/debugging. */
+export function graphCacheSize(): number {
+  return cache.size;
+}

--- a/packages/cache/repositoryCache.ts
+++ b/packages/cache/repositoryCache.ts
@@ -6,3 +6,82 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+// Caches a full indexed Repository (packages/repository/Repository.ts),
+// keyed by repoUrl + branch + a repo-level content fingerprint. See
+// progres/decisions.md's cache research entries (2026-08-07/08) for why
+// this is content-hash based rather than git-diff based.
+//
+// The fingerprint is a hash of every file's FileInfo.hash concatenated
+// (in a stable, sorted order) -- if even one file's content changes,
+// the fingerprint changes, and the cache entry is correctly treated as
+// stale. This is cheaper to compute than hashing full file contents at
+// lookup time, since FileInfo.hash is already computed once during
+// scanFiles.ts and carried on each module.
+//
+// In-memory only, same as fileCache.ts -- see that file's header
+// comment for why disk persistence isn't in scope yet.
+
+import { hashObject } from "../shared/hash";
+import type { Repository } from "../repository/Repository";
+import type { FileInfo } from "../shared/types";
+
+interface RepositoryCacheEntry {
+  fingerprint: string;
+  repository: Repository;
+}
+
+// Keyed by "repoUrl@branch" (branch defaults to whatever the caller
+// resolved it to -- this module doesn't know or care about "default
+// branch" semantics, that's cloneRepository.ts's job).
+const cache = new Map<string, RepositoryCacheEntry>();
+
+/**
+ * Computes a repo-level fingerprint from a set of files' hashes.
+ * Sorted by relativePath first so the same file set in a different
+ * scan order still produces the same fingerprint -- order shouldn't
+ * matter, only content.
+ */
+export function computeRepositoryFingerprint(files: Pick<FileInfo, "relativePath" | "hash">[]): string {
+  const sorted = [...files].sort((a, b) => a.relativePath.localeCompare(b.relativePath));
+  return hashObject(sorted.map((f) => `${f.relativePath}:${f.hash}`));
+}
+
+function cacheKey(repoUrl: string, branch: string): string {
+  return `${repoUrl}@${branch}`;
+}
+
+/**
+ * Returns the cached Repository IF the given fingerprint matches what
+ * it was cached with. Returns undefined on a cache miss.
+ */
+export function getCachedRepository(repoUrl: string, branch: string, fingerprint: string): Repository | undefined {
+  const entry = cache.get(cacheKey(repoUrl, branch));
+  if (!entry) return undefined;
+  if (entry.fingerprint !== fingerprint) return undefined;
+  return entry.repository;
+}
+
+/** Stores a Repository in the cache, keyed by repoUrl + branch + fingerprint. */
+export function setCachedRepository(
+  repoUrl: string,
+  branch: string,
+  fingerprint: string,
+  repository: Repository,
+): void {
+  cache.set(cacheKey(repoUrl, branch), { fingerprint, repository });
+}
+
+/** Removes a single repoUrl+branch entry from the cache. */
+export function invalidateCachedRepository(repoUrl: string, branch: string): void {
+  cache.delete(cacheKey(repoUrl, branch));
+}
+
+/** Clears the entire cache. See fileCache.ts's clearFileCache() for why this matters in a long-running process. */
+export function clearRepositoryCache(): void {
+  cache.clear();
+}
+
+/** Current number of cached entries. Useful for tests/debugging. */
+export function repositoryCacheSize(): number {
+  return cache.size;
+}


### PR DESCRIPTION
Both keyed by repoUrl + branch + a repo-level content fingerprint (computeRepositoryFingerprint in repositoryCache.ts, derived from sorted FileInfo.hash values -- already computed once during scanFiles.ts, no extra hashing work needed). DependencyGraph is derived entirely from Repository (buildDependencyGraph(repository) in pipeline.ts), so graphCache.ts intentionally reuses the same fingerprint scheme as repositoryCache.ts rather than computing its own -- keeps both caches invalidating together instead of maintaining two separate notions of 'has this repo changed'.

In-memory only, same as fileCache.ts. Not yet wired into engine/pipeline.ts -- these are the cache modules themselves, wiring is a separate step. 2 of 5 packages/cache files left: CacheProvider.ts (orchestrator) and memoryCache.ts (still unclear if it's a separate generic layer or redundant with what these three already do -- needs more thought before writing).

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [x] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [x] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
