### PR TITLE
fix(incremental): break module cycles via structural types in types.ts

### DIFF
--- a/packages/incremental/types.ts
+++ b/packages/incremental/types.ts
@@ -6,15 +6,23 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-import type { Cell } from "./Cell";
-import type { Query } from "./Query";
-
 /**
  * A reference to something a Query read during computation — either a raw
  * Cell or another Query's cached result at a specific key. Recorded by
  * Database.recordRead() and later used to check whether a cached result
  * is still valid (see Query.isStillValid).
+ *
+ * The cell/query fields use minimal structural types (not the classes
+ * themselves) so this module stays an import-free leaf — importing Cell
+ * and Query here created module cycles Cell↔Database↔types↔Cell and
+ * Database↔types↔Query↔Database (flagged by detectCircularDependency).
+ * The shapes match exactly what Query.isStillValid() calls on them.
  */
 export type DepRef =
-  | { kind: "cell"; cell: Cell<unknown> }
-  | { kind: "query"; query: Query<unknown[], unknown>; key: string; args: unknown[] };
+  | { kind: "cell"; cell: { getRevision(): number } }
+  | {
+      kind: "query";
+      query: { ensureUpToDateAndGetRevision(key: string, args: unknown[]): number };
+      key: string;
+      args: unknown[];
+    };


### PR DESCRIPTION
## What changed

Breaks the three module-level circular dependencies in `packages/incremental` flagged by `detectCircularDependency`:

- `Cell <-> Database <-> types <-> Cell`
- `Database <-> types <-> Query <-> Database`
- `types <-> Query <-> types`

**Root cause:** `packages/incremental/types.ts` imported the `Cell` and `Query` classes to type the `DepRef` union — creating back-edges from the leaf-ish types module into the classes.

**Fix:** `DepRef` now uses minimal **structural types** — exactly the shapes `Query.isStillValid()` calls on them (`cell.getRevision()`, `query.ensureUpToDateAndGetRevision(key, args)`). `types.ts` is now an import-free leaf of the module graph; `Cell.ts` / `Database.ts` / `Query.ts` are unchanged (their imports stay one-directional).

## How was this verified

- `pnpm run typecheck` (web) + `tsc -p apps/cli/tsconfig.json` — clean
- `vitest run` — 141/141 passed
- Self-analysis (`detectCircularDependency` on the repo): module cycles **8 → 5**; the 3 incremental cycles are gone. The remaining 5 are the **intentional** `playground/*-demo/cyclicA↔B` fixtures used to test the cycle detector.

## Checklist

- [x] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [x] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web) — N/A (packages only)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline) — N/A
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file — N/A
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry — N/A (type-only change)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable — N/A
- [ ] Tested on Termux (or noted why not applicable) — N/A (TS types, no runtime behavior change)
