### PR TITLE
chore: remove inactive collaborators from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default reviewers for all files
-* @Alitindrawan24 @xcontcom @svSeniorEngineer @mwakidenis
+* @mwakidenis

--- a/progres/collaborators.md
+++ b/progres/collaborators.md
@@ -43,6 +43,15 @@
 - **Assigned**: 2026-08-08
 - **Note**: 5th active collaborator. Came in via a detailed GitHub comment (not a cold invite) — starred the repo, asked sharp questions about incremental re-analysis, and suggested this exact detector idea based on real experience building mscodebase-intelligence (a mature MCP codebase-intelligence server for Zed, 1032 tests, 13.9k+ lines in src/core/ alone). Deliberately NOT added to CODEOWNERS yet -- want to see this first PR before granting default-reviewer access, even though the background looks strong.
 
+## Removed from CODEOWNERS (not from assignments)
+
+Alitindrawan24, xcontcom, and svSeniorEngineer removed as default PR
+reviewers on 2026-08-09 after 3-5 days with zero commits/PRs against
+their assigned issues (#53, #3, #50, #2). They keep their issue
+assignments -- this only removes their default-reviewer status so PRs
+don't sit waiting on review from inactive accounts. Re-add to
+CODEOWNERS if/when they become active again.
+
 ## Completed
 
 <!-- Move entries here once merged, keep the same format, add:


### PR DESCRIPTION
Alitindrawan24, xcontcom, svSeniorEngineer removed as default PR reviewers -- 3-5 days since issue assignment (#53, #3, #50, #2) with zero commits or PRs. They keep their issue assignments, this only stops PRs from waiting on review from inactive accounts.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
