### PR TITLE
fix(web): make lint pass again (react-hooks/set-state-in-effect, 5 files)

### DIFF
--- a/apps/web/components/graph/AnalyzingProgress.tsx
+++ b/apps/web/components/graph/AnalyzingProgress.tsx
@@ -29,8 +29,11 @@ const STAGES = [
 const STAGE_DURATION_MS = 2500;
 
 export function AnalyzingProgress() {
-  const [stageIndex, setStageIndex] = useState(0);
   const [elapsedMs, setElapsedMs] = useState(0);
+
+  // stageIndex is a pure function of elapsedMs — derive it instead of
+  // syncing it via an effect (react-hooks/set-state-in-effect).
+  const stageIndex = Math.min(STAGES.length - 1, Math.floor(elapsedMs / STAGE_DURATION_MS));
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -38,11 +41,6 @@ export function AnalyzingProgress() {
     }, 100);
     return () => clearInterval(interval);
   }, []);
-
-  useEffect(() => {
-    const nextIndex = Math.min(STAGES.length - 1, Math.floor(elapsedMs / STAGE_DURATION_MS));
-    setStageIndex(nextIndex);
-  }, [elapsedMs]);
 
   const isTakingAWhile = elapsedMs > STAGES.length * STAGE_DURATION_MS + 5000;
 

--- a/apps/web/components/graph/GraphFocusView.tsx
+++ b/apps/web/components/graph/GraphFocusView.tsx
@@ -28,7 +28,7 @@
 "use client";
 
 import { X, ArrowLeft, AlertTriangle } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useGraphContext } from "./GraphProvider";
 import { getGraphNodeColor } from "@/theme/graphColors";
 import { getNodeIconPath } from "./nodeIcons";
@@ -95,10 +95,14 @@ export function GraphFocusView() {
   // Collapse both sides again whenever the focused node changes, so
   // navigating to a new file (via a card click or the back button)
   // doesn't carry over a previous file's "show all" state.
-  useEffect(() => {
+  // React-recommended replacement for a setState-in-effect: adjust state
+  // during render, keyed on the previous prop value.
+  const [prevSelectedNodeId, setPrevSelectedNodeId] = useState(selectedNodeId);
+  if (prevSelectedNodeId !== selectedNodeId) {
+    setPrevSelectedNodeId(selectedNodeId);
     setDepsExpanded(false);
     setDependentsExpanded(false);
-  }, [selectedNodeId]);
+  }
 
   const node = graph?.nodes.find((n) => n.id === selectedNodeId);
   if (!node || !graph || !isFocusPanelOpen) return null;

--- a/apps/web/components/search/GlobalSearch.tsx
+++ b/apps/web/components/search/GlobalSearch.tsx
@@ -59,12 +59,20 @@ export function GlobalSearch({ repoUrl, branch, onSelect }: GlobalSearchProps) {
   const [results, setResults] = useState<SearchResult[]>([])
   const [hasSearched, setHasSearched] = useState(false)
 
-  useEffect(() => {
+  // Reset results when the query becomes empty. Done during render (not in
+  // an effect) per React's "adjusting state when a prop changes" guidance,
+  // avoiding react-hooks/set-state-in-effect.
+  const [prevDebouncedQuery, setPrevDebouncedQuery] = useState(debouncedQuery)
+  if (prevDebouncedQuery !== debouncedQuery) {
+    setPrevDebouncedQuery(debouncedQuery)
     if (!debouncedQuery.trim()) {
       setResults([])
       setHasSearched(false)
-      return
     }
+  }
+
+  useEffect(() => {
+    if (!debouncedQuery.trim()) return
 
     let cancelled = false
     async function run() {

--- a/apps/web/components/workspace/WorkspaceSearch.tsx
+++ b/apps/web/components/workspace/WorkspaceSearch.tsx
@@ -41,12 +41,20 @@ export function WorkspaceSearch({ repoUrl, branch, onSelect }: WorkspaceSearchPr
   const [results, setResults] = useState<SearchResult[]>([])
   const [isOpen, setIsOpen] = useState(false)
 
-  useEffect(() => {
+  // Reset results when the query becomes empty. Done during render (not in
+  // an effect) per React's "adjusting state when a prop changes" guidance,
+  // avoiding react-hooks/set-state-in-effect.
+  const [prevQuery, setPrevQuery] = useState(query)
+  if (prevQuery !== query) {
+    setPrevQuery(query)
     if (!query.trim()) {
       setResults([])
       setIsOpen(false)
-      return
     }
+  }
+
+  useEffect(() => {
+    if (!query.trim()) return
 
     let cancelled = false
     const timer = setTimeout(async () => {

--- a/apps/web/hooks/useTheme.ts
+++ b/apps/web/hooks/useTheme.ts
@@ -15,17 +15,17 @@
 
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useState, useCallback } from "react"
 
 type Theme = "light" | "dark"
 
 export function useTheme() {
-  const [theme, setTheme] = useState<Theme>("dark")
-
-  useEffect(() => {
-    const isDark = document.documentElement.classList.contains("dark")
-    setTheme(isDark ? "dark" : "light")
-  }, [])
+  // layout.tsx's inline init script applies the theme class before hydration,
+  // so reading it in the lazy initializer gives the true initial theme
+  // (dark-first, matches theme/arclux.json) without a sync-setState effect.
+  const [theme, setTheme] = useState<Theme>(() =>
+    typeof document !== "undefined" && document.documentElement.classList.contains("dark") ? "dark" : "light"
+  )
 
   const toggleTheme = useCallback(() => {
     setTheme((prev) => {


### PR DESCRIPTION
## Why

`pnpm run lint` is currently **red on ARCLUX.main** — 5 errors from `react-hooks/set-state-in-effect` across `apps/web`. This unblocks CI for every PR (e.g. it also fails on #301, which is unrelated to `apps/web`).

## Changes (React-recommended replacements, behavior preserved)

| File | Old pattern | New pattern |
|---|---|---|
| `apps/web/hooks/useTheme.ts` | effect reads `document` class → `setTheme` | lazy `useState` initializer reads the class (with `typeof document` guard for SSR) |
| `apps/web/components/graph/AnalyzingProgress.tsx` | `stageIndex` state synced in effect | `stageIndex` **derived** from `elapsedMs` (state removed) |
| `apps/web/components/graph/GraphFocusView.tsx` | effect resets expanded state on `selectedNodeId` change | reset **during render**, keyed on previous `selectedNodeId` (adjust-state-when-prop-changes) |
| `apps/web/components/search/GlobalSearch.tsx` | effect `setResults([])` when query empties | same reset **during render**, keyed on previous debounced query |
| `apps/web/components/workspace/WorkspaceSearch.tsx` | effect `setResults([])`/`setIsOpen(false)` when query empties | same reset **during render**, keyed on previous query |

## Validation

- `pnpm run lint` → **0 errors** (1 pre-existing warning left untouched: `_repository` unused in `apps/web/app/api/analyze/route.ts:56`)
- `npx tsc --noEmit -p apps/web/tsconfig.json` → clean
- `npx vitest run` → 23/23 passed