### PR TITLE
Log status: ManifestRegistry wired, parseRequirements done, cache sti…

### DIFF
--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -420,3 +420,21 @@ elsewhere in this doc (typecheck alone isn't sufficient evidence).
 - `detectUnusedExports.ts`/`detectOrphanFiles.ts` not updated to consult
   `getEntryModuleIds()` yet, so the entry-file false-positive caveat
   still applies
+
+## 2026-08-08 — ManifestRegistry wired into pipeline.ts
+
+**Status:** Done
+
+8 manifest parsers (packageJson, goMod, cargoToml, gemfile, composer, csproj, gradle, pom, requirements) now registered and consumed via manifestRegistry.detectDependencies() in analyzeRepository(). New 'dependencies' field on AnalyzeRepositoryResult. Fixes bug logged earlier today: manifest parsing was implemented but 100% dead code, never called by anything.
+
+## 2026-08-08 — parseRequirements.ts implemented
+
+**Status:** Done
+
+Python requirements.txt manifest parser added, following parseGemfile.ts's line-based regex pattern. Handles name, one version specifier, comments, environment markers, option flags.
+
+## 2026-08-08 — packages/cache: fileCache, repositoryCache, graphCache built but NOT wired
+
+**Status:** In Progress
+
+3 of 5 cache files implemented (fileCache.ts content-hash based per-file, repositoryCache.ts + graphCache.ts sharing a repo-level fingerprint). None are called from engine/pipeline.ts yet -- still standalone, unlike the manifest registry which is now wired in. Next session: wire these into buildIndex.ts (fileCache) and pipeline.ts (repositoryCache/graphCache), or decide this isn't worth doing yet.


### PR DESCRIPTION
…ll unwired

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
