### PR TITLE
[feat] Implement scheduler: JobState, Job, JobQueue, JobScheduler usi…

### DIFF
--- a/packages/scheduler/Job.ts
+++ b/packages/scheduler/Job.ts
@@ -1,11 +1,52 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Pattern reference: Linux kernel include/linux/workqueue.h's struct
+// delayed_work (deferred execution via a target time) and WQ_HIGHPRI
+// (priority jumps the queue instead of strict FIFO).
 
-// Scaffold: scheduler/Job — not yet implemented.
+export type JobPriority = "high" | "normal";
+
+export interface Job {
+  id: string;
+  name: string;
+  priority: JobPriority;
+  /** the work itself */
+  run: () => Promise<void>;
+  /**
+   * epoch ms this job should not run before. Undefined means "runnable
+   * immediately" -- mirrors workqueue.h's plain work_struct vs delayed_work
+   * distinction, but as one type with an optional field rather than two.
+   */
+  notBefore?: number;
+}
+
+export interface CreateJobOptions {
+  name: string;
+  run: () => Promise<void>;
+  priority?: JobPriority;
+  /** delay in ms before this job becomes runnable */
+  delayMs?: number;
+}
+
+let jobCounter = 0;
+
+export function createJob(options: CreateJobOptions): Job {
+  jobCounter += 1;
+  return {
+    id: `job-${Date.now()}-${jobCounter}`,
+    name: options.name,
+    priority: options.priority ?? "normal",
+    run: options.run,
+    notBefore: options.delayMs ? Date.now() + options.delayMs : undefined,
+  };
+}
+
+export function isJobRunnable(job: Job, now: number = Date.now()): boolean {
+  return job.notBefore === undefined || job.notBefore <= now;
+}

--- a/packages/scheduler/JobQueue.ts
+++ b/packages/scheduler/JobQueue.ts
@@ -1,11 +1,64 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Pattern reference: Linux kernel include/linux/workqueue.h's WQ_HIGHPRI
+// (high-priority work jumps the queue) and the "ordered" workqueue_attrs
+// flag (work items must execute strictly in queueing order).
 
-// Scaffold: scheduler/JobQueue — not yet implemented.
+import type { Job } from "./Job";
+import { isJobRunnable } from "./Job";
+
+export interface JobQueueOptions {
+  /** if true, dequeue() always returns jobs in insertion order, ignoring priority */
+  ordered?: boolean;
+}
+
+export class JobQueue {
+  private jobs: Job[] = [];
+  private readonly ordered: boolean;
+
+  constructor(options: JobQueueOptions = {}) {
+    this.ordered = options.ordered ?? false;
+  }
+
+  enqueue(job: Job): void {
+    this.jobs.push(job);
+  }
+
+  /**
+   * Returns and removes the next runnable job. High-priority jobs jump
+   * ahead of normal-priority ones (mirrors WQ_HIGHPRI), unless this queue
+   * is in ordered mode, in which case strict insertion order applies
+   * regardless of priority (mirrors the "ordered" workqueue_attrs flag).
+   * Jobs with a future notBefore are skipped until runnable.
+   */
+  dequeue(now: number = Date.now()): Job | null {
+    const runnableIndices = this.jobs
+      .map((job, i) => ({ job, i }))
+      .filter(({ job }) => isJobRunnable(job, now));
+
+    if (runnableIndices.length === 0) return null;
+
+    let chosen = runnableIndices[0];
+    if (!this.ordered) {
+      const highPriority = runnableIndices.find(({ job }) => job.priority === "high");
+      if (highPriority) chosen = highPriority;
+    }
+
+    this.jobs.splice(chosen.i, 1);
+    return chosen.job;
+  }
+
+  peekAll(): Job[] {
+    return [...this.jobs];
+  }
+
+  get size(): number {
+    return this.jobs.length;
+  }
+}

