### PR TITLE
[feat] Implement ProcessManager (fork-mode equivalent) + revise Proce…

### DIFF
--- a/packages/kernel/ProcessTable.ts
+++ b/packages/kernel/ProcessTable.ts
@@ -8,4 +8,79 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: kernel/ProcessTable — not yet implemented.
+/**
+ * ProcessTable — in-memory registry of processes tracked by the kernel.
+ * Status naming follows PM2's God.js convention (see lib/God/ForkMode.js,
+ * constants.js): LAUNCHING -> ONLINE -> STOPPING -> STOPPED, or ONLINE ->
+ * ERRORED on unexpected exit. This is ARCLUX's own equivalent of PM2's
+ * "clusters_db", scoped to ARCLUX's internal services (web server,
+ * watcher, indexer) rather than arbitrary user apps.
+ */
+
+export const ProcessStatus = {
+  LAUNCHING: "launching",
+  ONLINE: "online",
+  STOPPING: "stopping",
+  STOPPED: "stopped",
+  ERRORED: "errored",
+} as const;
+
+export type ProcessStatusValue = (typeof ProcessStatus)[keyof typeof ProcessStatus];
+
+export interface ProcessEntry {
+  id: string;
+  pid: number | null;
+  name: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  status: ProcessStatusValue;
+  startedAt: number | null;
+  restarts: number;
+  lastExitCode: number | null;
+}
+
+export class ProcessTable {
+  private entries = new Map<string, ProcessEntry>();
+
+  register(entry: Omit<ProcessEntry, "restarts" | "lastExitCode">): ProcessEntry {
+    const full: ProcessEntry = {
+      ...entry,
+      restarts: 0,
+      lastExitCode: null,
+    };
+    this.entries.set(entry.id, full);
+    return full;
+  }
+
+  updateStatus(id: string, status: ProcessStatusValue, exitCode?: number): void {
+    const entry = this.entries.get(id);
+    if (!entry) {
+      throw new Error(`ProcessTable: unknown process id "${id}"`);
+    }
+    entry.status = status;
+    if (status === ProcessStatus.ERRORED || status === ProcessStatus.STOPPED) {
+      entry.lastExitCode = exitCode ?? null;
+    }
+  }
+
+  incrementRestarts(id: string): void {
+    const entry = this.entries.get(id);
+    if (!entry) {
+      throw new Error(`ProcessTable: unknown process id "${id}"`);
+    }
+    entry.restarts += 1;
+  }
+
+  remove(id: string): boolean {
+    return this.entries.delete(id);
+  }
+
+  get(id: string): ProcessEntry | undefined {
+    return this.entries.get(id);
+  }
+
+  list(): ProcessEntry[] {
+    return Array.from(this.entries.values());
+  }
+}

--- a/packages/kernel/SignalBus.ts
+++ b/packages/kernel/SignalBus.ts
@@ -8,4 +8,42 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: kernel/SignalBus — not yet implemented.
+/**
+ * SignalBus — pub/sub for kernel-level signals, built on Node's built-in
+ * EventEmitter (no external dependency, unlike PM2's EventEmitter2 which
+ * adds wildcard/namespaced matching). Exact-match event names only, e.g.
+ * "process:online", "log:out", "log:err" — mirrors PM2's God.bus.emit
+ * naming convention (see lib/God/ForkMode.js) without the wildcard layer.
+ */
+
+import { EventEmitter } from "node:events";
+
+export class SignalBus {
+  private emitter = new EventEmitter();
+
+  constructor() {
+    // Kernel may track many services; avoid Node's default 10-listener warning.
+    this.emitter.setMaxListeners(1000);
+  }
+
+  on<T = unknown>(signal: string, handler: (payload: T) => void): () => void {
+    this.emitter.on(signal, handler);
+    return () => this.off(signal, handler);
+  }
+
+  off<T = unknown>(signal: string, handler: (payload: T) => void): void {
+    this.emitter.off(signal, handler);
+  }
+
+  emit<T = unknown>(signal: string, payload: T): void {
+    this.emitter.emit(signal, payload);
+  }
+
+  clear(signal?: string): void {
+    if (signal) {
+      this.emitter.removeAllListeners(signal);
+    } else {
+      this.emitter.removeAllListeners();
+    }
+  }
+}

