### PR TITLE
Security capability layer

### DIFF
--- a/packages/runtime/ProcessManager.ts
+++ b/packages/runtime/ProcessManager.ts
@@ -1,17 +1,20 @@
-/**
- * Copyright 2026 Mikatoshi
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
 import { spawn, type ChildProcess } from "node:child_process";
 import type { Kernel } from "../kernel/Kernel";
 import { ProcessStatus } from "../kernel/ProcessTable";
 import type { ProcessSpec } from "./ProcessSpec";
+import { JobScheduler } from "../scheduler/JobScheduler";
+import { createJob } from "../scheduler/Job";
+import { Sandbox } from "../security/Sandbox";
+import { PermissionManager } from "../security/PermissionManager";
+import { Capability } from "../security/Capability";
 
 interface TrackedChild {
   spec: ProcessSpec;
@@ -20,10 +23,27 @@ interface TrackedChild {
 
 export class ProcessManager {
   private children = new Map<string, TrackedChild>();
+  // Restart jobs go through JobScheduler with exponential backoff, instead of
+  // restarting instantly, to avoid crash-loop (a process erroring every <1s
+  // would otherwise busy-loop restart attempts). Pattern from Linux workqueue's
+  // delayed_work, see packages/scheduler/Job.ts.
+  private restartScheduler = new JobScheduler({ maxActive: 1 });
+  // Enforces capability checks before a process is allowed to spawn.
+  // See packages/security/Sandbox.ts -- ported from Linux capability.h's
+  // granular-permission model.
+  readonly permissions = new PermissionManager();
+  private sandbox = new Sandbox(this.permissions);
 
   constructor(private readonly kernel: Kernel) {}
 
   start(spec: ProcessSpec): void {
+    // Grant default capabilities on first start. Callers wanting a tighter
+    // policy should call this.permissions.grant() themselves BEFORE start().
+    if (!this.permissions.getCapabilitySet(spec.id)) {
+      this.permissions.grant(spec.id, [Capability.EXEC, Capability.ENV_WRITE, Capability.IPC_SEND, Capability.PROCESS_KILL]);
+    }
+    this.sandbox.enforce(spec);
+
     this.kernel.registerProcess({
       id: spec.id,
       pid: null,
@@ -69,7 +89,18 @@ export class ProcessManager {
 
       if (shouldRestart) {
         this.kernel.processTable.incrementRestarts(spec.id);
-        this.start(spec);
+        const restartCount = this.kernel.processTable.get(spec.id)?.restarts ?? 1;
+        // Exponential backoff: 1s, 2s, 4s, 8s... capped at 30s.
+        const delayMs = Math.min(30_000, 1_000 * 2 ** (restartCount - 1));
+        this.restartScheduler.schedule(
+          createJob({
+            name: `restart:${spec.name}`,
+            delayMs,
+            run: async () => {
+              this.start(spec);
+            },
+          })
+        );
       }
     });
 

--- a/packages/security/Capability.ts
+++ b/packages/security/Capability.ts
@@ -1,11 +1,83 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Pattern reference: Linux include/uapi/linux/capability.h. Two ideas
+// ported: (1) granular named capabilities instead of a single root/non-root
+// bit, (2) the three-set model (permitted / effective / inheritable).
+// Hardware/kernel-specific capabilities (CAP_NET_ADMIN, CAP_SYS_BOOT,
+// CAP_MKNOD, etc) deliberately NOT ported -- ARCLUX processes are Node
+// child processes (see packages/runtime/ProcessSpec.ts), not kernel-level
+// actors. Capabilities here map to what a ProcessSpec can actually do:
+// run a command, read/write a working directory, read/inject env vars.
 
-// Scaffold: security/Capability — not yet implemented.
+export const Capability = {
+  /** run the process's command at all */
+  EXEC: "exec",
+  /** read files under the process's cwd */
+  FS_READ: "fs:read",
+  /** write files under the process's cwd */
+  FS_WRITE: "fs:write",
+  /** read the process's own env vars */
+  ENV_READ: "env:read",
+  /** inject/override env vars for the process */
+  ENV_WRITE: "env:write",
+  /** send IPC messages to the process (see ProcessManager.send) */
+  IPC_SEND: "ipc:send",
+  /** kill/stop the process */
+  PROCESS_KILL: "process:kill",
+} as const;
+
+export type CapabilityValue = (typeof Capability)[keyof typeof Capability];
+
+/**
+ * Three-set model, mirrors struct __user_cap_data_struct's
+ * permitted/effective/inheritable split:
+ * - permitted: capabilities this subject is ALLOWED to hold
+ * - effective: capabilities CURRENTLY active (must be a subset of permitted)
+ * - inheritable: capabilities passed down to spawned child processes
+ */
+export interface CapabilitySet {
+  permitted: Set<CapabilityValue>;
+  effective: Set<CapabilityValue>;
+  inheritable: Set<CapabilityValue>;
+}
+
+export function createCapabilitySet(permitted: CapabilityValue[] = []): CapabilitySet {
+  const permittedSet = new Set(permitted);
+  return {
+    permitted: permittedSet,
+    effective: new Set(permittedSet),
+    inheritable: new Set(),
+  };
+}
+
+export function hasCapability(set: CapabilitySet, cap: CapabilityValue): boolean {
+  return set.effective.has(cap);
+}
+
+/** Drop a capability from effective (and permitted, matching Linux: once dropped from permitted it can't be re-added without a fresh grant). */
+export function dropCapability(set: CapabilitySet, cap: CapabilityValue): CapabilitySet {
+  const permitted = new Set(set.permitted);
+  const effective = new Set(set.effective);
+  permitted.delete(cap);
+  effective.delete(cap);
+  return { ...set, permitted, effective };
+}
+
+/** Mark a capability as inheritable, so child processes spawned from this subject receive it. */
+export function markInheritable(set: CapabilitySet, cap: CapabilityValue): CapabilitySet {
+  if (!set.permitted.has(cap)) return set;
+  const inheritable = new Set(set.inheritable);
+  inheritable.add(cap);
+  return { ...set, inheritable };
+}
+
+/** Derive the capability set a child process inherits from its parent -- only the inheritable subset becomes the child's permitted+effective set. */
+export function deriveChildCapabilitySet(parent: CapabilitySet): CapabilitySet {
+  return createCapabilitySet([...parent.inheritable]);
+}

