### PR TITLE
ci: bump workflow actions (Node 24, CodeQL v4) — clear deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run typecheck

--- a/.github/workflows/threatcrush-scan.yml
+++ b/.github/workflows/threatcrush-scan.yml
@@ -20,13 +20,13 @@ jobs:
       # the job — and the rest of this job runs a scanner installed from the
       # network over the contents of a pull request. A token that no step
       # needs should not be sitting in the working tree while that happens.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
 
       # An unretried `npm i -g` is a network call to a registry that decides
       # whether a security gate runs at all. Retry before giving up; a
@@ -161,7 +161,7 @@ jobs:
       - name: Upload to the Security tab
         if: always() && 'true' == 'true'
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: threatcrush.sarif
           category: threatcrush
@@ -246,7 +246,7 @@ jobs:
 
       - name: Upload SARIF artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: threatcrush-sarif
           path: threatcrush.sarif
@@ -261,7 +261,7 @@ jobs:
       - name: Comment on PR
         if: always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Why

Every GitHub Actions run now annotates two warnings on this repo's workflows:

1. **Node.js 20 is deprecated** — `actions/checkout@v4`, `actions/github-script@v7`, `actions/setup-node@v4`, `actions/upload-artifact@v4`, `github/codeql-action/upload-sarif@v3` target Node 20 and are forced onto Node 24.
2. **CodeQL Action v3 deprecated Dec 2026** — use v4.

## Changes

Action versions verified against each project's latest release (2026-08-13):

- `actions/checkout@v4` → **@v7**
- `actions/setup-node@v4` → **@v7**, `node-version: 20` → **24** (both workflows)
- `actions/upload-artifact@v4` → **@v7**
- `actions/github-script@v7` → **@v9** (uses only stable `github.rest.issues.*` + `core` APIs)
- `github/codeql-action/upload-sarif@v3` → **@v4**

Workflow-only change — the threatcrush fail-closed SARIF handling and report/comment rendering are untouched. YAML validated (`python -c "import yaml; yaml.safe_load(...)"`).

Note: `ci.yml` triggers on `pull_request: branches: [main]`, but the repo's default branch is `ARCLUX.main` — so that workflow doesn't currently run; the bumps keep it consistent for when it's wired up.