--- a/packages/runtime/ProcessManager.ts
+++ b/packages/runtime/ProcessManager.ts
@@ -8,4 +8,133 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: runtime/ProcessManager — not yet implemented.
+/**
+ * ProcessManager — spawns and tracks real OS processes for ARCLUX's own
+ * internal services (web server, watcher, indexer). This is ARCLUX's
+ * fork-mode equivalent of PM2's God.forkMode (lib/God/ForkMode.js):
+ * child_process.spawn + stdout/stderr capture + exit handling + IPC
+ * message forwarding, all broadcast through the kernel's SignalBus
+ * (mirrors God.bus.emit('log:out' / 'log:err' / 'process:msg', ...)).
+ *
+ * Deliberately NOT ported from PM2:
+ * - Cluster mode (cluster.fork() for multi-instance load balancing) —
+ *   see lib/God/ClusterMode.js in the PM2 reference clone. ARCLUX's
+ *   internal services are single-instance; add this later if a real
+ *   need for multi-instance load balancing shows up.
+ * - Log file persistence to disk, PID file writing, dayjs-formatted
+ *   timestamps, JSON log type toggle, uid/gid, Windows-specific options.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import type { Kernel } from "../kernel/Kernel";
+import { ProcessStatus } from "../kernel/ProcessTable";
+import type { ProcessSpec } from "./ProcessSpec";
+
+interface TrackedChild {
+  spec: ProcessSpec;
+  child: ChildProcess;
+}
+
+export class ProcessManager {
+  private children = new Map<string, TrackedChild>();
+
+  constructor(private readonly kernel: Kernel) {}
+
+  start(spec: ProcessSpec): void {
+    this.kernel.registerProcess({
+      id: spec.id,
+      pid: null,
+      name: spec.name,
+      command: spec.command,
+      args: spec.args ?? [],
+      cwd: spec.cwd ?? process.cwd(),
+      status: ProcessStatus.LAUNCHING,
+      startedAt: null,
+    });
+
+    const child = spawn(spec.command, spec.args ?? [], {
+      cwd: spec.cwd ?? process.cwd(),
+      env: { ...process.env, ...spec.env },
+      stdio: ["pipe", "pipe", "pipe", "ipc"],
+    });
+
+    this.children.set(spec.id, { spec, child });
+
+    this.kernel.updateProcessStatus(spec.id, ProcessStatus.ONLINE);
+    const entry = this.kernel.processTable.get(spec.id);
+    if (entry) {
+      entry.pid = child.pid ?? null;
+      entry.startedAt = Date.now();
+    }
+
+    child.stdout?.on("data", (data: Buffer) => {
+      this.kernel.signalBus.emit("log:out", {
+        processId: spec.id,
+        name: spec.name,
+        data: data.toString(),
+        at: Date.now(),
+      });
+    });
+
+    child.stderr?.on("data", (data: Buffer) => {
+      this.kernel.signalBus.emit("log:err", {
+        processId: spec.id,
+        name: spec.name,
+        data: data.toString(),
+        at: Date.now(),
+      });
+    });
+
+    child.on("message", (msg: unknown) => {
+      this.kernel.signalBus.emit("process:msg", {
+        processId: spec.id,
+        name: spec.name,
+        data: msg,
+        at: Date.now(),
+      });
+    });
+
+    child.once("exit", (code, signal) => {
+      const exitedAbnormally = code !== 0 && code !== null;
+      this.kernel.updateProcessStatus(
+        spec.id,
+        exitedAbnormally ? ProcessStatus.ERRORED : ProcessStatus.STOPPED,
+        code ?? undefined
+      );
+      this.children.delete(spec.id);
+
+      const shouldRestart =
+        spec.autorestart !== false &&
+        exitedAbnormally &&
+        (this.kernel.processTable.get(spec.id)?.restarts ?? 0) <
+          (spec.maxRestarts ?? 15); // 15 matches PM2's default unstable_restarts ceiling
+
+      if (shouldRestart) {
+        this.kernel.processTable.incrementRestarts(spec.id);
+        this.start(spec);
+      }
+    });
+
+    child.once("error", (err) => {
+      this.kernel.signalBus.emit("process:error", {
+        processId: spec.id,
+        name: spec.name,
+        error: err.message,
+        at: Date.now(),
+      });
+    });
+  }
+
+  stop(id: string): void {
+    const tracked = this.children.get(id);
+    if (!tracked) return;
+    this.kernel.updateProcessStatus(id, ProcessStatus.STOPPING);
+    tracked.child.kill("SIGINT");
+  }
+
+  send(id: string, message: unknown): boolean {
+    const tracked = this.children.get(id);
+    if (!tracked || !tracked.child.connected) return false;
+    return tracked.child.send(message);
+  }
+}

--- a/packages/runtime/ProcessSpec.ts
+++ b/packages/runtime/ProcessSpec.ts
@@ -8,4 +8,21 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: runtime/ProcessSpec — not yet implemented.
+/**
+ * ProcessSpec — declarative shape describing how to spawn one process.
+ * Scoped-down equivalent of PM2's pm2_env for fork mode (see
+ * lib/God/ForkMode.js): keeps command/args/cwd/env/autorestart, drops
+ * PM2-specific fields not relevant to ARCLUX (log file paths, pidfile
+ * path, uid/gid, windowsHide, versioning/vizion).
+ */
+
+export interface ProcessSpec {
+  id: string;
+  name: string;
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  autorestart?: boolean;
+  maxRestarts?: number;
+}


### PR DESCRIPTION
…ssTable/SignalBus based on real PM2 God.js reference

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
