### PR TITLE
fix(docs): valid MDX for Mintlify — comments to {/* */}, escape prose braces

### DIFF
--- a/docs-site/map/map-apps-web.mdx
+++ b/docs-site/map/map-apps-web.mdx
@@ -47,7 +47,6 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 **Isi folder:**
 
 - `AGENT.md`
-- `README.md`
 - `app`/
 - `components`/
 - `components.json`
@@ -55,13 +54,13 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 - `features`/
 - `hooks`/
 - `lib`/
-- `next-env.d.ts`
 - `next.config.ts`
 - `node_modules`/
 - `package-lock.json`
 - `package.json`
 - `postcss.config.mjs`
 - `public`/
+- `README.md`
 - `theme`/
 - `tsconfig.json`
 - `tsconfig.tsbuildinfo`

--- a/docs-site/map/map-packages-db.mdx
+++ b/docs-site/map/map-packages-db.mdx
@@ -12,7 +12,6 @@ _Tidak ada package.json (bukan package standar Node)._
 **Isi folder:**
 
 - `client.ts`
-- `migrations`/
 - `repositories`/
 - `schema.ts`
 

--- a/docs-site/map/map-packages-kernel.mdx
+++ b/docs-site/map/map-packages-kernel.mdx
@@ -11,10 +11,10 @@ _Tidak ada package.json (bukan package standar Node)._
 
 **Isi folder:**
 
+- `introspection`/
 - `Kernel.ts`
 - `ProcessTable.ts`
 - `ServiceRegistry.ts`
 - `SignalBus.ts`
-- `introspection`/
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-rules.mdx
+++ b/docs-site/map/map-packages-rules.mdx
@@ -11,12 +11,12 @@ _Tidak ada package.json (bukan package standar Node)._
 
 **Isi folder:**
 
-- `RuleEngine.ts`
 - `electron`/
 - `express`/
 - `nestjs`/
 - `nextjs`/
 - `react`/
+- `RuleEngine.ts`
 - `vite`/
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/map/map-packages-search.mdx
+++ b/docs-site/map/map-packages-search.mdx
@@ -11,12 +11,12 @@ _Tidak ada package.json (bukan package standar Node)._
 
 **Isi folder:**
 
+- `fuzzyScore.ts`
 - `SearchEngine.ts`
 - `SearchFilters.ts`
 - `SearchIndex.ts`
 - `SearchKeyboard.ts`
 - `SearchProvider.ts`
 - `SearchResults.ts`
