### PR TITLE
[feat] Add packages/change/: ChangePlan, PatchSet, ChangeExecutor (mi…

### DIFF
--- a/packages/change/ChangeExecutor.ts
+++ b/packages/change/ChangeExecutor.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Applies a ChangePlan's PatchSet to disk. Does not write directly --
+// every file goes through packages/storage/RecoveryManager's
+// writeTransactional(), so a crash mid-apply can recover via
+// recoverFromJournal() instead of leaving a half-written repo.
+
+import { writeTransactional } from "../storage/RecoveryManager";
+import type { ChangePlan } from "./ChangePlan";
+
+export interface ChangeExecutionResult {
+  planId: string;
+  filesWritten: string[];
+  failedFiles: { filePath: string; error: string }[];
+}
+
+export function executeChangePlan(plan: ChangePlan): ChangeExecutionResult {
+  const filesWritten: string[] = [];
+  const failedFiles: { filePath: string; error: string }[] = [];
+
+  for (const patch of plan.patchSet.patches) {
+    try {
+      writeTransactional(patch.filePath, patch.newContent);
+      filesWritten.push(patch.filePath);
+    } catch (err) {
+      failedFiles.push({
+        filePath: patch.filePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { planId: plan.id, filesWritten, failedFiles };
+}

--- a/packages/change/ChangePlan.ts
+++ b/packages/change/ChangePlan.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import type { PatchSet } from "./PatchSet";
+
+export interface ChangePlan {
+  id: string;
+  intent: string;
+  patchSet: PatchSet;
+  affectedModuleIds: string[];
+  createdAt: number;
+}
+
+export function createChangePlan(
+  intent: string,
+  patchSet: PatchSet,
+  affectedModuleIds: string[],
+): ChangePlan {
+  return {
+    id: crypto.randomUUID(),
+    intent,
+    patchSet,
+    affectedModuleIds,
+    createdAt: Date.now(),
+  };
+}

--- a/packages/change/PatchSet.ts
+++ b/packages/change/PatchSet.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+export interface FilePatch {
+  filePath: string;
+  originalContent: string;
+  newContent: string;
+}
+
+export interface PatchSet {
+  id: string;
+  patches: FilePatch[];
+  createdAt: number;
+}
+
+export function createPatchSet(patches: FilePatch[]): PatchSet {
+  return { id: crypto.randomUUID(), patches, createdAt: Date.now() };
+}

--- a/progres/decisions.md
+++ b/progres/decisions.md
@@ -829,3 +829,9 @@ an issue when a contributor picks it up. Known limitations documented
 in the code: default-imported callees unresolvable, `obj.foo()` /
 `this.foo()` not captured (AST-only, no type info).
 ARCLUX.main
+
+## 2026-08-14 — packages/change: new protocol for applying changes, not workstation duplicate
+
+**Status:** In Progress
+
+GPT proposed packages/workstation/ duplicating existing editor/language/terminal/scheduler packages. Corrected to: keep existing high-level packages as-is, add packages/change/ (ChangePlan, PatchSet, ChangeExecutor) as a new cross-cutting protocol any caller (editor, CLI, future assistant) can use to propose+apply changes. ChangeExecutor writes via storage/RecoveryManager.writeTransactional(), not fs directly. Scaffolded minimal 3-file vertical slice first; PatchPreview/ChangeVerifier deferred until a real caller needs them.


### PR DESCRIPTION
…nimal slice)

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
