### PR TITLE
docs: regen with folder-listing fallback, reapply MDX brace/comment f…

### DIFF
--- a/docs-site/map/map-apps-cli.mdx
+++ b/docs-site/map/map-apps-cli.mdx
@@ -7,6 +7,6 @@ description: "Ringkasan apps/cli"
 
 ## apps/cli
 
-_Belum ada deskripsi di package.json._
+_Belum ada deskripsi di package.json atau README.md._
 
-_Entry point `index.ts` ditemukan, tapi tidak ada named export terdeteksi._
+_Entry point `index.ts` ditemukan, tapi tidak ada export terdeteksi._

--- a/docs-site/map/map-apps-web.mdx
+++ b/docs-site/map/map-apps-web.mdx
@@ -7,6 +7,64 @@ description: "Ringkasan apps/web"
 
 ## apps/web
 
-_Belum ada deskripsi di package.json._
+This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm run dev
+# or
+yarn dev
+# or
+pnpm dev
+# or
+bun dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+
+## Learn More
+
+To learn more about Next.js, take a look at the following resources:
+
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+
+You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+
+## Deploy on Vercel
+
+The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+
+Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+**Isi folder:**
+
+- `AGENT.md`
+- `README.md`
+- `app`/
+- `components`/
+- `components.json`
+- `eslint.config.mjs`
+- `features`/
+- `hooks`/
+- `lib`/
+- `next-env.d.ts`
+- `next.config.ts`
+- `node_modules`/
+- `package-lock.json`
+- `package.json`
+- `postcss.config.mjs`
+- `public`/
+- `theme`/
+- `tsconfig.json`
+- `tsconfig.tsbuildinfo`
+- `vendor-ui`/
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-cache.mdx
+++ b/docs-site/map/map-packages-cache.mdx
@@ -7,6 +7,14 @@ description: "Ringkasan packages/cache"
 
 ## packages/cache
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `CacheProvider.ts`
+- `fileCache.ts`
+- `graphCache.ts`
+- `memoryCache.ts`
+- `repositoryCache.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-db.mdx
+++ b/docs-site/map/map-packages-db.mdx
@@ -7,6 +7,13 @@ description: "Ringkasan packages/db"
 
 ## packages/db
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `client.ts`
+- `migrations`/
+- `repositories`/
+- `schema.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-detectors.mdx
+++ b/docs-site/map/map-packages-detectors.mdx
@@ -7,6 +7,28 @@ description: "Ringkasan packages/detectors"
 
 ## packages/detectors
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `detectAmbiguousSymbolResolution.ts`
+- `detectCircularDependency.ts`
+- `detectComponentConvention.ts`
+- `detectDeadCode.ts`
+- `detectDuplicateModules.ts`
+- `detectEntryPoints.ts`
+- `detectFeatureStructure.ts`
+- `detectIndexFiles.ts`
+- `detectLargeModules.ts`
+- `detectLayerViolation.ts`
+- `detectMissingExports.ts`
+- `detectOrphanFiles.ts`
+- `detectRepositoryPattern.ts`
+- `detectRouteConvention.ts`
+- `detectSharedModules.ts`
+- `detectStoryConvention.ts`
+- `detectTestConvention.ts`
+- `detectUnusedExports.ts`
+- `detectUnusedFiles.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-diff.mdx
+++ b/docs-site/map/map-packages-diff.mdx
@@ -7,6 +7,12 @@ description: "Ringkasan packages/diff"
 
 ## packages/diff
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `architecturalDiff.ts`
+- `gitDiff.ts`
+- `types.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-engine.mdx
+++ b/docs-site/map/map-packages-engine.mdx
@@ -7,6 +7,20 @@ description: "Ringkasan packages/engine"
 
 ## packages/engine
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `analyzeArchitecture.ts`
+- `analyzeConvention.ts`
+- `analyzeDependency.ts`
+- `analyzeFile.ts`
+- `analyzeImpact.ts`
+- `analyzeModule.ts`
+- `contract.ts`
+- `detectRepositoryMeta.ts`
+- `generateReport.ts`
+- `generateSummary.ts`
+- `pipeline.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-git.mdx
+++ b/docs-site/map/map-packages-git.mdx
@@ -7,6 +7,17 @@ description: "Ringkasan packages/git"
 
 ## packages/git
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `checkoutBranch.ts`
+- `cleanupRepository.ts`
+- `cloneRepository.ts`
+- `detectDefaultBranch.ts`
+- `getBranches.ts`
+- `getCommitHistory.ts`
+- `getContributors.ts`
+- `readGitignore.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-graph.mdx
+++ b/docs-site/map/map-packages-graph.mdx
@@ -7,6 +7,16 @@ description: "Ringkasan packages/graph"
 
 ## packages/graph
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `buildCallGraph.ts`
+- `buildDependencyGraph.ts`
+- `buildExportGraph.ts`
+- `buildFolderGraph.ts`
+- `buildImportGraph.ts`
+- `resolvePath.ts`
+- `serializeGraph.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-impact.mdx
+++ b/docs-site/map/map-packages-impact.mdx
@@ -7,6 +7,18 @@ description: "Ringkasan packages/impact"
 
 ## packages/impact
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `buildImpactTree.ts`
+- `calculateAffectedComponents.ts`
+- `calculateAffectedFiles.ts`
+- `calculateAffectedModules.ts`
+- `calculateAffectedRoutes.ts`
+- `traceConsumers.ts`
+- `traceDependencies.ts`
+- `traceExports.ts`
+- `traceImports.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-incremental.mdx
+++ b/docs-site/map/map-packages-incremental.mdx
@@ -7,7 +7,7 @@ description: "Ringkasan packages/incremental"
 
 ## packages/incremental
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
 
 **Exports** (dari `index.ts`):
 

