### PR TITLE
feat: wire fileCache, repositoryCache, graphCache into the pipeline

### DIFF
--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -20,6 +20,9 @@ import { parseCommonJs } from "../parser/javascript/parseCommonJs";
 import { parseGo } from "../parser/go/parseGo";
 import { parseJava } from "../parser/java/parseJava";
 import { manifestRegistry } from "../parser/core/ManifestRegistry";
+import { scanFiles } from "../parser/core/scanFiles";
+import { computeRepositoryFingerprint, getCachedRepository, setCachedRepository } from "../cache/repositoryCache";
+import { getCachedGraph, setCachedGraph } from "../cache/graphCache";
 import { parsePackageJson } from "../parser/config/parsePackageJson";
 import { parseGoMod } from "../parser/go/parseGoMod";
 import { parseCargoToml } from "../parser/rust/parseCargoToml";
@@ -126,24 +129,45 @@ export async function analyzeRepository(
       analyzedAt: new Date().toISOString(),
     };
 
-    let repository: Repository;
-    try {
-      repository = await buildIndex({ rootPath: localPath, meta });
-    } catch (err) {
-      throw isArcluxError(err)
-        ? err
-        : new ArcluxError({ code: "INDEX_FAILED", message: "Indexing failed", cause: err });
-    }
+    // Cheap up-front scan (hashing only, not parsing) to compute a
+    // fingerprint of the repo's current content. If it matches what we
+    // cached last time for this repoUrl+branch, skip the expensive
+    // buildIndex/buildDependencyGraph work entirely. See
+    // progres/decisions.md's cache research entries for why this is
+    // content-hash based rather than git-diff based.
+    const scannedFiles = scanFiles(localPath);
+    const fingerprint = computeRepositoryFingerprint(scannedFiles);
 
+    let repository: Repository;
     let graph: DependencyGraph;
-    try {
-      graph = buildDependencyGraph(repository);
-    } catch (err) {
-      throw new ArcluxError({
-        code: "GRAPH_BUILD_FAILED",
-        message: "Graph construction failed",
-        cause: err,
-      });
+
+    const cachedRepository = getCachedRepository(options.repoUrl, meta.defaultBranch, fingerprint);
+    const cachedGraph = getCachedGraph(options.repoUrl, meta.defaultBranch, fingerprint);
+
+    if (cachedRepository && cachedGraph) {
+      repository = cachedRepository;
+      graph = cachedGraph;
+    } else {
+      try {
+        repository = await buildIndex({ rootPath: localPath, meta });
+      } catch (err) {
+        throw isArcluxError(err)
+          ? err
+          : new ArcluxError({ code: "INDEX_FAILED", message: "Indexing failed", cause: err });
+      }
+
+      try {
+        graph = buildDependencyGraph(repository);
+      } catch (err) {
+        throw new ArcluxError({
+          code: "GRAPH_BUILD_FAILED",
+          message: "Graph construction failed",
+          cause: err,
+        });
+      }
+
+      setCachedRepository(options.repoUrl, meta.defaultBranch, fingerprint, repository);
+      setCachedGraph(options.repoUrl, meta.defaultBranch, fingerprint, graph);
     }
 
     return {

--- a/packages/indexer/buildIndex.ts
+++ b/packages/indexer/buildIndex.ts
@@ -13,6 +13,7 @@ import { loadAliasConfig } from "./resolveAliases";
 import { resolveSameScopeDependencies, type ScopedFile } from "./resolveSameScopeDependencies";
 import { Repository } from "../repository/Repository";
 import { readFileSync } from "node:fs";
+import { getCachedParsedFile, setCachedParsedFile } from "../cache/fileCache";
 import { ArcluxError } from "../shared/errors";
 import type { RepositoryMeta, ModuleInfo, ParsedFile, ResolvedImport } from "../shared/types";
 
@@ -63,7 +64,10 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
       });
     }
 
-    const parsed = await parser.parse(file, content);
+    const cached = getCachedParsedFile(file.relativePath, content);
+    const parsed = cached ?? (await parser.parse(file, content));
+    if (!cached) setCachedParsedFile(file.relativePath, content, parsed);
+
     parsedByPath.set(file.relativePath, parsed);
     contentByPath.set(file.relativePath, content);
   }


### PR DESCRIPTION
buildIndex.ts: checks fileCache before calling parser.parse(), stores result after a successful parse. Skips re-parsing unchanged files within the same process lifetime.

pipeline.ts: computes a repo-level fingerprint via a cheap scanFiles() pass (hashing only, before the expensive buildIndex/ buildDependencyGraph work). If repositoryCache + graphCache both hit for this repoUrl+branch+fingerprint, skips straight to returning cached results. On a miss, builds normally and populates both caches for next time.

All three cache modules were built earlier but never called from anywhere -- this closes that gap. In-memory only, so this helps repeat analysis within the same server process lifetime (e.g. re-analyzing the same repo/branch, dashboard refresh), not across restarts -- see progres/decisions.md's cache research entries for why disk persistence isn't in scope yet.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
