### PR TITLE
docs: link ARCHITECTURE_MAP.md from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ main
 - [`TOOLING.md`](TOOLING.md) — all repo config/tooling explained (PROGRES system, git workflow, pre-commit hook, CI, CODEOWNERS, etc.)
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions for contributing code
 - [`PROGRES.md`](PROGRES.md) (+ [`progres/`](progres/)) — up-to-date project status: what works, what's a stub, decisions, known bugs/gotchas
+- [`ARCHITECTURE_MAP.md`](ARCHITECTURE_MAP.md) — boundary map for the codebase, read before adding new capabilities
 
 ## Status: alpha
 


### PR DESCRIPTION
ARCHITECTURE_MAP.md existed at repo root but wasn't referenced anywhere in README.