### PR TITLE
fix: wire implicitDependencies into buildDependencyGraph.ts

### DIFF
--- a/packages/graph/buildDependencyGraph.ts
+++ b/packages/graph/buildDependencyGraph.ts
@@ -63,6 +63,27 @@ export function buildDependencyGraph(repository: Repository): DependencyGraph {
         type: "import",
       });
     }
+
+    // Same-package/same-scope implicit dependencies (Go, Java -- see
+    // parseGo.ts/parseJava.ts's scopeId, resolveSameScopeDependencies.ts).
+    // These never appear in module.imports since there's no import
+    // statement for them at all, so they need their own pass here or
+    // the graph renders these files as disconnected islands even
+    // though they genuinely depend on each other. Fixes the bug where
+    // e.g. a Java repo like spring-boot shows all its file nodes with
+    // zero edges between them.
+    for (const implicitId of module.implicitDependencies) {
+      if (!moduleIds.has(implicitId)) continue;
+      if (seenTargets.has(implicitId)) continue; // already covered by an explicit import
+      seenTargets.add(implicitId);
+
+      edges.push({
+        id: `${module.id}->${implicitId}`,
+        source: module.id,
+        target: implicitId,
+        type: "import",
+      });
+    }
   }
 
   // Note: external package nodes are added by resolveExports.ts / a future pass,


### PR DESCRIPTION
buildDependencyGraph.ts only ever read module.imports (explicit import statements) when building edges. module.implicitDependencies (set by resolveSameScopeDependencies.ts for Go/Java files sharing a package/directory scope with zero import statements between them) was computed but never consumed -- this was a known gap noted in decisions.md ('data exists, graph rendering doesn't consume it yet').

This is why analyzing a Java-heavy repo like spring-boot showed all file nodes with zero edges between them: Java files in the same package reference each other constantly without import statements, and none of those relationships were becoming graph edges.

Added a second pass alongside the existing imports loop, same dedup/filtering logic, reading implicitDependencies instead.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