--- a/docs-site/map/map-packages-indexer.mdx
+++ b/docs-site/map/map-packages-indexer.mdx
@@ -7,6 +7,20 @@ description: "Ringkasan packages/indexer"
 
 ## packages/indexer
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `buildIndex.ts`
+- `indexSchema.ts`
+- `resolveAliases.ts`
+- `resolveComponents.ts`
+- `resolveExports.ts`
+- `resolveHooks.ts`
+- `resolveProviders.ts`
+- `resolveRoutes.ts`
+- `resolveSameScopeDependencies.ts`
+- `updateIndex.ts`
+- `watchIndex.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-parser.mdx
+++ b/docs-site/map/map-packages-parser.mdx
@@ -7,6 +7,21 @@ description: "Ringkasan packages/parser"
 
 ## packages/parser
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `config`/
+- `core`/
+- `cpp`/
+- `csharp`/
+- `go`/
+- `java`/
+- `javascript`/
+- `php`/
+- `python`/
+- `ruby`/
+- `rust`/
+- `typescript`/
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-repository.mdx
+++ b/docs-site/map/map-packages-repository.mdx
@@ -7,6 +7,17 @@ description: "Ringkasan packages/repository"
 
 ## packages/repository
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `Dependency.ts`
+- `Edge.ts`
+- `File.ts`
+- `Folder.ts`
+- `Graph.ts`
+- `Module.ts`
+- `Node.ts`
+- `Repository.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-rules.mdx
+++ b/docs-site/map/map-packages-rules.mdx
@@ -7,6 +7,16 @@ description: "Ringkasan packages/rules"
 
 ## packages/rules
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `RuleEngine.ts`
+- `electron`/
+- `express`/
+- `nestjs`/
+- `nextjs`/
+- `react`/
+- `vite`/
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-search.mdx
+++ b/docs-site/map/map-packages-search.mdx
@@ -7,6 +7,16 @@ description: "Ringkasan packages/search"
 
 ## packages/search
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `SearchEngine.ts`
+- `SearchFilters.ts`
+- `SearchIndex.ts`
+- `SearchKeyboard.ts`
+- `SearchProvider.ts`
+- `SearchResults.ts`
+- `fuzzyScore.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-shared.mdx
+++ b/docs-site/map/map-packages-shared.mdx
@@ -7,6 +7,17 @@ description: "Ringkasan packages/shared"
 
 ## packages/shared
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `config.ts`
+- `constants.ts`
+- `errors.ts`
+- `hash.ts`
+- `logger.ts`
+- `paths.ts`
+- `types.ts`
+- `utils.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-ui.mdx
+++ b/docs-site/map/map-packages-ui.mdx
@@ -7,6 +7,14 @@ description: "Ringkasan packages/ui"
 
 ## packages/ui
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `graphAnimation.ts`
+- `graphColor.ts`
+- `graphIcons.ts`
+- `graphLayout.ts`
+- `graphTheme.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-watcher.mdx
+++ b/docs-site/map/map-packages-watcher.mdx
@@ -7,6 +7,13 @@ description: "Ringkasan packages/watcher"
 
 ## packages/watcher
 
-_Belum ada deskripsi di package.json._
+_Tidak ada package.json (bukan package standar Node)._
+
+**Isi folder:**
+
+- `changeQueue.ts`
+- `watchFilesystem.ts`
+- `watchGit.ts`
+- `watchRepository.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/scripts/generate-docs-mintlify.js
+++ b/scripts/generate-docs-mintlify.js
@@ -94,8 +94,8 @@ function extractSection(content, headingRegex) {
 
 console.log('== ARCLUX Docs (Mintlify) -- generating content from repo ==\n');
 
-if (!fs.existsSync(DOCS_OUT) || !fs.existsSync(path.join(DOCS_OUT, 'mint.json'))) {
-  console.error('ERROR: docs-site/mint.json belum ada. Jalankan 01-reset-and-scaffold-mintlify.sh dulu.');
+if (!fs.existsSync(DOCS_OUT) || !fs.existsSync(path.join(DOCS_OUT, 'docs.json'))) {
+  console.error('ERROR: docs-site/docs.json belum ada. Jalankan 01-reset-and-scaffold-mintlify.sh dulu.');
   process.exit(1);
 }
 


### PR DESCRIPTION
…ixes

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
