### PR TITLE
[feat] Add missing platform scaffold: kernel, semantic-diff, notifica…

### DIFF
--- a/add_missing_platform.sh
+++ b/add_missing_platform.sh
@@ -1,0 +1,60 @@
+set +H
+cd ~/arclux || { echo "repo not found at ~/arclux"; exit 1; }
+
+LICENSE_HEADER='/**
+ * Copyright '"$(date +%Y)"' ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */'
+
+make_stub() {
+  local filepath="$1"
+  local label="$2"
+  mkdir -p "$(dirname "$filepath")"
+  if [ -f "$filepath" ]; then
+    echo "SKIP (exists): $filepath"
+    return
+  fi
+  cat > "$filepath" << INNEREOF
+$LICENSE_HEADER
+
+// Scaffold: $label — not yet implemented.
+INNEREOF
+  echo "created: $filepath"
+}
+
+# ── packages/kernel ──────────────────────────────
+make_stub packages/kernel/Kernel.ts "kernel/Kernel"
+make_stub packages/kernel/ProcessTable.ts "kernel/ProcessTable"
+make_stub packages/kernel/SignalBus.ts "kernel/SignalBus"
+make_stub packages/kernel/ServiceRegistry.ts "kernel/ServiceRegistry"
+make_stub packages/kernel/introspection/ProcSnapshot.ts "kernel/introspection/ProcSnapshot"
+make_stub packages/kernel/introspection/formatProcTree.ts "kernel/introspection/formatProcTree"
+
+# ── packages/semantic-diff ──────────────────────────────
+make_stub packages/semantic-diff/SemanticDiff.ts "semantic-diff/SemanticDiff"
+make_stub packages/semantic-diff/SymbolDiff.ts "semantic-diff/SymbolDiff"
+make_stub packages/semantic-diff/AstDiff.ts "semantic-diff/AstDiff"
+make_stub packages/semantic-diff/DependencyDiff.ts "semantic-diff/DependencyDiff"
+make_stub packages/semantic-diff/DiffRenderer.ts "semantic-diff/DiffRenderer"
+
+# ── packages/notifications ──────────────────────────────
+make_stub packages/notifications/NotificationManager.ts "notifications/NotificationManager"
+make_stub packages/notifications/Notification.ts "notifications/Notification"
+make_stub packages/notifications/NotificationChannel.ts "notifications/NotificationChannel"
+
+# ── packages/package-manager ──────────────────────────────
+make_stub packages/package-manager/PackageManager.ts "package-manager/PackageManager"
+make_stub packages/package-manager/PackageManifest.ts "package-manager/PackageManifest"
+make_stub packages/package-manager/PackageResolver.ts "package-manager/PackageResolver"
+make_stub packages/package-manager/PackageState.ts "package-manager/PackageState"
+
+# ── apps/cli/commands (missing) ──────────────────────────────
+make_stub apps/cli/commands/health.ts "cli/commands/health"
+make_stub apps/cli/commands/package.ts "cli/commands/package"
+
+echo "✅ Done. New files: $(git status --porcelain | wc -l)"

--- a/apps/cli/commands/health.ts
+++ b/apps/cli/commands/health.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: cli/commands/health — not yet implemented.

--- a/apps/cli/commands/package.ts
+++ b/apps/cli/commands/package.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: cli/commands/package — not yet implemented.

--- a/packages/kernel/Kernel.ts
+++ b/packages/kernel/Kernel.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: kernel/Kernel — not yet implemented.

--- a/packages/kernel/ProcessTable.ts
+++ b/packages/kernel/ProcessTable.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: kernel/ProcessTable — not yet implemented.

--- a/packages/kernel/ServiceRegistry.ts
+++ b/packages/kernel/ServiceRegistry.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: kernel/ServiceRegistry — not yet implemented.

--- a/packages/kernel/SignalBus.ts
+++ b/packages/kernel/SignalBus.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: kernel/SignalBus — not yet implemented.

--- a/packages/kernel/introspection/ProcSnapshot.ts
+++ b/packages/kernel/introspection/ProcSnapshot.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: kernel/introspection/ProcSnapshot — not yet implemented.

--- a/packages/kernel/introspection/formatProcTree.ts
+++ b/packages/kernel/introspection/formatProcTree.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: kernel/introspection/formatProcTree — not yet implemented.

--- a/packages/notifications/Notification.ts
+++ b/packages/notifications/Notification.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: notifications/Notification — not yet implemented.

--- a/packages/notifications/NotificationChannel.ts
+++ b/packages/notifications/NotificationChannel.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: notifications/NotificationChannel — not yet implemented.

--- a/packages/notifications/NotificationManager.ts
+++ b/packages/notifications/NotificationManager.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: notifications/NotificationManager — not yet implemented.

--- a/packages/package-manager/PackageManager.ts
+++ b/packages/package-manager/PackageManager.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: package-manager/PackageManager — not yet implemented.

--- a/packages/package-manager/PackageManifest.ts
+++ b/packages/package-manager/PackageManifest.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: package-manager/PackageManifest — not yet implemented.

--- a/packages/package-manager/PackageResolver.ts
+++ b/packages/package-manager/PackageResolver.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: package-manager/PackageResolver — not yet implemented.

--- a/packages/package-manager/PackageState.ts
+++ b/packages/package-manager/PackageState.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: package-manager/PackageState — not yet implemented.

--- a/packages/semantic-diff/AstDiff.ts
+++ b/packages/semantic-diff/AstDiff.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: semantic-diff/AstDiff — not yet implemented.

--- a/packages/semantic-diff/DependencyDiff.ts
+++ b/packages/semantic-diff/DependencyDiff.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: semantic-diff/DependencyDiff — not yet implemented.

--- a/packages/semantic-diff/DiffRenderer.ts
+++ b/packages/semantic-diff/DiffRenderer.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: semantic-diff/DiffRenderer — not yet implemented.

--- a/packages/semantic-diff/SemanticDiff.ts
+++ b/packages/semantic-diff/SemanticDiff.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: semantic-diff/SemanticDiff — not yet implemented.

--- a/packages/semantic-diff/SymbolDiff.ts
+++ b/packages/semantic-diff/SymbolDiff.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Scaffold: semantic-diff/SymbolDiff — not yet implemented.


### PR DESCRIPTION
…tions, package-manager, health/package CLI

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
