### PR TITLE
fix(storage): break circular dependency storage<->kernel (issue #312)

### DIFF
--- a/packages/kernel/ProcessTable.ts
+++ b/packages/kernel/ProcessTable.ts
@@ -8,28 +8,20 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-export const ProcessStatus = {
-  LAUNCHING: "launching",
-  ONLINE: "online",
-  STOPPING: "stopping",
-  STOPPED: "stopped",
-  ERRORED: "errored",
-} as const;
+// ProcessStatus/ProcessStatusValue/ProcessEntry moved to packages/shared/types.ts
+// (2026-08-14, issue #312) — re-exported here so existing kernel importers stay
+// unchanged. Storage imports them directly from shared to break the package cycle.
+import {
+  ProcessStatus,
+  type ProcessStatusValue,
+  type ProcessEntry,
+} from "../shared/types";
 
-export type ProcessStatusValue = (typeof ProcessStatus)[keyof typeof ProcessStatus];
-
-export interface ProcessEntry {
-  id: string;
-  pid: number | null;
-  name: string;
-  command: string;
-  args: string[];
-  cwd: string;
-  status: ProcessStatusValue;
-  startedAt: number | null;
-  restarts: number;
-  lastExitCode: number | null;
-}
+export {
+  ProcessStatus,
+  type ProcessStatusValue,
+  type ProcessEntry,
+} from "../shared/types";
 
 export class ProcessTable {
   private entries = new Map<string, ProcessEntry>();

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -71,6 +71,40 @@ export interface RawExport {
   line: number;
 }
 
+// ─────────────────────────────────────────────
+// Process runtime (kernel + storage)
+// ─────────────────────────────────────────────
+
+/**
+ * Lifecycle states of an internal service process, PM2-inspired.
+ * Moved here from packages/kernel/ProcessTable.ts (2026-08-14) so
+ * packages/storage can persist process records without importing from
+ * packages/kernel — fixes issue #312 (storage <-> kernel package cycle).
+ */
+export const ProcessStatus = {
+  LAUNCHING: "launching",
+  ONLINE: "online",
+  STOPPING: "stopping",
+  STOPPED: "stopped",
+  ERRORED: "errored",
+} as const;
+
+export type ProcessStatusValue = (typeof ProcessStatus)[keyof typeof ProcessStatus];
+
+/** One tracked process in the runtime's process table / persisted pid record. */
+export interface ProcessEntry {
+  id: string;
+  pid: number | null;
+  name: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  status: ProcessStatusValue;
+  startedAt: number | null;
+  restarts: number;
+  lastExitCode: number | null;
+}
+
 /**
  * Output of a single file parse. This is the CONTRACT every language parser
  * (parseJs, parseTs, parsePython, ...) must return, regardless of language.

--- a/packages/storage/SnapshotManager.ts
+++ b/packages/storage/SnapshotManager.ts
@@ -11,7 +11,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import type { ProcessEntry } from "../kernel/ProcessTable";
+import type { ProcessEntry } from "../shared/types";
 
 /**
  * File-based persistence for kernel process state.


### PR DESCRIPTION
## What changed

Fixes #312 — package-level circular dependency `packages/storage <-> packages/kernel`.

**Cycle:** `packages/kernel/Kernel.ts` imports `writeProcessRecord`/`removeProcessRecord` from `storage/SnapshotManager.ts` (value), while `storage/SnapshotManager.ts` imports `type ProcessEntry` from `kernel/ProcessTable.ts` — closing the loop at package level.

**Fix:** move `ProcessStatus` / `ProcessStatusValue` / `ProcessEntry` from `packages/kernel/ProcessTable.ts` into `packages/shared/types.ts` (the project's mandated home for shared data shapes — the file header requires all packages to use types from there). `ProcessTable.ts` re-exports them so existing kernel importers (`Kernel.ts`, `ProcSnapshot.ts`, `formatProcTree.ts`, `ProcessManager.ts`) stay unchanged; `SnapshotManager.ts` now imports `ProcessEntry` from `shared/types`.

## How was this verified

- `pnpm run typecheck` (web) + `tsc -p apps/cli/tsconfig.json` — clean
- `vitest run` — 141/141 passed
- Self-analysis (`arclux analyze .` + `detectRepositoryPattern`): **0 package-level cycle findings** (both #2 and #312 cycles gone)

## Checklist

- [x] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [x] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
- [x] `grep`-sweep: zero remaining `storage -> kernel` imports
- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web) — N/A (packages only)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline) — N/A
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file — N/A
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry — N/A (types move, no status change)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable — N/A
- [ ] Tested on Termux (or noted why not applicable) — N/A (TS packages, no runtime-specific code)
