### PR TITLE
docs: fallback to folder listing when no package.json/index found

### DIFF
--- a/scripts/generate-docs-mintlify.js
+++ b/scripts/generate-docs-mintlify.js
@@ -246,6 +246,7 @@ const context = readIfExists('CONTEXT.md');
         } catch (e) {}
       }
       const exp = scanExports(dir);
+      const hasPkgJson = fs.existsSync(pkgPath);
       let body = `## ${groupDir}/${name}\n\n`;
       if (description) {
         body += `${description}\n\n`;
@@ -253,8 +254,21 @@ const context = readIfExists('CONTEXT.md');
         const pkgReadme = findPackageReadme(dir);
         if (pkgReadme) {
           body += `${pkgReadme}\n\n`;
+        } else if (!hasPkgJson) {
+          body += `_Tidak ada package.json (bukan package standar Node)._\n\n`;
         } else {
           body += '_Belum ada deskripsi di package.json atau README.md._\n\n';
+        }
+      }
+      if (!exp) {
+        const entries = fs.readdirSync(dir).filter((f) => !f.startsWith('.'));
+        if (entries.length) {
+          body += `**Isi folder:**\n\n`;
+          entries.forEach((e) => {
+            const isDir = fs.statSync(path.join(dir, e)).isDirectory();
+            body += `- \`${e}\`${isDir ? '/' : ''}\n`;
+          });
+          body += `\n`;
         }
       }
       if (exp && (exp.exports.length || exp.reExports.length || exp.hasDefault)) {


### PR DESCRIPTION
## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
