### PR TITLE
ci: bump pnpm/action-setup to v6 to clear Node 20 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7
         with:
           node-version: 24


### PR DESCRIPTION
pnpm/action-setup@v4 targets Node 20 (deprecated, forced to Node 24 by
runners). v6 (refs/tags/v6, latest v6.0.10) declares runs.using: node24
— same class of fix as #306 for the other actions.
