### PR TITLE
feat: add detectAmbiguousSymbolResolution detector

### DIFF
--- a/packages/detectors/detectAmbiguousSymbolResolution.ts
+++ b/packages/detectors/detectAmbiguousSymbolResolution.ts
@@ -1,0 +1,234 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Logic contributed by ManSio (github.com/ManSio/mscodebase-intelligence).
+// The categorisation + severity model is adapted from a runtime ranking fix
+// for the D1 "wrong-source resolution" bug in that project: a symbol lookup
+// that silently resolved to experiments/run_experiment_pagerank.py instead
+// of src/symbol_index.py, producing wrong_rate = 1.0. The runtime fix
+// (pick best candidate by path category at query time) translates here into
+// a static detector: surface the collision to the developer upfront, before
+// any tooling silently picks the wrong one.
+
+import type { Repository } from "../repository/Repository";
+
+// ─────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────
+
+export type SymbolCategory =
+  | "source"    // src/, lib/, core/, app/ — real production code
+  | "test"      // test/, __tests__/, *.test.ts, *.spec.ts
+  | "example"   // examples/, demo/
+  | "fixture"   // fixtures/, __fixtures__/
+  | "mock"      // mocks/, __mocks__/
+  | "script"    // scripts/, tools/
+  | "other";    // anything else
+
+export interface AmbiguousDefinition {
+  moduleId: string;
+  modulePath: string;
+  line: number;
+  category: SymbolCategory;
+}
+
+/**
+ * Severity reflects how likely the collision is to produce a silently-wrong
+ * answer in tooling that resolves symbols without category-awareness:
+ *
+ * high   — a real source definition has at least one shadow in a non-source
+ *          location (test, example, fixture, mock, script). This is the
+ *          exact D1 failure mode: tooling picks the wrong one confidently.
+ *
+ * medium — two or more definitions that are both in source paths. Less
+ *          likely to be accidental, but worth flagging (e.g. copy-paste
+ *          across packages, or a rename that left the old definition in
+ *          place).
+ *
+ * low    — multiple definitions, none in a clear source path. Least
+ *          urgent: a test helper duplicated in two fixture folders, etc.
+ */
+export type AmbiguousSeverity = "high" | "medium" | "low";
+
+export interface AmbiguousSymbolFinding {
+  symbolName: string;
+  severity: AmbiguousSeverity;
+  reason: string;
+  definitions: AmbiguousDefinition[];
+}
+
+// ─────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────
+
+/**
+ * Assign a category to a module based on its relative path.
+ *
+ * Checks are ordered from most-specific to least-specific so that a path
+ * like "src/__tests__/foo.test.ts" is classified as "test" (it matches the
+ * test patterns first) rather than "source". This matters for severity
+ * calculations: a test file that shadows a real source export is the classic
+ * D1 case and should be flagged "high", not silently treated as a second
+ * source definition.
+ */
+function categorize(relativePath: string): SymbolCategory {
+  const p = relativePath.replace(/\\/g, "/"); // normalise Windows paths
+
+  // Test files — check both directory names AND file suffixes
+  if (
+    p.includes("/test/") ||
+    p.includes("/tests/") ||
+    p.includes("/__tests__/") ||
+    p.endsWith(".test.ts") ||
+    p.endsWith(".test.tsx") ||
+    p.endsWith(".test.js") ||
+    p.endsWith(".spec.ts") ||
+    p.endsWith(".spec.tsx") ||
+    p.endsWith(".spec.js")
+  )
+    return "test";
+
+  // Fixtures
+  if (p.includes("/fixtures/") || p.includes("/__fixtures__/"))
+    return "fixture";
+
+  // Mocks
+  if (p.includes("/mocks/") || p.includes("/__mocks__/"))
+    return "mock";
+
+  // Examples / demos
+  if (
+    p.includes("/examples/") ||
+    p.includes("/example/") ||
+    p.includes("/demo/")
+  )
+    return "example";
+
+  // Scripts / tooling
+  if (p.includes("/scripts/") || p.includes("/tools/"))
+    return "script";
+
+  // Real source — checked last so the test/fixture/mock overrides above win
+  if (
+    p.includes("/src/") ||
+    p.startsWith("src/") ||
+    p.includes("/lib/") ||
+    p.startsWith("lib/") ||
+    p.includes("/core/") ||
+    p.includes("/app/") ||
+    p.includes("/apps/")
+  )
+    return "source";
+
+  return "other";
+}
+
+// ─────────────────────────────────────────────
+// Main detector
+// ─────────────────────────────────────────────
+
+/**
+ * Finds exported symbol names that appear in more than one module, i.e.
+ * cases where tooling resolving "give me the definition of X" has to pick
+ * one without any principled criterion — and may pick the wrong one silently.
+ *
+ * Scope of what this detects (and doesn't):
+ * ✓  Same exported name, multiple modules — static, export-level only
+ * ✗  Same name in nested JS/TS scopes within one file (that's ESLint no-shadow)
+ * ✗  Same name reached through re-export chains that collapse to the same
+ *    origin (resolvedReExports could disambiguate this, but re-export chains
+ *    that bottom out at the same file aren't a collision — skipped)
+ * ✗  Default exports: every module can have one "default", so the name
+ *    "default" is inherently multi-defined. Skipped unless the caller opts in.
+ *
+ * Re-exports (exp.kind === "re-export") are skipped — they don't define
+ * a new symbol, they forward one from elsewhere. Counting them would produce
+ * false positives on barrel files (index.ts that re-exports everything).
+ */
+export function detectAmbiguousSymbolResolution(
+  repository: Repository,
+  { includeDefaultExports = false }: { includeDefaultExports?: boolean } = {}
+): AmbiguousSymbolFinding[] {
+  // symbolName -> list of (moduleId, relativePath, line, category)
+  const byName = new Map<string, AmbiguousDefinition[]>();
+
+  for (const module of repository.getAllModules()) {
+    const category = categorize(module.file.relativePath);
+
+    for (const exp of module.exports) {
+      // Re-exports are forwarding, not defining — skip them
+      if (exp.kind === "re-export") continue;
+
+      // Default exports are universally multi-defined; skip unless opted in
+      if (exp.kind === "default" && !includeDefaultExports) continue;
+
+      const definition: AmbiguousDefinition = {
+        moduleId: module.id,
+        modulePath: module.file.relativePath,
+        line: exp.line,
+        category,
+      };
+
+      const existing = byName.get(exp.name) ?? [];
+      existing.push(definition);
+      byName.set(exp.name, existing);
+    }
+  }
+
+  const findings: AmbiguousSymbolFinding[] = [];
+
+  for (const [symbolName, definitions] of byName) {
+    if (definitions.length < 2) continue;
+
+    const sourceDefs = definitions.filter((d) => d.category === "source");
+    const nonSourceDefs = definitions.filter((d) => d.category !== "source");
+
+    if (sourceDefs.length > 0 && nonSourceDefs.length > 0) {
+      // High: real source definition shadowed by test/example/fixture/mock/script
+      const shadowCategories = [
+        ...new Set(nonSourceDefs.map((d) => d.category)),
+      ].join(", ");
+
+      findings.push({
+        symbolName,
+        severity: "high",
+        reason: `Source definition shadowed by ${nonSourceDefs.length} non-source definition(s) in: ${shadowCategories}`,
+        definitions,
+      });
+    } else if (sourceDefs.length >= 2) {
+      // Medium: multiple definitions all in source paths
+      findings.push({
+        symbolName,
+        severity: "medium",
+        reason: `${sourceDefs.length} source-path definitions (possible duplicate or unfinished rename)`,
+        definitions: sourceDefs,
+      });
+    } else if (definitions.length >= 2) {
+      // Low: multiple non-source definitions (test helper duplicated, etc.)
+      findings.push({
+        symbolName,
+        severity: "low",
+        reason: `${definitions.length} non-source definitions with the same name`,
+        definitions,
+      });
+    }
+  }
+
+  // Sort: high first, then medium, then low; ties alphabetical by symbol name
+  const order: Record<AmbiguousSeverity, number> = {
+    high: 0,
+    medium: 1,
+    low: 2,
+  };
+
+  return findings.sort(
+    (a, b) =>
+      order[a.severity] - order[b.severity] ||
+      a.symbolName.localeCompare(b.symbolName)
+  );
+}


### PR DESCRIPTION
Contributed by ManSio (github.com/ManSio) via issue #176. Detects exported symbol names that resolve to more than one module -- e.g. a real source file AND a test fixture or examples/ folder -- which can cause tooling to silently pick the wrong definition with no error.

Categorizes each definition's path (source/test/example/fixture/mock/ script/other) and assigns severity: high when a source definition is shadowed by a non-source one (the exact failure mode this was motivated by), medium for multiple source-path definitions, low otherwise. Skips re-exports (forwarding, not defining) and default exports (universally multi-defined) by design.

Full author's design notes and rationale preserved in the file's own comments, written by ManSio in issue #176's discussion.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
