### PR TITLE
fix: neutralize HTML comments in collaborators.mdx (v3, regen had rev…

### DIFF
--- a/docs-site/progres/progres-collaborators.mdx
+++ b/docs-site/progres/progres-collaborators.mdx
@@ -28,13 +28,13 @@ description: "Detail progres: collaborators"
 
 ## Active assignments
 
-<!-- Format:
+ Format:
 ### [username] — issue #N
 - **Task**: one-line summary
 - **Files**: which file(s) this covers
 - **Status**: not started / in progress / PR open (#N) / blocked on X
 - **Assigned**: date
--->
+
 
 ### mwakidenis — issue #147
 - **Task**: Implement 3 remaining apps/web/hooks stubs
@@ -68,9 +68,9 @@ CODEOWNERS if/when they become active again.
 
 ## Completed
 
-<!-- Move entries here once merged, keep the same format, add:
+ Move entries here once merged, keep the same format, add:
 - **Merged**: PR #N, date
--->
+
 
 ## 2026-08-08 — mwakidenis contributed CITATION.cff unprompted
 


### PR DESCRIPTION
…erted it)

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
