### PR TITLE
fix: clean corrupted merge markers from diagnostics editor layers

### DIFF
--- a/packages/diagnostics/DiagnosticEngine.ts
+++ b/packages/diagnostics/DiagnosticEngine.ts
@@ -1,7 +1,3 @@
-feat/editor-layer
-=======
-feat/diagnostics-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,10 +28,8 @@ export interface DiagnosticFinding {
   locations: ErrorLocation[];
 }
 
-feat/editor-layer
 /** detectCircularDependency returns { cycle: string[] } -- module ids only, no line info at all. */
 
-ARCLUX.main
 function adaptCircularDependency(repository: Repository): DiagnosticFinding[] {
   const results = detectCircularDependency(repository);
 
@@ -50,10 +44,8 @@ function adaptCircularDependency(repository: Repository): DiagnosticFinding[] {
   }));
 }
 
- feat/editor-layer
 /** detectDeadCode returns { filePath, unusedExportCount, importedByCount, message } -- file-level, no line. */
 
-ARCLUX.main
 function adaptDeadCode(repository: Repository): DiagnosticFinding[] {
   const results = detectDeadCode(repository);
 
@@ -68,10 +60,8 @@ function adaptDeadCode(repository: Repository): DiagnosticFinding[] {
   });
 }
 
- feat/editor-layer
 /** detectAmbiguousSymbolResolution returns real line info per definition -- use it directly, no fallback needed. */
 
-ARCLUX.main
 function adaptAmbiguousSymbolResolution(repository: Repository): DiagnosticFinding[] {
   const results = detectAmbiguousSymbolResolution(repository);
 
@@ -90,7 +80,6 @@ export function runDiagnostics(repository: Repository): DiagnosticFinding[] {
     ...adaptAmbiguousSymbolResolution(repository),
   ];
 }
-feat/editor-layer
 
 
 /**
@@ -103,6 +92,3 @@ feat/editor-layer
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: diagnostics/DiagnosticEngine — not yet implemented.
- ARCLUX.main
- ARCLUX.main

--- a/packages/diagnostics/DiagnosticEvent.ts
+++ b/packages/diagnostics/DiagnosticEvent.ts
@@ -1,7 +1,4 @@
-feat/editor-layer
 
-feat/diagnostics-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +9,11 @@ ARCLUX.main
 //
 // Flattens a FindingWithContext into a notification-ready shape: one
 // event per location, carrying just enough to jump straight to file+line
-feat/editor-layer
 // and show affected-file count. Consumers (apps/cli, apps/web) render
 // this, they don't re-derive it from DiagnosticFinding/ImpactNavigationResult
 // themselves.
 
 // and show affected-file count.
-ARCLUX.main
 
 import type { FindingWithContext } from "./ErrorContext";
 import type { DiagnosticSeverity } from "./DiagnosticEngine";
@@ -52,7 +47,6 @@ export function toDiagnosticEvents(withContext: FindingWithContext): DiagnosticE
 export function toDiagnosticEventsForAll(withContextList: FindingWithContext[]): DiagnosticEvent[] {
   return withContextList.flatMap(toDiagnosticEvents);
 }
-feat/editor-layer
 
 
 /**
@@ -65,6 +59,3 @@ feat/editor-layer
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: diagnostics/DiagnosticEvent — not yet implemented
-  ARCLUX.main
-  ARCLUX.main

--- a/packages/diagnostics/ErrorContext.ts
+++ b/packages/diagnostics/ErrorContext.ts
@@ -1,7 +1,3 @@
-feat/editor-layer
-
-feat/diagnostics-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,22 +11,29 @@ ARCLUX.main
 // Does not recompute impact -- reuses the existing chain end to end.
 
 import type { Repository } from "../repository/Repository";
-import { getImpactNavigation, type ImpactNavigationResult } from "../editor/ImpactNavigator";
+import {
+  getImpactNavigation,
+  type ImpactNavigationResult,
+} from "../editor/ImpactNavigator";
 import type { DiagnosticFinding } from "./DiagnosticEngine";
 
 export interface FindingWithContext {
   finding: DiagnosticFinding;
-<<<<<< feat/editor-layer
-  /** Impact for each distinct moduleId referenced in finding.locations. */
 
-ARCLUX.main
+  /** Impact for each distinct moduleId referenced in finding.locations. */
   impactByModuleId: Record<string, ImpactNavigationResult>;
 }
 