--- a/packages/scheduler/JobScheduler.ts
+++ b/packages/scheduler/JobScheduler.ts
@@ -1,11 +1,69 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Pattern reference: Linux kernel include/linux/workqueue.h's max_active
+// (cap on in-flight work items) -- jobs beyond the cap wait in JobQueue
+// instead of all firing at once. CPU-affinity/NUMA pool concepts from the
+// same file deliberately NOT ported -- not applicable here.
 
-// Scaffold: scheduler/JobScheduler — not yet implemented.
+import type { Job } from "./Job";
+import { JobQueue } from "./JobQueue";
+import { JobStatus, createJobState, transitionJobState, type JobStateEntry } from "./JobState";
+
+export interface JobSchedulerOptions {
+  /** max jobs running concurrently, mirrors workqueue's max_active */
+  maxActive?: number;
+  ordered?: boolean;
+}
+
+export class JobScheduler {
+  private queue: JobQueue;
+  private readonly maxActive: number;
+  private states = new Map<string, JobStateEntry>();
+  private runningCount = 0;
+
+  constructor(options: JobSchedulerOptions = {}) {
+    this.queue = new JobQueue({ ordered: options.ordered });
+    this.maxActive = options.maxActive ?? 4;
+  }
+
+  schedule(job: Job): void {
+    this.queue.enqueue(job);
+    this.states.set(job.id, createJobState(job.id, job.notBefore ? JobStatus.DELAYED : JobStatus.PENDING));
+    this.drain();
+  }
+
+  getState(jobId: string): JobStateEntry | undefined {
+    return this.states.get(jobId);
+  }
+
+  /** Pulls runnable jobs off the queue until maxActive is reached or the queue is empty. */
+  private drain(): void {
+    while (this.runningCount < this.maxActive) {
+      const job = this.queue.dequeue();
+      if (!job) break;
+      this.runJob(job);
+    }
+  }
+
+  private async runJob(job: Job): Promise<void> {
+    this.runningCount += 1;
+    this.states.set(job.id, transitionJobState(this.states.get(job.id)!, JobStatus.RUNNING));
+
+    try {
+      await job.run();
+      this.states.set(job.id, transitionJobState(this.states.get(job.id)!, JobStatus.DONE));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.states.set(job.id, transitionJobState(this.states.get(job.id)!, JobStatus.FAILED, message));
+    } finally {
+      this.runningCount -= 1;
+      this.drain();
+    }
+  }
+}

--- a/packages/scheduler/JobState.ts
+++ b/packages/scheduler/JobState.ts
@@ -1,11 +1,39 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Pattern reference: Linux kernel kernel/workqueue.c + include/linux/workqueue.h
+// (queue -> execute -> done lifecycle, priority, delayed work, ordered mode).
+// Concurrency-management/CPU-affinity concepts (NUMA, cpumask, per-CPU pools)
+// deliberately NOT ported -- not applicable to a single-process Node scheduler.
 
-// Scaffold: scheduler/JobState — not yet implemented.
+export const JobStatus = {
+  PENDING: "pending",
+  DELAYED: "delayed",
+  RUNNING: "running",
+  DONE: "done",
+  FAILED: "failed",
+} as const;
+
+export type JobStatusValue = (typeof JobStatus)[keyof typeof JobStatus];
+
+export interface JobStateEntry {
+  jobId: string;
+  status: JobStatusValue;
+  /** epoch ms this state was entered */
+  since: number;
+  /** set only when status is FAILED */
+  error?: string;
+}
+
+export function createJobState(jobId: string, status: JobStatusValue = JobStatus.PENDING): JobStateEntry {
+  return { jobId, status, since: Date.now() };
+}
+
+export function transitionJobState(entry: JobStateEntry, status: JobStatusValue, error?: string): JobStateEntry {
+  return { ...entry, status, since: Date.now(), error };
+}


### PR DESCRIPTION
…ng Linux workqueue.c pattern (max_active concurrency cap, priority, delayed jobs, ordered mode)

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
