### PR TITLE
perf: memoize GraphNode to avoid unnecessary re-renders

### DIFF
--- a/apps/web/components/graph/GraphNode.tsx
+++ b/apps/web/components/graph/GraphNode.tsx
@@ -8,6 +8,7 @@
 
 "use client";
 
+import { memo } from "react";
 import { getGraphNodeColor } from "@/theme/graphColors";
 import { getNodeIconPath } from "./nodeIcons";
 import type { GraphNode as GraphNodeData } from "@/packages/shared/types";
@@ -66,7 +67,7 @@ function getImpactHaloRadius(importCount: number): number | null {
   return null;
 }
 
-export function GraphNode({
+function GraphNodeComponent({
   node,
   position,
   isSelected,
@@ -140,3 +141,11 @@ export function GraphNode({
     </g>
   );
 }
+
+// Memoized: without this, every GraphNode instance re-renders whenever
+// GraphCanvas.tsx's transform state changes (pan/zoom), even if that
+// specific node's own props (position, selection, hover, importCount)
+// haven't changed. On a graph with hundreds of nodes, that's hundreds
+// of unnecessary re-renders per pan/zoom frame. Default shallow-compare
+// is sufficient here since all props are primitives or stable references.
+export const GraphNode = memo(GraphNodeComponent);


### PR DESCRIPTION
GraphNode instances re-rendered on every GraphCanvas.tsx transform change (pan/zoom), even when that specific node's own props hadn't changed. On a graph with hundreds of nodes this meant hundreds of wasted re-renders per frame during panning/zooming.

Inspired by looking at cytoscape.js's rendering architecture (layered-texture-cache.mjs) for reference -- not adopting its full caching system (that's Canvas-based, ARCLUX is SVG, much bigger scope), just the underlying principle: don't redo work for elements that haven't actually changed. React.memo's default shallow compare is enough here since GraphNode's props are all primitives/stable refs.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