-export function attachImpactContext(repository: Repository, finding: DiagnosticFinding): FindingWithContext {
-  const uniqueModuleIds = [...new Set(finding.locations.map((loc) => loc.moduleId))];
+export function attachImpactContext(
+  repository: Repository,
+  finding: DiagnosticFinding,
+): FindingWithContext {
+  const uniqueModuleIds = [
+    ...new Set(finding.locations.map((loc) => loc.moduleId)),
+  ];
 
   const impactByModuleId: Record<string, ImpactNavigationResult> = {};
+
   for (const moduleId of uniqueModuleIds) {
     impactByModuleId[moduleId] = getImpactNavigation(repository, moduleId);
   }
@@ -38,22 +41,9 @@ export function attachImpactContext(repository: Repository, finding: DiagnosticF
   return { finding, impactByModuleId };
 }
 
-export function attachImpactContextToAll(repository: Repository, findings: DiagnosticFinding[]): FindingWithContext[] {
+export function attachImpactContextToAll(
+  repository: Repository,
+  findings: DiagnosticFinding[],
+): FindingWithContext[] {
   return findings.map((f) => attachImpactContext(repository, f));
 }
-feat/editor-layer
-
-
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
-
-// Scaffold: diagnostics/ErrorContext — not yet implemented.
-ARCLUX.main
-ARCLUX.main

--- a/packages/diagnostics/ErrorLocation.ts
+++ b/packages/diagnostics/ErrorLocation.ts
@@ -1,7 +1,3 @@
-feat/editor-layer
-
-feat/diagnostics-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,26 +22,27 @@ export interface ErrorLocation {
   locationPrecision: "line" | "file";
 }
 
-export function fileLevelLocation(moduleId: string, filePath: string): ErrorLocation {
-  return { moduleId, filePath, line: 1, locationPrecision: "file" };
+export function fileLevelLocation(
+  moduleId: string,
+  filePath: string,
+): ErrorLocation {
+  return {
+    moduleId,
+    filePath,
+    line: 1,
+    locationPrecision: "file",
+  };
 }
 
-export function preciseLocation(moduleId: string, filePath: string, line: number): ErrorLocation {
-  return { moduleId, filePath, line, locationPrecision: "line" };
+export function preciseLocation(
+  moduleId: string,
+  filePath: string,
+  line: number,
+): ErrorLocation {
+  return {
+    moduleId,
+    filePath,
+    line,
+    locationPrecision: "line",
+  };
 }
-feat/editor-layer
-
-
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
-
-// Scaffold: diagnostics/ErrorLocation — not yet implemented.
- ARCLUX.main
-ARCLUX.main

--- a/packages/diagnostics/FixSuggestion.ts
+++ b/packages/diagnostics/FixSuggestion.ts
@@ -1,4 +1,3 @@
-feat/diagnostics-layer
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,5 +48,3 @@ export function getFixSuggestions(findings: DiagnosticFinding[]): FixSuggestion[
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: diagnostics/FixSuggestion — not yet implemented.
- ARCLUX.main

--- a/packages/editor/CodeNavigator.ts
+++ b/packages/editor/CodeNavigator.ts
@@ -1,7 +1,4 @@
-feat/diagnostics-layer
 
-feat/editor-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,7 +50,6 @@ export function listDirectConsumerTargets(repository: Repository, moduleId: stri
     return { moduleId: consumerId, filePath: consumer?.file.relativePath ?? consumerId };
   });
 }
-feat/diagnostics-layer
 
 
 /**
@@ -66,6 +62,3 @@ feat/diagnostics-layer
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: editor/CodeNavigator — not yet implemented.
-ARCLUX.main
-ARCLUX.main

--- a/packages/editor/EditContext.ts
+++ b/packages/editor/EditContext.ts
@@ -1,7 +1,4 @@
-feat/diagnostics-layer
 
-feat/editor-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +39,6 @@ export function switchFile(
 ): EditSession {
   return { ...session, activeModuleId: moduleId, cursor };
 }
-feat/diagnostics-layer
 
 
 /**
@@ -55,6 +51,3 @@ feat/diagnostics-layer
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: editor/EditContext — not yet implemented.
-ARCLUX.main
-ARCLUX.main

--- a/packages/editor/ImpactNavigator.ts
+++ b/packages/editor/ImpactNavigator.ts
@@ -1,7 +1,4 @@
-feat/diagnostics-layer
 
-feat/editor-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +45,6 @@ export function getImpactNavigation(repository: Repository, moduleId: string): I
     tree,
   };
 }
-feat/diagnostics-layer
 
 
 /**
@@ -61,6 +57,3 @@ feat/diagnostics-layer
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: editor/ImpactNavigator — not yet implemented.
-ARCLUX.main
-ARCLUX.main

--- a/packages/editor/LineContext.ts
+++ b/packages/editor/LineContext.ts
@@ -1,7 +1,4 @@
-feat/diagnostics-layer
 
-feat/editor-layer
- ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +25,6 @@ export function getLineContext(repository: Repository, moduleId: string, line: n
     hasParserWarning: false,
   };
 }
-feat/diagnostics-layer
 
 
 /**
@@ -41,6 +37,3 @@ feat/diagnostics-layer
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: editor/LineContext — not yet implemented.
-ARCLUX.main
-ARCLUX.main

--- a/packages/editor/SymbolProvider.ts
+++ b/packages/editor/SymbolProvider.ts
@@ -1,7 +1,4 @@
-feat/diagnostics-layer
 
-feat/editor-layer
-ARCLUX.main
 // Copyright 2026 Mikatoshi
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,7 +42,6 @@ export function getFileSymbols(repository: Repository, moduleId: string): Symbol
 export function getSymbolsAtLine(repository: Repository, moduleId: string, line: number): SymbolInfo[] {
   return getFileSymbols(repository, moduleId).filter((s) => s.line === line);
 }
-feat/diagnostics-layer
 
 
 /**
@@ -58,6 +54,3 @@ feat/diagnostics-layer
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: editor/SymbolProvider — not yet implemented.
-ARCLUX.main
-ARCLUX.main


### PR DESCRIPTION
## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
