### PR TITLE
feat: implement parseRequirements.ts for Python requirements.txt

### DIFF
--- a/packages/parser/python/parseRequirements.ts
+++ b/packages/parser/python/parseRequirements.ts
@@ -6,3 +6,62 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { ManifestParser, ManifestDependency } from "../core/ManifestParserInterface";
+
+// requirements.txt is line-based, not a structured format -- one
+// dependency per line, in the form "name", "name==1.2.3", "name>=1.2.3",
+// "name~=1.2.3", "name!=1.2.3", or combinations ("name>=1.0,<2.0"). This
+// keeps only the name and the FIRST version specifier (good enough for
+// dependency-listing purposes, not for resolving the exact allowed range).
+//
+// Skipped, not treated as dependencies: blank lines, comments (# ...),
+// option flags (--index-url, --extra-index-url, -r other.txt, -e ./local,
+// etc.), and environment markers after a semicolon (e.g.
+// "name==1.0; python_version < '3.8'" -- the marker itself is dropped,
+// only "name==1.0" is kept).
+
+function stripLineComment(line: string): string {
+  const idx = line.indexOf("#");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+function stripEnvironmentMarker(line: string): string {
+  const idx = line.indexOf(";");
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+// Matches: name, then optionally one version specifier (==, >=, <=, ~=, !=, >, <)
+// followed by a version string. Package names can contain letters, digits,
+// ., -, _, and an optional [extra] suffix (e.g. "requests[socks]").
+const REQUIREMENT_PATTERN = /^([A-Za-z0-9._-]+(?:\[[^\]]+\])?)\s*(==|>=|<=|~=|!=|>|<)?\s*([A-Za-z0-9._*+!-]+)?/;
+
+export const parseRequirements: ManifestParser = {
+  filename: "requirements.txt",
+
+  parse(content: string): ManifestDependency[] {
+    const dependencies: ManifestDependency[] = [];
+
+    for (const rawLine of content.split("\n")) {
+      let line = stripLineComment(rawLine);
+      line = stripEnvironmentMarker(line);
+      line = line.trim();
+
+      if (!line) continue;
+      if (line.startsWith("-")) continue; // option flags: -r, -e, --index-url, etc.
+
+      const match = line.match(REQUIREMENT_PATTERN);
+      if (!match) continue;
+
+      const [, name, operator, version] = match;
+      if (!name) continue;
+
+      dependencies.push({
+        name,
+        versionRange: operator && version ? `${operator}${version}` : undefined,
+        kind: "runtime",
+      });
+    }
+
+    return dependencies;
+  },
+};

--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -263,3 +263,9 @@ Fixed in stages: (1) ci.yml used npm install despite project being pnpm-workspac
 **Status:** Not Started
 
 Now that CI's lint step actually runs (previously crashed before reaching it), real pre-existing issues are visible: prefer-const violations and missing useEffect deps in vendor-ui/aceternity/*.tsx, unused vars in app/api/analyze/route.ts, and two setState-called-synchronously-in-effect errors in AnalyzingProgress.tsx and GlobalSearch.tsx (react-hooks/set-state-in-effect). Not fixed yet -- next session should start here to get CI fully green.
+
+## 2026-08-08 — Manifest parsers never wired to a registry (affects ALL of them, not just new ones)
+
+**Status:** Not Started
+
+Confirmed: parseGemfile.ts, parseCargoToml.ts, parseGoMod.ts, parseComposer.ts, parsePackageJson.ts, parseCsproj.ts, parseGradlePom.ts, and now parseRequirements.ts all implement ManifestParser correctly but NONE are referenced anywhere outside their own file -- no ManifestRegistry equivalent to ParserRegistry (for LanguageParser) exists. Dependency-manifest parsing is effectively 100% dead code right now, despite several manifest parsers being 'done'. Needs a ManifestRegistry (or similar wiring into detectRepositoryMeta.ts, per ManifestParserInterface.ts's own doc comment mentioning that file) before any of this has real effect.


### PR DESCRIPTION
Line-based parser following parseGemfile.ts's pattern (regex per line, not a real format parser). Handles name, one version specifier (==/>=/<=/~=/!=/>/<), comments, environment markers, and option flags (-r, -e, --index-url etc, all skipped).

Also logged a bigger finding while checking how this gets wired in: ALL manifest parsers (this one and the existing 7) are never referenced by any registry/detection code -- dependency-manifest parsing is dead code project-wide right now. Separate bug logged in bugs.md, not fixed here.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
