### PR TITLE
fix: wire ManifestRegistry into pipeline.ts, fixing dead manifest par…

### DIFF
--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -19,6 +19,15 @@ import { parseJsx } from "../parser/javascript/parseJsx";
 import { parseCommonJs } from "../parser/javascript/parseCommonJs";
 import { parseGo } from "../parser/go/parseGo";
 import { parseJava } from "../parser/java/parseJava";
+import { manifestRegistry } from "../parser/core/ManifestRegistry";
+import { parsePackageJson } from "../parser/config/parsePackageJson";
+import { parseGoMod } from "../parser/go/parseGoMod";
+import { parseCargoToml } from "../parser/rust/parseCargoToml";
+import { parseGemfile } from "../parser/ruby/parseGemfile";
+import { parseComposer } from "../parser/php/parseComposer";
+import { parseCsproj } from "../parser/csharp/parseCsproj";
+import { parseGradle_, parsePom } from "../parser/java/parseGradlePom";
+import { parseRequirements } from "../parser/python/parseRequirements";
 import { detectFrameworks, detectPackageManager } from "./detectRepositoryMeta";
 import { ArcluxError, isArcluxError } from "../shared/errors";
 import type { DependencyGraph, RepositoryMeta } from "../shared/types";
@@ -36,6 +45,17 @@ function ensureParsersRegistered() {
   parserRegistry.register(parseCommonJs);
   parserRegistry.register(parseGo);
   parserRegistry.register(parseJava);
+
+  manifestRegistry.register(parsePackageJson);
+  manifestRegistry.register(parseGoMod);
+  manifestRegistry.register(parseCargoToml);
+  manifestRegistry.register(parseGemfile);
+  manifestRegistry.register(parseComposer);
+  manifestRegistry.register(parseCsproj);
+  manifestRegistry.register(parseGradle_);
+  manifestRegistry.register(parsePom);
+  manifestRegistry.register(parseRequirements);
+
   parsersRegistered = true;
 }
 
@@ -58,6 +78,8 @@ export interface AnalyzeRepositoryResult {
    * calculateAffectedFiles usage in api/impact/route.ts for the pattern).
    */
   repository: Repository;
+  /** Combined dependency list from every manifest file present in the repo (package.json, go.mod, etc). See ManifestRegistry.ts. */
+  dependencies: import("../parser/core/ManifestParserInterface").ManifestDependency[];
 }
 
 /** Parses "org/name" out of a git URL, for https, ssh, and shorthand forms */
@@ -129,6 +151,7 @@ export async function analyzeRepository(
       moduleCount: repository.moduleCount,
       graph,
       repository,
+      dependencies: manifestRegistry.detectDependencies(localPath),
     };
   } finally {
     // Always clean up the temp clone, even if analysis threw partway through.

--- a/packages/parser/core/ManifestRegistry.ts
+++ b/packages/parser/core/ManifestRegistry.ts
@@ -1,0 +1,71 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ManifestParser, ManifestDependency } from "./ManifestParserInterface";
+
+/**
+ * Central place where all manifest parsers register themselves, mirroring
+ * ParserRegistry's role for LanguageParser. Consumers ask THIS which
+ * manifest files are present in a repo and get back every dependency
+ * across all of them, rather than importing individual parseX.ts files
+ * directly.
+ *
+ * Fixes a real gap: parsePackageJson.ts, parseGoMod.ts, parseCargoToml.ts,
+ * parseGemfile.ts, parseComposer.ts, parseCsproj.ts, parseGradlePom.ts,
+ * and parseRequirements.ts all existed and worked correctly, but NONE
+ * were ever referenced by any registry or detection code -- manifest
+ * dependency parsing was 100% dead code project-wide until this file.
+ */
+export class ManifestRegistry {
+  private parsersByFilename: Map<string, ManifestParser> = new Map();
+
+  register(parser: ManifestParser): void {
+    this.parsersByFilename.set(parser.filename, parser);
+  }
+
+  getParserForFilename(filename: string): ManifestParser | undefined {
+    return this.parsersByFilename.get(filename);
+  }
+
+  get registeredFilenames(): string[] {
+    return Array.from(this.parsersByFilename.keys());
+  }
+
+  /**
+   * Scans rootPath for every registered manifest filename that's actually
+   * present, parses each one found, and returns the combined dependency
+   * list. A repo can legitimately have more than one manifest present
+   * (e.g. a JS frontend + a Python backend in the same repo) -- all
+   * matching manifests are parsed, not just the first one found.
+   */
+  detectDependencies(rootPath: string): ManifestDependency[] {
+    const allDependencies: ManifestDependency[] = [];
+
+    for (const [filename, parser] of this.parsersByFilename) {
+      const filePath = join(rootPath, filename);
+      if (!existsSync(filePath)) continue;
+
+      try {
+        const content = readFileSync(filePath, "utf-8");
+        allDependencies.push(...parser.parse(content));
+      } catch {
+        // A single unreadable/malformed manifest shouldn't fail the whole
+        // scan -- same "never throw" contract ManifestParser.parse itself
+        // follows, applied here too in case readFileSync itself fails.
+        continue;
+      }
+    }
+
+    return allDependencies;
+  }
+}
+
+/** Shared singleton registry — import THIS everywhere, don't `new ManifestRegistry()` elsewhere */
+export const manifestRegistry = new ManifestRegistry();


### PR DESCRIPTION
…sing

Registers all 8 manifest parsers (packageJson, goMod, cargoToml, gemfile, composer, csproj, gradle, pom, requirements) and calls detectDependencies() in analyzeRepository(), exposed as a new 'dependencies' field on AnalyzeRepositoryResult. Closes the bug logged earlier this session: manifest dependency parsing was implemented but never wired to anything, 100% dead code across all 8 parsers.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
