### PR TITLE
fix: resolve tree-sitter-wasms .wasm path via package.json, not direc…

### DIFF
--- a/packages/parser/python/parsePython.ts
+++ b/packages/parser/python/parsePython.ts
@@ -7,6 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 import { createRequire } from "node:module";
+import path from "node:path";
 import type { LanguageParser } from "../core/ParserInterface";
 import type { FileInfo, ParsedFile, RawImport, RawExport } from "../../shared/types";
 
@@ -61,7 +62,14 @@ export function getPythonRuntime(): Promise<PythonRuntime> {
     runtimePromise = (async () => {
       await Parser.init();
       const parser = new Parser();
-      const wasmPath = nodeRequire.resolve("tree-sitter-wasms/out/tree-sitter-python.wasm");
+      // Resolve via package.json (not the .wasm file directly) -- resolving
+      // the .wasm path itself matches next.config.ts's `test: /\.wasm$/`
+      // webpack rule even with serverExternalPackages set, which rewrites
+      // the resolved value into a virtual "(rsc)/..." asset path instead
+      // of a real filesystem path, breaking Language.load() at runtime.
+      // package.json never matches that rule, so this sidesteps it.
+      const packageJsonPath = nodeRequire.resolve("tree-sitter-wasms/package.json");
+      const wasmPath = path.join(path.dirname(packageJsonPath), "out", "tree-sitter-python.wasm");
       const language = await Language.load(wasmPath);
       parser.setLanguage(language);
       return { parser, language };


### PR DESCRIPTION
…t .wasm resolve

Root cause of Python files parsing to zero imports/exports (silent failure, not an error): resolving the .wasm file path directly via nodeRequire.resolve('tree-sitter-wasms/out/tree-sitter-python.wasm') matches next.config.ts's `test: /\.wasm$/` webpack rule, which rewrites the resolved value into a virtual '(rsc)/...' asset path instead of a real filesystem path. Language.load() then fails at runtime, caught by parsePython.ts's try/catch, silently returning empty imports/exports for every Python file with no visible error.

Fixed by resolving tree-sitter-wasms/package.json instead (which never matches the .wasm webpack rule) and building the .wasm path relative to that package's directory on the filesystem.

Verified via a throwaway debug script against a real repo (ManSio/mscodebase-intelligence, 323 Python files): graph.edges.length went from 0 to 607, with 838 resolved imports across 199 modules. Confirms this was the actual root cause behind the exportCount:0 and zero-graph-edges bugs logged earlier -- not a separate resolvePath.ts issue, though that dotted-import fix (PR #192) was still correct and necessary for the edges to resolve once parsing actually succeeded.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
