### PR TITLE
Feat/process persistence ps

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -29,3 +29,11 @@ their respective repositories.
   The fuzzy-match scoring algorithm in packages/search/fuzzyScore.ts is
   separately adapted (re-typed to TypeScript, renamed) from this project's
   src/command-score.ts.
+
+- forever (https://github.com/foreverjs/forever) — MIT License
+  Read for reference on cross-process state visibility (getAllProcesses/
+  getSockets pattern: scan a directory of per-process records, verify
+  liveness before trusting a record, self-clean stale entries). ARCLUX's
+  packages/storage/SnapshotManager.ts re-implements this concept using
+  plain JSON files + process.kill(pid, 0) liveness checks instead of
+  forever's UNIX-socket-based IPC — no code copied, pattern only.

--- a/apps/cli/commands/ps.ts
+++ b/apps/cli/commands/ps.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 ARCLUX
+ * Copyright 2026 Mikatoshi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,4 +8,25 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: cli/commands/ps — not yet implemented.
+import type { Command } from "commander";
+import { readLiveProcessRecords } from "../../../packages/storage/SnapshotManager";
+import { snapshotFromEntries } from "../../../packages/kernel/introspection/ProcSnapshot";
+import { formatProcTree } from "../../../packages/kernel/introspection/formatProcTree";
+
+export function registerPsCommand(program: Command): void {
+  program
+    .command("ps")
+    .description("List processes currently registered with the ARCLUX kernel")
+    .option("--json", "output raw snapshot JSON instead of the formatted tree")
+    .action((options: { json?: boolean }) => {
+      const processes = readLiveProcessRecords();
+      const snapshot = snapshotFromEntries(processes);
+
+      if (options.json) {
+        console.log(JSON.stringify(snapshot, null, 2));
+        return;
+      }
+
+      console.log(formatProcTree(snapshot));
+    });
+}

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -16,6 +16,7 @@ import { registerVerifyCommand } from "./verify";
 import { registerDoctorCommand } from "./doctor";
 import { registerConfigCommand } from "./config";
 import { registerDiagnoseCommand } from "./diagnose";
+import { registerPsCommand } from "./commands/ps";
 
 const program = new Command();
 program.name("arclux").description("Repository intelligence CLI").version("0.1.0");
@@ -28,5 +29,6 @@ registerVerifyCommand(program);
 registerDoctorCommand(program);
 registerConfigCommand(program);
 registerDiagnoseCommand(program);
+registerPsCommand(program);
 
 program.parse();

--- a/packages/kernel/Kernel.ts
+++ b/packages/kernel/Kernel.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 ARCLUX
+ * Copyright 2026 Mikatoshi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 import { ProcessTable, type ProcessEntry, type ProcessStatusValue } from "./ProcessTable";
 import { SignalBus } from "./SignalBus";
 import { ServiceRegistry, type ServiceHandle } from "./ServiceRegistry";
+import { takeProcSnapshot, type ProcSnapshot } from "./introspection/ProcSnapshot";
+import { formatProcTree } from "./introspection/formatProcTree";
+import { writeProcessRecord, removeProcessRecord } from "../storage/SnapshotManager";
 
 export class Kernel {
   readonly processTable = new ProcessTable();
@@ -19,6 +22,7 @@ export class Kernel {
 
   registerProcess(entry: Omit<ProcessEntry, "restarts" | "lastExitCode">): ProcessEntry {
     const registered = this.processTable.register(entry);
+    writeProcessRecord(registered);
     this.signalBus.emit("process:registered", registered);
     return registered;
   }
@@ -26,7 +30,16 @@ export class Kernel {
   updateProcessStatus(id: string, status: ProcessStatusValue, exitCode?: number): void {
     this.processTable.updateStatus(id, status, exitCode);
     const entry = this.processTable.get(id);
+    if (entry) writeProcessRecord(entry);
     this.signalBus.emit(`process:${status}`, entry);
+  }
+
+  /** Remove a process from the table and delete its persisted record. */
+  removeProcess(id: string): boolean {
+    const removed = this.processTable.remove(id);
+    removeProcessRecord(id);
+    if (removed) this.signalBus.emit("process:removed", { id });
+    return removed;
   }
 
   registerService(handle: ServiceHandle): void {
@@ -34,7 +47,31 @@ export class Kernel {
     this.signalBus.emit("service:registered", handle);
   }
 
+  /** Update runtime info (pid, startedAt) discovered after spawn, persisting the change. */
+  setProcessRuntimeInfo(id: string, info: { pid: number | null; startedAt: number | null }): void {
+    const entry = this.processTable.get(id);
+    if (!entry) return;
+    entry.pid = info.pid;
+    entry.startedAt = info.startedAt;
+    writeProcessRecord(entry);
+    this.signalBus.emit("process:updated", entry);
+  }
+
+  snapshotProcesses(): ProcSnapshot {
+    return takeProcSnapshot(this.processTable);
+  }
+
+  printProcessTree(): string {
+    return formatProcTree(this.snapshotProcesses());
+  }
+
   shutdown(): void {
+    // Clean up this kernel's own persisted process records so `ps` run
+    // from another process doesn't keep reporting entries that only
+    // existed in this now-dead kernel's memory.
+    for (const entry of this.processTable.list()) {
+      removeProcessRecord(entry.id);
+    }
     this.signalBus.emit("kernel:shutdown", { at: Date.now() });
     this.signalBus.clear();
   }

--- a/packages/kernel/introspection/ProcSnapshot.ts
+++ b/packages/kernel/introspection/ProcSnapshot.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 ARCLUX
+ * Copyright 2026 Mikatoshi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,4 +8,37 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: kernel/introspection/ProcSnapshot — not yet implemented.
+import type { ProcessEntry, ProcessTable } from "../ProcessTable";
+
+/**
+ * An immutable snapshot of process state at one point in time.
+ *
+ * Snapshots exist so introspection (CLI `ps`, web dashboard, diagnostics)
+ * never reads live, mutable state directly — whether that's an in-memory
+ * ProcessTable in the same process, or records read off disk from a
+ * different process entirely.
+ */
+export interface ProcSnapshot {
+  /** epoch ms when this snapshot was taken */
+  takenAt: number;
+  /** shallow copies of every process entry at snapshot time */
+  processes: ProcessEntry[];
+}
+
+/** Build a ProcSnapshot from any list of process entries. */
+export function snapshotFromEntries(processes: ProcessEntry[]): ProcSnapshot {
+  return {
+    takenAt: Date.now(),
+    processes: processes.map((entry) => ({ ...entry })),
+  };
+}
+
+/**
+ * Capture the current state of an in-memory ProcessTable as a
+ * ProcSnapshot. Only meaningful within the same Node process that
+ * owns the table — for cross-process use (e.g. the CLI), read
+ * persisted records instead (see packages/storage/SnapshotManager).
+ */
+export function takeProcSnapshot(table: ProcessTable): ProcSnapshot {
+  return snapshotFromEntries(table.list());
+}

--- a/packages/kernel/introspection/formatProcTree.ts
+++ b/packages/kernel/introspection/formatProcTree.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 ARCLUX
+ * Copyright 2026 Mikatoshi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,4 +8,66 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: kernel/introspection/formatProcTree — not yet implemented.
+import { ProcessStatus, type ProcessEntry, type ProcessStatusValue } from "../ProcessTable";
+import type { ProcSnapshot } from "./ProcSnapshot";
+
+// Display order: most-actionable states first (errored needs attention,
+// launching/stopping are transient, stopped/online are steady states).
+const STATUS_ORDER: ProcessStatusValue[] = [
+  ProcessStatus.ERRORED,
+  ProcessStatus.LAUNCHING,
+  ProcessStatus.STOPPING,
+  ProcessStatus.ONLINE,
+  ProcessStatus.STOPPED,
+];
+
+function formatEntryLine(entry: ProcessEntry, isLast: boolean): string {
+  const branch = isLast ? "└─" : "├─";
+  const pid = entry.pid !== null ? `pid ${entry.pid}` : "no pid";
+
+  const detail =
+    entry.status === ProcessStatus.ERRORED || entry.status === ProcessStatus.STOPPED
+      ? `exit code ${entry.lastExitCode ?? "unknown"}`
+      : entry.startedAt !== null
+        ? `started ${new Date(entry.startedAt).toLocaleTimeString()}`
+        : "not started";
+
+  const restarts = entry.restarts > 0 ? `, ${entry.restarts} restart${entry.restarts === 1 ? "" : "s"}` : "";
+
+  return `${branch} ${entry.name} (${pid}, ${detail}${restarts})`;
+}
+
+/**
+ * Render a ProcSnapshot as a human-readable tree, grouped by status.
+ *
+ * This is a display concern only — it does not mutate or re-derive
+ * anything from the live ProcessTable, it only formats what's already
+ * in the snapshot. Intended for CLI `ps`/`proc` output and the web
+ * dashboard's process panel.
+ */
+export function formatProcTree(snapshot: ProcSnapshot): string {
+  if (snapshot.processes.length === 0) {
+    return "No processes registered.";
+  }
+
+  const grouped = new Map<ProcessStatusValue, ProcessEntry[]>();
+  for (const entry of snapshot.processes) {
+    const bucket = grouped.get(entry.status) ?? [];
+    bucket.push(entry);
+    grouped.set(entry.status, bucket);
+  }
+
+  const lines: string[] = [`Process snapshot @ ${new Date(snapshot.takenAt).toLocaleTimeString()}`];
+
+  for (const status of STATUS_ORDER) {
+    const entries = grouped.get(status);
+    if (!entries || entries.length === 0) continue;
+
+    lines.push(`${status.toUpperCase()} (${entries.length})`);
+    entries.forEach((entry, i) => {
+      lines.push(formatEntryLine(entry, i === entries.length - 1));
+    });
+  }
+
+  return lines.join("\n");
+}

--- a/packages/runtime/ProcessManager.ts
+++ b/packages/runtime/ProcessManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 ARCLUX
+ * Copyright 2026 Mikatoshi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,11 +43,7 @@ export class ProcessManager {
 
     this.children.set(spec.id, { spec, child });
     this.kernel.updateProcessStatus(spec.id, ProcessStatus.ONLINE);
-    const entry = this.kernel.processTable.get(spec.id);
-    if (entry) {
-      entry.pid = child.pid ?? null;
-      entry.startedAt = Date.now();
-    }
+    this.kernel.setProcessRuntimeInfo(spec.id, { pid: child.pid ?? null, startedAt: Date.now() });
 
     child.stdout?.on("data", (data: Buffer) => {
       this.kernel.signalBus.emit("log:out", { processId: spec.id, name: spec.name, data: data.toString(), at: Date.now() });

--- a/packages/storage/SnapshotManager.ts
+++ b/packages/storage/SnapshotManager.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 ARCLUX
+ * Copyright 2026 Mikatoshi
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -8,4 +8,113 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: storage/SnapshotManager — not yet implemented.
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { ProcessEntry } from "../kernel/ProcessTable";
+
+/**
+ * File-based persistence for kernel process state.
+ *
+ * The Kernel's ProcessTable is in-memory and scoped to a single Node
+ * process. Any command that runs as a separate process (e.g. the CLI's
+ * `ps`) needs a way to see what's registered without sharing memory.
+ *
+ * This module writes one small JSON file per process under
+ * `~/.arclux/pids/<id>.json`, and treats the filesystem as the source
+ * of truth across process boundaries. Reads are always "live-checked":
+ * before returning a record, we confirm the OS still has that PID
+ * running via `process.kill(pid, 0)` (a no-op signal used purely to
+ * test existence — it does not kill anything). Records for PIDs that
+ * are no longer alive are deleted as they're found, so the directory
+ * self-cleans instead of accumulating stale entries left behind by
+ * processes that died without a clean shutdown.
+ */
+
+function arcluxRoot(): string {
+  return process.env.ARCLUX_ROOT || path.join(os.homedir(), ".arclux");
+}
+
+function pidsDir(): string {
+  return path.join(arcluxRoot(), "pids");
+}
+
+function recordPath(id: string): string {
+  return path.join(pidsDir(), `${id}.json`);
+}
+
+function ensurePidsDir(): void {
+  fs.mkdirSync(pidsDir(), { recursive: true });
+}
+
+/**
+ * Returns true if the given pid is currently alive on this machine.
+ * `process.kill(pid, 0)` sends no actual signal — it only asks the OS
+ * whether it *could* deliver one, throwing ESRCH if the pid is gone.
+ */
+function isPidAlive(pid: number | null): boolean {
+  if (pid === null) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Write (or overwrite) the on-disk record for a single process entry. */
+export function writeProcessRecord(entry: ProcessEntry): void {
+  ensurePidsDir();
+  fs.writeFileSync(recordPath(entry.id), JSON.stringify(entry, null, 2), "utf8");
+}
+
+/** Remove the on-disk record for a process, if it exists. */
+export function removeProcessRecord(id: string): void {
+  try {
+    fs.unlinkSync(recordPath(id));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+}
+
+/**
+ * Read every persisted process record, dropping (and deleting) any
+ * whose PID is no longer alive. This is the function CLI/dashboard
+ * code should call to list processes — it never returns a record for
+ * something that has actually died, even if the process itself
+ * crashed before it could clean up its own record.
+ */
+export function readLiveProcessRecords(): ProcessEntry[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(pidsDir());
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const live: ProcessEntry[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const fullPath = path.join(pidsDir(), file);
+
+    let entry: ProcessEntry;
+    try {
+      entry = JSON.parse(fs.readFileSync(fullPath, "utf8"));
+    } catch {
+      // Corrupt or half-written record (e.g. crash mid-write) — remove
+      // it rather than let a bad file crash every future `ps` call.
+      fs.unlinkSync(fullPath);
+      continue;
+    }
+
+    if (isPidAlive(entry.pid)) {
+      live.push(entry);
+    } else {
+      removeProcessRecord(entry.id);
+    }
+  }
+
+  return live;
+}

--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -343,3 +343,9 @@ The ArrowLeft icon next to "This file needs" in GraphFocusView.tsx looked like a
 **Status:** Done
 
 User reported a file with (25) shown in the "affects" header but only a handful of cards visible and scrolling did nothing. Root cause found by reading the actual component code (not guessing from the screenshot): dependencies/dependents arrays were .slice(0, 12) before rendering, with the remainder shown only as static text ("+13 more") -- not a button, not scrollable, permanently unreachable. First fix attempt removed the cap entirely (render all), which surfaced a real follow-up concern from the user: a file with hundreds of affected files would render all of them at once and could make the panel heavy/unusable. Second iteration: replaced the hard cap with INITIAL_VISIBLE=30 + a real clickable expand button per side (not a dead label), with expand state reset via useEffect when selectedNodeId changes so navigating to a new file does not carry over a previous file stay-expanded state. Lesson: match the fix to the actual reported symptom before generalizing -- "remove the cap" and "cap with expand-on-demand" are different designs, worth confirming with the user before defaulting to the simplest read of the bug report.
+
+## 2026-08-13 — ProcessManager pid never persisted, causing ps to always show empty
+
+**Status:** Done
+
+ProcessManager.start() mutated entry.pid/entry.startedAt directly on the in-memory ProcessTable object after spawn, bypassing Kernel's persistence write. The on-disk record kept pid: null forever, so SnapshotManager.readLiveProcessRecords()'s liveness check (process.kill(pid, 0)) always failed and immediately deleted the record. Fixed by adding Kernel.setProcessRuntimeInfo() which mutates and persists atomically; ProcessManager now calls that instead of mutating the table entry directly.

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -485,3 +485,15 @@ packages/kernel/ (ProcessTable, SignalBus, ServiceRegistry, Kernel) dan packages
 **Status:** In Progress
 
 Kernel.ts, ProcessTable.ts, SignalBus.ts, ServiceRegistry.ts, ProcessManager.ts, ProcessSpec.ts, RuntimeManager.ts semua berisi logic asli berdasarkan referensi PM2 (God.js, ForkMode.js). apps/cli/commands/run.ts terhubung ke RuntimeManager sebagai integrasi pertama. Sempat ada insiden git reset --hard yang menghapus kerjaan tanpa sengaja, sudah dipulihkan penuh dan diverifikasi lolos tsc --noEmit. Belum ditest end-to-end (arclux run web belum pernah dijalankan beneran).
+
+## 2026-08-13 — Add process persistence for ps command
+
+**Status:** Done
+
+Kernel now persists ProcessEntry records to ~/.arclux/pids/*.json on register/update (packages/storage/SnapshotManager.ts, new). readLiveProcessRecords() live-checks each PID via process.kill(pid, 0) and self-deletes stale records instead of trusting on-disk state blindly — pattern read from forever's getAllProcesses/getSockets (not copied, re-implemented for file-based instead of socket-based IPC). Kernel.shutdown() now also cleans up its own records. Wired apps/cli/commands/ps.ts to read persisted records directly (CLI runs as a separate process from whatever registered the process, so it can't share Kernel memory) and registered it in apps/cli/index.ts. Added ProcSnapshot.snapshotFromEntries() so both live in-memory ProcessTable and cross-process disk records can produce the same ProcSnapshot shape.
+
+## 2026-08-13 — Cross-process process visibility via file-based persistence
+
+**Status:** Done
+
+Added packages/storage/SnapshotManager.ts: writes one JSON record per process to ~/.arclux/pids/<id>.json on register/update, reads live-check each PID via process.kill(pid, 0) and self-deletes stale records. Pattern read from forever's getAllProcesses/getSockets (see NOTICE), re-implemented with plain files instead of socket IPC. Wired into Kernel.ts (registerProcess/updateProcessStatus/removeProcess/shutdown all persist), packages/kernel/introspection/ProcSnapshot.ts (added snapshotFromEntries for cross-process use), and apps/cli/commands/ps.ts (reads disk records directly, registered in apps/cli/index.ts).


### PR DESCRIPTION
## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