--- a/packages/security/PermissionManager.ts
+++ b/packages/security/PermissionManager.ts
@@ -1,11 +1,65 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Maps a process id (see packages/runtime/ProcessSpec.ts) to its
+// CapabilitySet, and provides the check/require entry points other
+// packages should call instead of touching CapabilitySet/PolicyEngine
+// directly. Mirrors how Kernel.ts is the single entry point wrapping
+// ProcessTable/SignalBus/ServiceRegistry.
 
-// Scaffold: security/PermissionManager — not yet implemented.
+import {
+  createCapabilitySet,
+  deriveChildCapabilitySet,
+  type CapabilitySet,
+  type CapabilityValue,
+} from "./Capability";
+import { evaluate, requireCapability, type PolicyDecision } from "./PolicyEngine";
+
+export class PermissionManager {
+  private sets = new Map<string, CapabilitySet>();
+
+  /** Grant a process id a capability set. Call once, typically alongside Kernel.registerProcess. */
+  grant(processId: string, capabilities: CapabilityValue[]): CapabilitySet {
+    const set = createCapabilitySet(capabilities);
+    this.sets.set(processId, set);
+    return set;
+  }
+
+  /** Grant a process the capability set inherited from a parent process's inheritable set. */
+  grantFromParent(processId: string, parentProcessId: string): CapabilitySet {
+    const parentSet = this.sets.get(parentProcessId);
+    const childSet = parentSet ? deriveChildCapabilitySet(parentSet) : createCapabilitySet();
+    this.sets.set(processId, childSet);
+    return childSet;
+  }
+
+  revoke(processId: string): boolean {
+    return this.sets.delete(processId);
+  }
+
+  check(processId: string, capability: CapabilityValue): PolicyDecision {
+    const set = this.sets.get(processId);
+    if (!set) {
+      return { allowed: false, capability, reason: `no capability set registered for process "${processId}"` };
+    }
+    return evaluate(set, capability);
+  }
+
+  /** Throws if the process doesn't have the capability. */
+  require(processId: string, capability: CapabilityValue): void {
+    const set = this.sets.get(processId);
+    if (!set) {
+      throw new Error(`Policy violation: no capability set registered for process "${processId}"`);
+    }
+    requireCapability(set, capability);
+  }
+
+  getCapabilitySet(processId: string): CapabilitySet | undefined {
+    return this.sets.get(processId);
+  }
+}

