### PR TITLE
fix: remove turbo from scripts, call apps/web directly via pnpm --filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "license": "Apache-2.0",
   "packageManager": "pnpm@9.15.0",
   "scripts": {
-    "dev": "turbo run dev",
-    "build": "turbo run build",
-    "lint": "turbo run lint",
+    "dev": "pnpm --filter web dev",
+    "build": "pnpm --filter web build",
+    "lint": "pnpm --filter web lint",
     "test": "vitest run",
     "typecheck": "tsc --noEmit -p apps/web/tsconfig.json"
   },


### PR DESCRIPTION
turbo.json was removed in an earlier session (dead config, turbo never actually used), but package.json's dev/build/lint scripts still called 'turbo run ...', causing 'Could not find turbo.json' failures. Switched to pnpm --filter web, which the pnpm-workspace.yaml setup already supports directly -- no need for turbo at all given this repo's simple apps/* workspace structure.

This unblocks CI's lint step from crashing outright, but reveals 10 pre-existing real lint errors that were previously masked (CI always failed before reaching this step). Those are a separate bug, not fixed here.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