-- `fuzzyScore.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/progres/progres-bugs.mdx
+++ b/docs-site/progres/progres-bugs.mdx
@@ -205,10 +205,10 @@ Done and merged to main this session:
 
 STILL NOT DONE - call graph (packages/graph/buildCallGraph.ts):
 Planned but not implemented yet. Design decided:
-- RawCall { calleeName, line } added to ParsedFile as OPTIONAL field
+- RawCall &#123; calleeName, line &#125; added to ParsedFile as OPTIONAL field
   (calls?), since 7 other parsers - Go, Java, Python, TS, etc - build
   ParsedFile literals without it and would break if it were required.
-- ResolvedCall { moduleId, calleeName, line } plus calls/calledBy fields
+- ResolvedCall &#123; moduleId, calleeName, line &#125; plus calls/calledBy fields
   added to ModuleInfo as REQUIRED (only buildIndex.ts constructs
   ModuleInfo, so safe to make required there).
 - Known limitation to document in code: extractCallsJs will only catch
@@ -307,7 +307,7 @@ Deeper investigation of the zero-edges issue: exportCount is 0 for literally eve
 
 **Status:** Not Started
 
-Traced further: return { file, imports, exports, warnings } at the normal path DOES call extractExports() correctly. The exports:[] seen is only in the catch block (parse failure fallback). Need to check: is getPythonRuntime() or parser.parse() throwing silently for mscodebase-intelligence's files? Check warnings array in actual API response next -- if warnings has a 'Failed to parse' message, that confirms it. Not checked yet.
+Traced further: return &#123; file, imports, exports, warnings &#125; at the normal path DOES call extractExports() correctly. The exports:[] seen is only in the catch block (parse failure fallback). Need to check: is getPythonRuntime() or parser.parse() throwing silently for mscodebase-intelligence's files? Check warnings array in actual API response next -- if warnings has a 'Failed to parse' message, that confirms it. Not checked yet.
 
 ## 2026-08-09 — extractExports() in parsePython.ts skipped decorated top-level definitions
 

--- a/docs-site/progres/progres-collaborators.mdx
+++ b/docs-site/progres/progres-collaborators.mdx
@@ -28,13 +28,13 @@ description: "Detail progres: collaborators"
 
 ## Active assignments
 
-<!-- Format:
+{/* Format:
 ### [username] — issue #N
 - **Task**: one-line summary
 - **Files**: which file(s) this covers
 - **Status**: not started / in progress / PR open (#N) / blocked on X
 - **Assigned**: date
--->
+*/}
 
 ### mwakidenis — issue #147
 - **Task**: Implement 3 remaining apps/web/hooks stubs
@@ -68,9 +68,9 @@ CODEOWNERS if/when they become active again.
 
 ## Completed
 
-<!-- Move entries here once merged, keep the same format, add:
+{/* Move entries here once merged, keep the same format, add:
 - **Merged**: PR #N, date
--->
+*/}
 
 ## 2026-08-08 — mwakidenis contributed CITATION.cff unprompted
 

--- a/docs-site/progres/progres-decisions.mdx
+++ b/docs-site/progres/progres-decisions.mdx
@@ -89,9 +89,9 @@ node kinds apart. Impact must be a SEPARATE visual signal layered on top
 **Implementation plan, in order**:
 
 1. In `apps/web/components/graph/GraphProvider.tsx`: add a `useMemo`
-   that, whenever `graph` changes, builds `Map&lt;nodeId, number>` by
+   that, whenever `graph` changes, builds `Map<nodeId, number>` by
    iterating `graph.edges` and counting occurrences of each `edge.target`.
-   Expose this as a new `importCounts: Map&lt;string, number>` field on
+   Expose this as a new `importCounts: Map<string, number>` field on
    `GraphContextValue` (add to both the interface and the `value` object
    near the bottom of the file, same pattern as the existing `positions`
    field).
@@ -111,12 +111,12 @@ node kinds apart. Impact must be a SEPARATE visual signal layered on top
    real repos of different sizes, e.g. python-demo vs vscode vs next.js,
    since "100 importers" means very different things in a 50-file repo
    vs a 15,000-file repo). For High/Medium tiers, render an additional
-   `&lt;circle>` halo BEHIND the existing node circle (larger radius, no
+   `<circle>` halo BEHIND the existing node circle (larger radius, no
    fill, a neutral stroke color like white or amber at low opacity --
    NOT reusing graphNodeColors, since that would collide with the
    type-color meaning). Consider also scaling BASE_RADIUS slightly for
    High-tier nodes. Existing isSelected halo logic
-   (`{isSelected && &lt;circle r={radius + 5} ... />}`) is a useful
+   (`{isSelected && <circle r={radius + 5} ... />}`) is a useful
    reference for the halo-circle pattern already used in this file --
    don't duplicate logic, structure the new halo consistently with it.
 
@@ -283,7 +283,7 @@ The Contributors section (contrib.rocks avatar grid) was intentionally removed f
 
 **Status:** In Progress
 
-Discussed but not yet started: extend the zoomScale-gating pattern already used for the impact halo (GraphNode.tsx, MIN_ZOOM_FOR_HALO) to also gate label/icon visibility at low zoom, reducing DOM/render load when zoomed out on large graphs. Rough plan discussed: very low zoom (&lt;0.5) hides icon+label entirely (node becomes a plain dot), mid zoom (0.5-1) keeps current behavior (label only on select/hover), high zoom (>=1) optionally always shows labels for high-importance nodes. Checked reactflow-ref's Stress example for a reference pattern first -- it's a performance benchmarking harness, not an LOD implementation (React Flow handles this internally, not via example code), so no direct pattern to borrow. This is a natural extension of existing code (GraphNode.tsx's opacity={isSelected || isHovered ? ...} pattern at the label render, ~line 104), not a new subsystem. Prioritized as step 1 of 3 general performance directions discussed (graph viewer LOD/canvas rendering, pipeline parallelization+caching, new analysis features) -- graph viewer was picked first since it's the most immediately felt by users and doesn't overlap with collaborator-assigned work (call graph is assigned to xcontcom via issue #50).
+Discussed but not yet started: extend the zoomScale-gating pattern already used for the impact halo (GraphNode.tsx, MIN_ZOOM_FOR_HALO) to also gate label/icon visibility at low zoom, reducing DOM/render load when zoomed out on large graphs. Rough plan discussed: very low zoom (&lt;0.5) hides icon+label entirely (node becomes a plain dot), mid zoom (0.5-1) keeps current behavior (label only on select/hover), high zoom (>=1) optionally always shows labels for high-importance nodes. Checked reactflow-ref's Stress example for a reference pattern first -- it's a performance benchmarking harness, not an LOD implementation (React Flow handles this internally, not via example code), so no direct pattern to borrow. This is a natural extension of existing code (GraphNode.tsx's opacity=&#123;isSelected || isHovered ? ...&#125; pattern at the label render, ~line 104), not a new subsystem. Prioritized as step 1 of 3 general performance directions discussed (graph viewer LOD/canvas rendering, pipeline parallelization+caching, new analysis features) -- graph viewer was picked first since it's the most immediately felt by users and doesn't overlap with collaborator-assigned work (call graph is assigned to xcontcom via issue #50).
 
 ## 2026-08-07 — Cache package design research (packages/cache)
 
@@ -300,7 +300,7 @@ Researched before implementing packages/cache (CacheProvider.ts, fileCache.ts, g
 Studied ~/dependency-cruiser/src/cache/ as reference (NOT for copying, for architecture ideas -- user explicitly wants ARCLUX's cache to be MORE capable than this reference, not simplified). Key findings:
 - Two invalidation strategies: MetadataStrategy (git-diff based via watskeburt/getSHA -- fast, no file reads, just asks git what changed since last SHA) vs ContentStrategy (per-file checksum comparison -- works without git but has to hash every file). MetadataStrategy is the better fit for ARCLUX since packages/git and packages/watcher already do git-diff based watching -- reuse that instead of hashing.
 - Cache format has an explicit CACHE_FORMAT_VERSION constant (numeric, bumped on breaking changes) so an old cache from a previous ARCLUX version gets safely invalidated instead of returning corrupt/incompatible results.
-- Cache dirtiness is scoped precisely: they maintain an explicit list of which CLI options/config changes should 100% invalidate cache vs which only invalidate a subset. ARCLUX equivalent: analyzeRepository({repoUrl, branch, ...}) options that affect output (branch, exclude patterns, etc) should be part of the cache key/invalidation check.
+- Cache dirtiness is scoped precisely: they maintain an explicit list of which CLI options/config changes should 100% invalidate cache vs which only invalidate a subset. ARCLUX equivalent: analyzeRepository(&#123;repoUrl, branch, ...&#125;) options that affect output (branch, exclude patterns, etc) should be part of the cache key/invalidation check.
 - brotli compression at min quality (faster than gzip, still better ratio) used for on-disk cache storage, sync not async (sync is faster in this context and avoids promisifying zlib).
 
 NEXT STEPS for actually implementing packages/cache (not done yet):
@@ -360,7 +360,7 @@ Idea discussed, not started: ARCLUX's engine/ (analyzeRepository()) already retu
 
 **Status:** Not Started
 
-Collaborator ManSio reviewed parsePython.ts + scanFiles.ts, found 4 potential issues, NONE verified yet by us: (1) relative imports with leading dots 'from ..utils import X' may not resolve correctly if tree-sitter strips the dots before resolvePath.ts sees it — highest priority, likely to produce wrong edges on real repos. (2) parsePython.ts has zero test files, unlike Go/Rust parsers. (3) scanFiles.ts has catch{} blocks that silently drop unreadable files with no warning — same class as the wasm silent-failure gotcha. (4) wasmPath in parsePython.ts is hardcoded to a pnpm-specific node_modules path (.pnpm/tree-sitter-wasms@version/...) — will silently fail under npm/yarn installs. Next session: verify each against parsePython.ts/scanFiles.ts directly before fixing anything, per usual verification standard (cat/grep the actual code, don't just trust the review).
+Collaborator ManSio reviewed parsePython.ts + scanFiles.ts, found 4 potential issues, NONE verified yet by us: (1) relative imports with leading dots 'from ..utils import X' may not resolve correctly if tree-sitter strips the dots before resolvePath.ts sees it — highest priority, likely to produce wrong edges on real repos. (2) parsePython.ts has zero test files, unlike Go/Rust parsers. (3) scanFiles.ts has catch&#123;&#125; blocks that silently drop unreadable files with no warning — same class as the wasm silent-failure gotcha. (4) wasmPath in parsePython.ts is hardcoded to a pnpm-specific node_modules path (.pnpm/tree-sitter-wasms@version/...) — will silently fail under npm/yarn installs. Next session: verify each against parsePython.ts/scanFiles.ts directly before fixing anything, per usual verification standard (cat/grep the actual code, don't just trust the review).
 
 ## 2026-08-11 — Cytoscape.js researched as UI/UX reference for graph rendering
 
@@ -385,7 +385,7 @@ rather than building new abstractions speculatively. See
 roadmap.md's "Core Principle" — this is that principle applied to
 process, not just architecture.
 
-### LAB 1 — `arclux diff &lt;refA> &lt;refB> [repoPath]`
+### LAB 1 — `arclux diff <refA> <refB> [repoPath]`
 
 New files: `packages/diff/types.ts`, `gitDiff.ts`, `architecturalDiff.ts`,
 `apps/cli/diff.ts`. Registered in `apps/cli/index.ts`.

--- a/docs-site/progres/progres-status-backlog.mdx
+++ b/docs-site/progres/progres-status-backlog.mdx
@@ -9,6 +9,16 @@ description: "Detail progres: status backlog"
 
 See PROGRES.md for the index. Split by topic from the original PROGRES-status.md.
 
+## 2026-08-13 — UPDATE: framework rule stubs — implemented
+
+All 10 remaining rule stubs in `packages/rules/*` (nextjs x4, nestjs x2,
+express, vite, electron x2) are now implemented, wired into
+`apps/cli/verify.ts` and `packages/engine/contract.ts` (13 rules total,
+react/requirePropsTyping remains a documented deferral). Test coverage
+for issue #8 completed: graph, impact, indexer, pipeline, and per-language
+parser suites — 141 tests / 20 files, vitest green. See the old entry
+below for the historical stub list.
+
 ## 2026-08-03 — ❌ STILL EMPTY (8-line stub, license header only)
 
 **Priority #1 — core feature — NOTE: this was previously miscategorized,

--- a/docs-site/progres/progres-status-core.mdx
+++ b/docs-site/progres/progres-status-core.mdx
@@ -171,7 +171,7 @@ dynamic import(), require(), and per-property CommonJS
 (module.exports.x = / exports.x =).
 
 KNOWN GAP, NOT YET FIXED: whole-object exports
-(module.exports = { a, b }) are NOT detected -- only per-property
+(module.exports = &#123; a, b &#125;) are NOT detected -- only per-property
 assignment is. This under-reports exports for a lot of real-world
 CommonJS. Confirmed common via nodejs/cjs-module-lexer's own test fixtures
 (~/research/cjs-module-lexer/test/_unit.js) during research for this
@@ -275,13 +275,13 @@ own readDependencyNames() (package.json only, flat Set&lt;string>) still runs
 separately and hasn't been merged with this new ManifestDependency-based
 system — that's a follow-up, not done here.
 
-**Gotcha hit while building this**: a `cat > file &lt;&lt; EOF` heredoc run
+**Gotcha hit while building this**: a `cat > file << EOF` heredoc run
 while `cd`'d into ~/manifest-samples instead of ~/arclux silently created
 packages/parser/rust/parseCargoToml.ts under ~/manifest-samples/packages/...
 instead of overwriting the real file — the real ~/arclux file kept its
 old (buggy, pre-fix) content even though the terminal showed no error.
 Caught only because testManifests.ts's output (13 deps) didn't match the
-expected fix. Lesson: always `pwd` before a `cat > path &lt;&lt; EOF` if you've
+expected fix. Lesson: always `pwd` before a `cat > path << EOF` if you've
 `cd`'d anywhere else in the same session — a wrong-directory heredoc
 fails silently, it doesn't error.
 
@@ -375,8 +375,8 @@ the single hop `ModuleInfo.resolvedReExports` already covers (documented
 limitation in `types.ts`'s own doc comment). Walks the chain per
 export name until it hits a non-re-export origin, with cycle detection
 (stops at last resolvable hop if a cycle is found). Inherits the same
-aliased-re-export limitation as `resolvedReExports` itself (`export {
-foo as bar }` — name tracking breaks across hops since `RawExport` only
+aliased-re-export limitation as `resolvedReExports` itself (`export &#123;
+foo as bar &#125;` — name tracking breaks across hops since `RawExport` only
 stores the final name) — documented in-file, not fixed here, needs parser
 layer changes.
 

--- a/docs-site/progres/progres-status-web.mdx
+++ b/docs-site/progres/progres-status-web.mdx
@@ -99,7 +99,7 @@ only), never written at all.
 Design: AnalyzeRepositoryResult now carries a `repository` field (a full
 Repository instance, NOT a plain object). IMPORTANT — this field is
 server-side only. Repository.modules is a private Map, so if
-JSON.stringify'd as-is it silently becomes {} (not a crash, silent data
+JSON.stringify'd as-is it silently becomes &#123;&#125; (not a crash, silent data
 loss). apps/web/app/api/analyze/route.ts (which has worked for a while)
 was patched to strip the `repository` field before responding, so the
 JSON shape doesn't silently change now that this field exists.
@@ -133,7 +133,7 @@ interactive ones, `cn()` from `@/lib/cn`, primitives from
   primitives from `components/ui/`, with props APIs matched exactly to
   the real shape (`DialogContent`, `SheetContent side="bottom"`, etc. —
   checked from vendor-ui source first, not guessed).
-- `DataTable` is built from a native `&lt;table>` + Tailwind — there's no
+- `DataTable` is built from a native `<table>` + Tailwind — there's no
   shadcn `table.tsx` primitive in `vendor-ui/` yet.
 - `FilterBar` deliberately does not use `Badge` (not yet wrapped in
   `components/ui/`, still an open item from `detectMissingExports`),
@@ -186,8 +186,8 @@ Fixes:
 - `apps/web/components/graph/GraphEdge.tsx` — highlighted edges now show
   an arrowhead (SVG marker) and a type label ("imports"/"exports"/
   "calls"/"routes to") at the midpoint.
-- `apps/web/components/graph/GraphCanvas.tsx` — registers 4 `&lt;marker>`
-  defs (one per edge type) in `&lt;defs>`, referenced by GraphEdge via
+- `apps/web/components/graph/GraphCanvas.tsx` — registers 4 `<marker>`
+  defs (one per edge type) in `<defs>`, referenced by GraphEdge via
   `markerEnd`.
 
 **Known limitation, not fixed in this change**: line endpoints are node
@@ -245,13 +245,13 @@ same caveat as the earlier edge-label/arrow update.
 by testing it against ourselves earlier) — this was pushed via
 `feat/graph-focus-view` branch + PR, not direct push. Any future session:
 you CANNOT `git push` directly to `main` anymore, always
-`git checkout -b &lt;branch>` first.
+`git checkout -b <branch>` first.
 
 ## 2026-08-05 — Update -- components/workspace/* 8 stub files are now DONE
 
 Wrote all 8 files: Workspace.tsx (composition root), WorkspaceHeader.tsx,
 WorkspaceCommand.tsx, WorkspaceSearch.tsx, WorkspaceSwitcher.tsx, and
-panels/{Files,Impact,Issues}Panel.tsx.
+panels/&#123;Files,Impact,Issues&#125;Panel.tsx.
 
 Reference used: browsed ~/git-truck/src/routes/view.tsx and RevisionSelect.tsx
 for composition/dropdown-switcher PATTERNS only (concept, not code -- that

--- a/docs-site/stack.mdx
+++ b/docs-site/stack.mdx
@@ -160,7 +160,7 @@ git diff main..<your-branch> --stat
 ```
 
 Read the output. If a file shows a lot of unexpected `-` (deletions),
-check the actual diff content (`git diff main..&lt;branch> -- &lt;file>`)
+check the actual diff content (`git diff main..<branch> -- <file>`)
 before continuing -- it might be overwriting something important.
 
 After merging, **always** verify locally again:

--- a/docs-site/tooling.mdx
+++ b/docs-site/tooling.mdx
@@ -160,7 +160,7 @@ git diff main..<your-branch> --stat
 ```
 
 Read the output. If a file shows a lot of unexpected `-` (deletions),
-check the actual diff content (`git diff main..&lt;branch> -- &lt;file>`)
+check the actual diff content (`git diff main..<branch> -- <file>`)
 before continuing -- it might be overwriting something important.
 
 After merging, **always** verify locally again:

--- a/scripts/generate-docs-mintlify.js
+++ b/scripts/generate-docs-mintlify.js
@@ -39,6 +39,14 @@ function mdxSafe(text) {
 
   out = out.replace(/<!--/g, '\u0000CMTOPEN\u0000').replace(/-->/g, '\u0000CMTCLOSE\u0000');
 
+  // Inline code (single backticks): braces di dalamnya literal — lindungi dari
+  // brace-escape di bawah, biar tidak jadi &#123; (entity tidak didecode di code span).
+  const inlineCode = [];
+  out = out.replace(/`[^`\n]+`/g, (m) => {
+    inlineCode.push(m);
+    return `\u0000CODE${inlineCode.length - 1}\u0000`;
+  });
+
   // Proteksi tag komponen Mintlify: <Card ...>, </Card>, <CardGroup cols={2}>, <Tabs>, dll.
   // Konvensi Mintlify: nama komponen selalu diawali huruf kapital.
   const jsxTags = [];
@@ -47,10 +55,18 @@ function mdxSafe(text) {
     return `\u0000JSX${jsxTags.length - 1}\u0000`;
   });
 
+  // Kurung kurawal di teks biasa diparse MDX sebagai ekspresi JSX (acorn gagal
+  // pada `...` dst) — escape. Ekspresi di dalam JSX tag yang dilindungi
+  // (<Card cols={2}>) dikembalikan mentah dan tetap hidup.
+  out = out.replace(/\{/g, '&#123;').replace(/\}/g, '&#125;');
+
   out = out.replace(/</g, '&lt;');
 
   out = out.replace(/\u0000JSX(\d+)\u0000/g, (m, i) => jsxTags[Number(i)]);
-  out = out.replace(/\u0000CMTOPEN\u0000/g, '<!--').replace(/\u0000CMTCLOSE\u0000/g, '-->');
+  out = out.replace(/\u0000CODE(\d+)\u0000/g, (m, i) => inlineCode[Number(i)]);
+  // HTML comment <!-- --> tidak valid di MDX (Mintlify menolaknya saat deploy) —
+  // kembalikan sebagai MDX comment {/* ... */}.
+  out = out.replace(/\u0000CMTOPEN\u0000/g, '{/*').replace(/\u0000CMTCLOSE\u0000/g, '*/}');
   out = out.replace(/\u0000AUTOLINK(\d+)\u0000/g, (m, i) => autolinks[Number(i)]);
   out = out.replace(/\u0000FENCE(\d+)\u0000/g, (m, i) => fenceBlocks[Number(i)]);
 


### PR DESCRIPTION
## What changed

Fix `scripts/generate-docs-mintlify.js` so generated Mintlify docs deploy without MDX parse errors:

- HTML comments `<!-- -->` are emitted as MDX comments `{/* */}` — Mintlify's MDX parser rejects raw HTML comments ("Unexpected character !")
- Literal braces in prose are escaped to `&#123;`/`&#125;` — previously parsed as JSX expressions (acorn fails on `...`); inline code and Mintlify component tags are protected
- Regenerated `docs-site/` (12 pages); bonus fix: `&lt;` inside code spans is now proper `<`

Fixes the "Updated deployment with errors" on `docs-site/progres/progres-collaborators.mdx` and `docs-site/progres/progres-decisions.mdx`.

## How was this verified

- Generator run twice — idempotent
- No `<!--` left in docs-site; MDX comments balanced; no raw braces outside code/comments/JSX tags
- Mintlify Deployment check on this PR should show "Deployment Succeeded" without "Updated deployment with errors"

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web) — N/A (docs + generator script)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline) — N/A
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file — N/A
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry — N/A
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable — N/A
- [ ] Tested on Termux (or noted why not applicable) — N/A (docs generator, no runtime code)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
