### PR TITLE
chore: add ManSio to CODEOWNERS after strong first PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default reviewers for all files
-* @mwakidenis
+* @mwakidenis @ManSio

--- a/progres/collaborators.md
+++ b/progres/collaborators.md
@@ -41,7 +41,7 @@
 - **Files**: New file under `packages/detectors/` (exact name TBD by ManSio)
 - **Status**: not started
 - **Assigned**: 2026-08-08
-- **Note**: 5th active collaborator. Came in via a detailed GitHub comment (not a cold invite) — starred the repo, asked sharp questions about incremental re-analysis, and suggested this exact detector idea based on real experience building mscodebase-intelligence (a mature MCP codebase-intelligence server for Zed, 1032 tests, 13.9k+ lines in src/core/ alone). Deliberately NOT added to CODEOWNERS yet -- want to see this first PR before granting default-reviewer access, even though the background looks strong.
+- **Note**: 5th active collaborator. Came in via a detailed GitHub comment (not a cold invite) — starred the repo, asked sharp questions about incremental re-analysis, and suggested this exact detector idea based on real experience building mscodebase-intelligence (a mature MCP codebase-intelligence server for Zed, 1032 tests, 13.9k+ lines in src/core/ alone). Delivered a complete, well-reasoned first PR (detectAmbiguousSymbolResolution.ts) same-day, following existing repo patterns without being asked. Added to CODEOWNERS 2026-08-09 based on that first PR's quality.
 
 ## Removed from CODEOWNERS (not from assignments)
 


### PR DESCRIPTION
detectAmbiguousSymbolResolution.ts (issue #176) was well-reasoned, followed existing repo patterns, and included clear design rationale without being asked -- granting default-reviewer access based on that.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