--- a/packages/security/PolicyEngine.ts
+++ b/packages/security/PolicyEngine.ts
@@ -1,11 +1,43 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Evaluates whether an action is allowed given a CapabilitySet. Deliberately
+// simple (no MAC/LSM-style pluggable policy modules like Linux's
+// CAP_MAC_OVERRIDE/CAP_MAC_ADMIN suggest) -- ARCLUX has one policy model,
+// not a framework for swapping policy backends.
 
-// Scaffold: security/PolicyEngine — not yet implemented.
+import { hasCapability, type CapabilitySet, type CapabilityValue } from "./Capability";
+
+export interface PolicyDecision {
+  allowed: boolean;
+  capability: CapabilityValue;
+  reason: string;
+}
+
+export function evaluate(set: CapabilitySet, capability: CapabilityValue): PolicyDecision {
+  const allowed = hasCapability(set, capability);
+  return {
+    allowed,
+    capability,
+    reason: allowed
+      ? `"${capability}" is in the effective capability set`
+      : `"${capability}" is not in the effective capability set`,
+  };
+}
+
+/** Evaluates multiple capabilities at once, all must be allowed. */
+export function evaluateAll(set: CapabilitySet, capabilities: CapabilityValue[]): PolicyDecision[] {
+  return capabilities.map((cap) => evaluate(set, cap));
+}
+
+export function requireCapability(set: CapabilitySet, capability: CapabilityValue): void {
+  const decision = evaluate(set, capability);
+  if (!decision.allowed) {
+    throw new Error(`Policy violation: ${decision.reason}`);
+  }
+}

--- a/packages/security/Sandbox.ts
+++ b/packages/security/Sandbox.ts
@@ -1,11 +1,52 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Enforces PermissionManager checks at the point a process is about to
+// actually spawn/act, instead of relying on callers to remember to check.
+// This is the integration point ProcessManager.start() should call
+// through, mirroring how packages/diagnostics wraps detectors instead of
+// callers running detectors ad hoc.
 
-// Scaffold: security/Sandbox — not yet implemented.
+import type { ProcessSpec } from "../runtime/ProcessSpec";
+import { PermissionManager } from "./PermissionManager";
+import { Capability } from "./Capability";
+
+export interface SandboxCheckResult {
+  allowed: boolean;
+  denied: string[];
+}
+
+export class Sandbox {
+  constructor(private readonly permissions: PermissionManager) {}
+
+  /**
+   * Checks whether a ProcessSpec is allowed to run, based on what it
+   * actually needs: EXEC always, ENV_WRITE if spec.env is set (it's
+   * injecting/overriding env vars for the child).
+   */
+  checkSpec(spec: ProcessSpec): SandboxCheckResult {
+    const required = [Capability.EXEC];
+    if (spec.env && Object.keys(spec.env).length > 0) {
+      required.push(Capability.ENV_WRITE);
+    }
+
+    const denied = required.filter((cap) => !this.permissions.check(spec.id, cap).allowed);
+
+    return { allowed: denied.length === 0, denied };
+  }
+
+  /** Throws if the spec is not allowed to run. Call this at the top of ProcessManager.start(). */
+  enforce(spec: ProcessSpec): void {
+    const result = this.checkSpec(spec);
+    if (!result.allowed) {
+      throw new Error(
+        `Sandbox: process "${spec.id}" denied -- missing capabilities: ${result.denied.join(", ")}`
+      );
+    }
+  }
+}


### PR DESCRIPTION
Implements packages/security/ (Capability, PolicyEngine, PermissionManager, Sandbox) using Linux capability.h's granular-permission + permitted/effective/inheritable model, scoped to what a ProcessSpec can do (exec, fs read/write, env read/write, ipc, kill). Wires Sandbox.enforce() into ProcessManager.start() so processes are capability-checked before spawn. Also re-applies the scheduler backoff patch (JobScheduler) to ProcessManager.ts since ARCLUX.main's copy was missing it (main/ARCLUX.main divergence).