### PR TITLE
ci(docs): enable GitHub Pages automatically via configure-pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,6 +34,8 @@ jobs:
         run: pnpm build
         working-directory: docs-site
       - uses: actions/configure-pages@v6
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v5
         with:
           path: docs-site/build


### PR DESCRIPTION
## What changed

`deploy-docs.yml`: add `enablement: true` to `actions/configure-pages@v6`.

First deploy run failed at configure-pages ('Get Pages site failed') because the repo has Pages disabled. The action can enable Pages itself (GitHub Actions source) using the workflow token — no manual admin step required.