### PR TITLE
feat: /api/doctor + IssuesPanel — 19-detector suite exposed over HTTP

### DIFF
--- a/apps/web/app/api/doctor/route.ts
+++ b/apps/web/app/api/doctor/route.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { analyzeRepository } from "@/packages/engine/pipeline";
+import { runDoctor } from "@/packages/engine/runDoctor";
+import { isArcluxError } from "@/packages/shared/errors";
+
+/** Maps internal ArcluxErrorCode to an HTTP status — mirrors /api/analyze */
+function statusForErrorCode(code: string): number {
+  switch (code) {
+    case "NOT_FOUND":
+      return 404;
+    case "UNSUPPORTED_LANGUAGE":
+      return 422;
+    case "CLONE_FAILED":
+    case "PARSE_FAILED":
+    case "INDEX_FAILED":
+    case "GRAPH_BUILD_FAILED":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+interface DoctorRequestBody {
+  repoUrl: string;
+  branch?: string;
+}
+
+/**
+ * POST /api/doctor { repoUrl, branch? }
+ *
+ * Runs the full 19-detector suite server-side (packages/engine/runDoctor.ts
+ * — the HTTP counterpart of `arclux doctor`) and returns the findings
+ * normalized to { checkId, severity, filePath?, message } plus severity
+ * counts. Same no-cache cost as /api/analyze: full clone + index per call.
+ */
+export async function POST(request: NextRequest) {
+  let body: DoctorRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.repoUrl || typeof body.repoUrl !== "string") {
+    return NextResponse.json({ error: "`repoUrl` is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await analyzeRepository({
+      repoUrl: body.repoUrl,
+      branch: body.branch,
+    });
+
+    const doctor = runDoctor(result.repository);
+
+    return NextResponse.json({ repoUrl: body.repoUrl, ...doctor }, { status: 200 });
+  } catch (err) {
+    if (isArcluxError(err)) {
+      return NextResponse.json(
+        { error: err.message, code: err.code, filePath: err.filePath },
+        { status: statusForErrorCode(err.code) }
+      );
+    }
+    console.error("Unexpected error in /api/doctor:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/web/components/workspace/Workspace.tsx
+++ b/apps/web/components/workspace/Workspace.tsx
@@ -70,7 +70,7 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
                 <ImpactPanel repoUrl={repoUrl} moduleId={selectedModuleId} />
               </TabsContent>
               <TabsContent value="issues" className="flex-1 overflow-auto">
-                <IssuesPanel />
+                <IssuesPanel repoUrl={repoUrl} branch={branch} />
               </TabsContent>
             </Tabs>
           }

--- a/apps/web/components/workspace/panels/IssuesPanel.tsx
+++ b/apps/web/components/workspace/panels/IssuesPanel.tsx
@@ -6,24 +6,150 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-import { EmptyState } from "@/components/patterns/EmptyState"
+"use client";
+
+import { useEffect, useState } from "react";
+import { postJson } from "@/lib/api";
+import { LoadingState } from "@/components/patterns/LoadingState";
+import { ErrorState } from "@/components/patterns/ErrorState";
+import { EmptyState } from "@/components/patterns/EmptyState";
+import type { DoctorFinding, DoctorSeverity } from "@/packages/engine/runDoctor";
+
+export interface IssuesPanelProps {
+  repoUrl: string;
+  branch?: string;
+}
+
+interface DoctorResponse {
+  repoUrl: string;
+  findings: DoctorFinding[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}
+
+const SEVERITY_STYLE: Record<DoctorSeverity, string> = {
+  error: "bg-red-500",
+  warning: "bg-yellow-500",
+  info: "bg-neutral-500",
+};
+
+const SEVERITY_LABEL: Record<DoctorSeverity, string> = {
+  error: "error",
+  warning: "warning",
+  info: "info",
+};
+
+function FindingRow({ finding }: { finding: DoctorFinding }) {
+  return (
+    <li className="flex items-start gap-2 rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2">
+      <span
+        className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${SEVERITY_STYLE[finding.severity]}`}
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <code className="text-xs text-neutral-400">{finding.checkId}</code>
+          <span className="text-[10px] uppercase tracking-wide text-neutral-600">
+            {SEVERITY_LABEL[finding.severity]}
+          </span>
+          {finding.filePath && (
+            <code className="truncate font-mono text-xs text-neutral-300">{finding.filePath}</code>
+          )}
+        </div>
+        <p className="mt-0.5 text-xs text-neutral-400">{finding.message}</p>
+      </div>
+    </li>
+  );
+}
 
 /**
- * STATUS: honest placeholder, not real data. Deliberately NOT faking
- * detector findings here -- there is no /api/issues or /api/doctor route
- * (apps/web/app/api only has analyze/file/graph/impact/search). The
- * detector logic itself is complete (packages/detectors/*, 18/18, see
- * PROGRES-status.md) and already runs via `apps/cli doctor`, but nothing
- * exposes it over HTTP for the web UI yet. Follow-up work: add an
- * /api/doctor route that runs the detector suite server-side and returns
- * findings[], then wire this panel to render them (grouped by severity,
- * similar to ImpactSummary's severity badges).
+ * Workspace Issues tab: renders detector findings from POST /api/doctor
+ * (packages/engine/runDoctor.ts — the 19-detector suite normalized to one
+ * flat list), grouped error → warning → info. Replaces the honest
+ * "no issues panel yet" placeholder; see that file's old comment for the
+ * reasoning that led here.
  */
-export function IssuesPanel() {
+export function IssuesPanel({ repoUrl, branch }: IssuesPanelProps) {
+  const [data, setData] = useState<DoctorResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [retryCount, setRetryCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await postJson<DoctorResponse>("/api/doctor", { repoUrl, branch });
+        if (!cancelled) setData(result);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to run detector suite");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoUrl, branch, retryCount]);
+
+  if (isLoading) return <LoadingState label="Running detectors..." />;
+  if (error || !data) {
+    return (
+      <ErrorState
+        title="Could not run detectors"
+        message={error ?? "No data returned from /api/doctor."}
+        onRetry={() => setRetryCount((count) => count + 1)}
+      />
+    );
+  }
+
+  const bySeverity = (severity: DoctorSeverity) =>
+    data.findings.filter((finding) => finding.severity === severity);
+
+  if (data.findings.length === 0) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          title="No issues found"
+          message="The detector suite ran clean against this repository."
+        />
+      </div>
+    );
+  }
+
   return (
-    <EmptyState
-      title="No issues panel yet"
-      message="Detector findings aren't exposed over the API yet -- see IssuesPanel.tsx for what's needed."
-    />
-  )
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-3 border-b border-neutral-800 px-4 py-2.5 text-sm">
+        <span className="font-medium text-red-400">{data.errorCount} errors</span>
+        <span className="text-yellow-400">{data.warningCount} warnings</span>
+        <span className="text-neutral-500">{data.infoCount} info</span>
+      </div>
+      <div className="flex-1 space-y-2 overflow-y-auto p-3">
+        {(["error", "warning", "info"] as const).map((severity) => {
+          const findings = bySeverity(severity);
+          if (findings.length === 0) return null;
+          return (
+            <section key={severity}>
+              <h3 className="mb-1.5 px-1 text-[10px] font-semibold uppercase tracking-wide text-neutral-500">
+                {SEVERITY_LABEL[severity]} ({findings.length})
+              </h3>
+              <ul className="space-y-1.5">
+                {findings.map((finding, index) => (
+                  <FindingRow key={`${finding.checkId}-${index}`} finding={finding} />
+                ))}
+              </ul>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
 }

--- a/docs-site/map/map-packages-engine.mdx
+++ b/docs-site/map/map-packages-engine.mdx
@@ -22,5 +22,6 @@ _Tidak ada package.json (bukan package standar Node)._
 - `generateReport.ts`
 - `generateSummary.ts`
 - `pipeline.ts`
+- `runDoctor.ts`
 
 _Tidak ada file entry point (index.ts/js) ditemukan._

--- a/docs-site/progres/progres-status-web.mdx
+++ b/docs-site/progres/progres-status-web.mdx
@@ -290,6 +290,11 @@ Real vs honest-placeholder breakdown:
   doctor`, but nothing exposes them over HTTP yet -- needs a new
   /api/doctor route.
 
+> **[STATUS UPDATE, 2026-08-14]: resolved — /api/doctor exists
+> (packages/engine/runDoctor.ts, all 19 detectors normalized to one flat
+> finding list) and IssuesPanel renders it grouped by severity. See
+> "IssuesPanel + /api/doctor" below.**
+
 Verification: npx tsc --noEmit -p apps/web/tsconfig.json clean (only the
 2 pre-existing file-tree.tsx errors, unrelated). NOT yet verified
 visually in-browser -- Workspace.tsx is not wired into any app/ route yet
@@ -485,3 +490,25 @@ never leaves the server); lib/api.ts gained a `postJson` helper. Verified
 live: /api/analyze on ARCLUX → 533 modules, folderTree root 8 children,
 packages/ 36 children; overview page HTTP 200; tsc 0, eslint 0. Not
 visually verified in a real browser (standard gap).
+
+## 2026-08-14 — IssuesPanel + /api/doctor (workspace Issues tab is now real)
+
+**Status:** Done
+
+- `packages/engine/runDoctor.ts` (new): runs all 19 detectors and
+  normalizes every finding to `&#123; checkId, severity, filePath?, message
+  &#125;` — the HTTP counterpart of `arclux doctor`'s terminal print.
+  Severity per family: structural = error, hygiene/conventions =
+  warning, informational classifiers (entryPoints, sharedModules, pure
+  barrels) = info; ambiguous symbols map high→error, medium/low→warning.
+- `POST /api/doctor` (new route): analyzeRepository → runDoctor →
+  `{ repoUrl, findings, errorCount, warningCount, infoCount }`.
+- `IssuesPanel` (was an honest "no issues panel yet" placeholder):
+  fetches /api/doctor, renders findings grouped error → warning → info
+  with severity dots + checkId + filePath + message; loading/error/retry
+  states. `Workspace.tsx` passes repoUrl/branch through.
+- Verified live: POST /api/doctor on GSF-001/ARCLUX → 200, 1203 findings
+  (767 errors — real data: 4 circular deps incl. playground fixtures,
+  432 unused exports, 326 orphans; 386 warnings; 50 info). 6 unit tests
+  (tests/runDoctor.test.ts); tsc 0, eslint 0, vitest 202/202. Not
+  visually verified in a real browser (standard gap).

--- a/packages/engine/runDoctor.ts
+++ b/packages/engine/runDoctor.ts
@@ -1,0 +1,190 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Server-side detector suite, normalized to one flat finding list — the
+// HTTP counterpart of `arclux doctor` (apps/cli/doctor.ts prints the same
+// detectors to a terminal; this module feeds /api/doctor and anything
+// else that needs detector findings as data, not text).
+//
+// Runs ALL 19 detectors. Each detector's native finding shape is mapped
+// to a DoctorFinding { checkId, severity, filePath?, message }. Severity
+// is assigned per detector family (structural problems = error, hygiene/
+// conventions = warning, informational classifiers = info); ambiguous
+// symbols carry their own per-finding severity.
+
+import type { Repository } from "../repository/Repository";
+import { detectCircularDependency } from "../detectors/detectCircularDependency";
+import { detectUnusedExports } from "../detectors/detectUnusedExports";
+import { detectOrphanFiles } from "../detectors/detectOrphanFiles";
+import { detectLargeModules } from "../detectors/detectLargeModules";
+import { detectDuplicateModules } from "../detectors/detectDuplicateModules";
+import { detectSharedModules } from "../detectors/detectSharedModules";
+import { detectIndexFiles } from "../detectors/detectIndexFiles";
+import { detectLayerViolation } from "../detectors/detectLayerViolation";
+import { detectDeadCode } from "../detectors/detectDeadCode";
+import { detectAmbiguousSymbolResolution } from "../detectors/detectAmbiguousSymbolResolution";
+import { detectComponentConvention } from "../detectors/detectComponentConvention";
+import { detectFeatureStructure } from "../detectors/detectFeatureStructure";
+import { detectMissingExports } from "../detectors/detectMissingExports";
+import { detectRepositoryPattern } from "../detectors/detectRepositoryPattern";
+import { detectRouteConvention } from "../detectors/detectRouteConvention";
+import { detectStoryConvention } from "../detectors/detectStoryConvention";
+import { detectTestConvention } from "../detectors/detectTestConvention";
+import { detectUnusedFiles } from "../detectors/detectUnusedFiles";
+import { detectEntryPoints } from "../detectors/detectEntryPoints";
+
+export type DoctorSeverity = "error" | "warning" | "info";
+
+export interface DoctorFinding {
+  checkId: string;
+  severity: DoctorSeverity;
+  /** Best-effort location: filePath, featurePath, or cycle string. */
+  filePath?: string;
+  message: string;
+}
+
+export interface RunDoctorResult {
+  findings: DoctorFinding[];
+  errorCount: number;
+  warningCount: number;
+  infoCount: number;
+}
+
+/** Location of a convention finding, mirroring doctor.ts's selection order. */
+function locationOf(f: Record<string, unknown>): string | undefined {
+  if ("filePath" in f && typeof f.filePath === "string") return f.filePath;
+  if ("featurePath" in f && typeof f.featurePath === "string") return f.featurePath;
+  if ("cycle" in f && Array.isArray(f.cycle)) return (f.cycle as string[]).join(" \u2192 ");
+  return undefined;
+}
+
+export function runDoctor(repository: Repository): RunDoctorResult {
+  const findings: DoctorFinding[] = [];
+
+  // ── error: structural problems ──────────────────────────────
+  for (const c of detectCircularDependency(repository)) {
+    findings.push({
+      checkId: "circularDependency",
+      severity: "error",
+      message: c.cycle.join(" \u2192 "),
+    });
+  }
+  for (const f of detectUnusedExports(repository)) {
+    findings.push({
+      checkId: "unusedExports",
+      severity: "error",
+      filePath: f.filePath,
+      message: `${f.exportName} (${f.exportKind}, line ${f.line}) \u2014 ${f.message}`,
+    });
+  }
+  for (const f of detectOrphanFiles(repository)) {
+    findings.push({
+      checkId: "orphanFiles",
+      severity: "error",
+      filePath: f.filePath,
+      message: f.message,
+    });
+  }
+  for (const f of detectLayerViolation(repository)) {
+    findings.push({
+      checkId: "layerViolation",
+      severity: "error",
+      filePath: f.filePath,
+      message: `imports ${f.importedFilePath} [${f.ruleName}] at line ${f.line} \u2014 ${f.message}`,
+    });
+  }
+  for (const f of detectAmbiguousSymbolResolution(repository)) {
+    findings.push({
+      checkId: "ambiguousSymbolResolution",
+      severity: f.severity === "high" ? "error" : "warning",
+      message: `${f.symbolName} — ${f.reason}; definitions: ${f.definitions
+        .map((d) => `${d.modulePath}:${d.line} (${d.category})`)
+        .join(", ")}`,
+    });
+  }
+
+  // ── warning: hygiene / conventions ──────────────────────────
+  for (const f of detectLargeModules(repository)) {
+    findings.push({
+      checkId: "largeModules",
+      severity: "warning",
+      filePath: f.filePath,
+      message: `${f.sizeBytes.toLocaleString()} bytes \u2014 ${f.message}`,
+    });
+  }
+  for (const g of detectDuplicateModules(repository)) {
+    findings.push({
+      checkId: "duplicateModules",
+      severity: "warning",
+      message: `${g.filePaths.join(", ")} (${g.sizeBytes.toLocaleString()} bytes each)`,
+    });
+  }
+  for (const f of detectIndexFiles(repository)) {
+    findings.push({
+      checkId: "indexFiles",
+      severity: f.isPureBarrel ? "info" : "warning",
+      filePath: f.filePath,
+      message: f.message,
+    });
+  }
+  for (const f of detectDeadCode(repository)) {
+    findings.push({
+      checkId: "deadCode",
+      severity: "warning",
+      filePath: f.filePath,
+      message: `${f.unusedExportCount} unused export(s), imported by ${f.importedByCount} \u2014 ${f.message}`,
+    });
+  }
+
+  const conventionDetectors: Array<{ checkId: string; run: () => unknown[] }> = [
+    { checkId: "componentConvention", run: () => detectComponentConvention(repository) },
+    { checkId: "featureStructure", run: () => detectFeatureStructure(repository) },
+    { checkId: "missingExports", run: () => detectMissingExports(repository) },
+    { checkId: "repositoryPattern", run: () => detectRepositoryPattern(repository) },
+    { checkId: "routeConvention", run: () => detectRouteConvention(repository) },
+    { checkId: "storyConvention", run: () => detectStoryConvention(repository) },
+    { checkId: "testConvention", run: () => detectTestConvention(repository) },
+    { checkId: "unusedFiles", run: () => detectUnusedFiles(repository) },
+  ];
+  for (const { checkId, run } of conventionDetectors) {
+    for (const finding of run()) {
+      const f = finding as Record<string, unknown>;
+      findings.push({
+        checkId,
+        severity: "warning",
+        filePath: locationOf(f),
+        message: typeof f.message === "string" ? f.message : JSON.stringify(finding),
+      });
+    }
+  }
+
+  // ── info: informational classifiers ─────────────────────────
+  for (const f of detectSharedModules(repository)) {
+    findings.push({
+      checkId: "sharedModules",
+      severity: "info",
+      filePath: f.filePath,
+      message: `imported by ${f.importerCount} \u2014 ${f.message}`,
+    });
+  }
+  for (const f of detectEntryPoints(repository)) {
+    findings.push({
+      checkId: "entryPoints",
+      severity: "info",
+      filePath: f.filePath,
+      message: f.reason,
+    });
+  }
+
+  return {
+    findings,
+    errorCount: findings.filter((f) => f.severity === "error").length,
+    warningCount: findings.filter((f) => f.severity === "warning").length,
+    infoCount: findings.filter((f) => f.severity === "info").length,
+  };
+}

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -283,6 +283,11 @@ Real vs honest-placeholder breakdown:
   doctor`, but nothing exposes them over HTTP yet -- needs a new
   /api/doctor route.
 
+> **[STATUS UPDATE, 2026-08-14]: resolved — /api/doctor exists
+> (packages/engine/runDoctor.ts, all 19 detectors normalized to one flat
+> finding list) and IssuesPanel renders it grouped by severity. See
+> "IssuesPanel + /api/doctor" below.**
+
 Verification: npx tsc --noEmit -p apps/web/tsconfig.json clean (only the
 2 pre-existing file-tree.tsx errors, unrelated). NOT yet verified
 visually in-browser -- Workspace.tsx is not wired into any app/ route yet
@@ -478,3 +483,25 @@ never leaves the server); lib/api.ts gained a `postJson` helper. Verified
 live: /api/analyze on ARCLUX → 533 modules, folderTree root 8 children,
 packages/ 36 children; overview page HTTP 200; tsc 0, eslint 0. Not
 visually verified in a real browser (standard gap).
+
+## 2026-08-14 — IssuesPanel + /api/doctor (workspace Issues tab is now real)
+
+**Status:** Done
+
+- `packages/engine/runDoctor.ts` (new): runs all 19 detectors and
+  normalizes every finding to `{ checkId, severity, filePath?, message
+  }` — the HTTP counterpart of `arclux doctor`'s terminal print.
+  Severity per family: structural = error, hygiene/conventions =
+  warning, informational classifiers (entryPoints, sharedModules, pure
+  barrels) = info; ambiguous symbols map high→error, medium/low→warning.
+- `POST /api/doctor` (new route): analyzeRepository → runDoctor →
+  `{ repoUrl, findings, errorCount, warningCount, infoCount }`.
+- `IssuesPanel` (was an honest "no issues panel yet" placeholder):
+  fetches /api/doctor, renders findings grouped error → warning → info
+  with severity dots + checkId + filePath + message; loading/error/retry
+  states. `Workspace.tsx` passes repoUrl/branch through.
+- Verified live: POST /api/doctor on GSF-001/ARCLUX → 200, 1203 findings
+  (767 errors — real data: 4 circular deps incl. playground fixtures,
+  432 unused exports, 326 orphans; 386 warnings; 50 info). 6 unit tests
+  (tests/runDoctor.test.ts); tsc 0, eslint 0, vitest 202/202. Not
+  visually verified in a real browser (standard gap).

--- a/tests/runDoctor.test.ts
+++ b/tests/runDoctor.test.ts
@@ -1,0 +1,154 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for packages/engine/runDoctor.ts — the normalized 19-detector
+// suite that powers POST /api/doctor (HTTP counterpart of `arclux doctor`).
+
+import { describe, it, expect } from "vitest";
+import { Repository } from "../packages/repository/Repository";
+import { runDoctor } from "../packages/engine/runDoctor";
+import type { ModuleInfo, RepositoryMeta, FileInfo, RawExport } from "../packages/shared/types";
+
+function makeFile(relativePath: string, language = "typescript"): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language,
+    extension: language === "javascript" ? ".js" : ".ts",
+    sizeBytes: 100,
+    hash: "fake-hash",
+  };
+}
+
+function named(name: string, line = 1): RawExport {
+  return { name, kind: "named", line };
+}
+
+interface ResolvedImport {
+  moduleId: string;
+  namedImports: string[];
+  hasDefaultImport: boolean;
+  hasNamespaceImport: boolean;
+  line: number;
+}
+
+function makeModule(
+  relativePath: string,
+  opts: { exports?: RawExport[]; imports?: string[]; resolvedImports?: ResolvedImport[] } = {}
+): ModuleInfo {
+  const imports = opts.imports ?? [];
+  return {
+    id: relativePath,
+    file: makeFile(relativePath),
+    exports: opts.exports ?? [],
+    resolvedReExports: {},
+    importedBy: [],
+    imports,
+    resolvedImports: opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 })),
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "doctor-test",
+    org: "test-org",
+    name: "doctor-test",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+describe("runDoctor", () => {
+  it("flags an unused export as an error with checkId + filePath", () => {
+    const repo = makeRepository([makeModule("src/lonely.ts", { exports: [named("lonely")] })]);
+    const result = runDoctor(repo);
+
+    const finding = result.findings.find((f) => f.checkId === "unusedExports");
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe("error");
+    expect(finding?.filePath).toBe("src/lonely.ts");
+    expect(result.errorCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("flags a 2-module import cycle as circularDependency", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/a.ts"] }),
+    ]);
+    const result = runDoctor(repo);
+
+    const finding = result.findings.find((f) => f.checkId === "circularDependency");
+    expect(finding?.severity).toBe("error");
+    expect(finding?.message).toContain("src/a.ts");
+    expect(finding?.message).toContain("src/b.ts");
+  });
+
+  it("flags an orphan file as an error", () => {
+    const repo = makeRepository([makeModule("src/orphan.ts")]);
+    const result = runDoctor(repo);
+
+    const finding = result.findings.find((f) => f.checkId === "orphanFiles");
+    expect(finding?.severity).toBe("error");
+    expect(finding?.filePath).toBe("src/orphan.ts");
+  });
+
+  it("lists entry points as info, not error", () => {
+    const repo = makeRepository([makeModule("apps/cli/index.ts")]);
+    const result = runDoctor(repo);
+
+    const finding = result.findings.find((f) => f.checkId === "entryPoints");
+    expect(finding?.severity).toBe("info");
+    // entry points are NOT flagged as orphan errors (entry-file filtering)
+    expect(result.findings.some((f) => f.checkId === "orphanFiles")).toBe(false);
+  });
+
+  it("returns no error/warning findings for a fully-referenced chain (entry point root)", () => {
+    const repo = makeRepository([
+      makeModule("apps/cli/index.ts", {
+        imports: ["src/consumer.ts"],
+        resolvedImports: [{ moduleId: "src/consumer.ts", namedImports: ["consumer"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+      }),
+      makeModule("src/consumer.ts", {
+        imports: ["src/used.ts"],
+        resolvedImports: [{ moduleId: "src/used.ts", namedImports: ["helper"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+      }),
+      makeModule("src/used.ts", { exports: [named("helper")] }),
+    ]);
+    // buildIndex back-fills importedBy; the fixture must too — otherwise
+    // findModulesWithNoImporters flags everything as orphan.
+    const modules = repo.getAllModules();
+    modules[0].importedBy = []; // entry point: nothing imports the CLI
+    modules[1].importedBy = ["apps/cli/index.ts"];
+    modules[2].importedBy = ["src/consumer.ts"];
+
+    const result = runDoctor(repo);
+    // Only the informational entryPoints finding may remain — no errors/warnings.
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+  });
+
+  it("computes severity counts that sum to findings length", () => {
+    const repo = makeRepository([
+      makeModule("src/lonely.ts", { exports: [named("lonely")] }),
+      makeModule("src/orphan.ts"),
+    ]);
+    const result = runDoctor(repo);
+    expect(result.errorCount + result.warningCount + result.infoCount).toBe(result.findings.length);
+  });
+});


### PR DESCRIPTION
## What changed

The detector suite (19 detectors) was complete and ran via `arclux doctor`, but **nothing exposed it over HTTP** — the workspace Issues tab was an honest placeholder ('no /api/issues or /api/doctor route', per its own comment). Now:

- **`packages/engine/runDoctor.ts`** (new, shared + tested): runs all 19 detectors and normalizes every finding to `{ checkId, severity, filePath?, message }`. Severity per family: structural = error, hygiene/conventions = warning, informational classifiers (entryPoints, sharedModules, pure barrels) = info; ambiguous symbols map high→error, medium/low→warning.
- **`POST /api/doctor`** (new route): `analyzeRepository` → `runDoctor` → `{ repoUrl, findings, errorCount, warningCount, infoCount }` — mirrors /api/analyze's body/error handling.
- **`IssuesPanel`**: now fetches /api/doctor and renders findings grouped error → warning → info with severity dots, checkId, filePath, message; loading/error/retry states. `Workspace.tsx` passes repoUrl/branch through.

## How was this verified

- Live dev server: POST /api/doctor on GSF-001/ARCLUX → HTTP 200, **1203 findings** (767 errors — 4 real circular deps incl. playground fixtures, 432 unused exports, 326 orphans; 386 warnings; 50 info), correct per-checkId breakdown.
- `npx vitest run`: **202 passed / 24 files** (+6 new in tests/runDoctor.test.ts).
- `npx tsc --noEmit -p apps/web/tsconfig.json`: exit 0. `npx eslint` on changed files: 0 problems.
- NOTE: panel rendering not visually confirmed in a real browser (standard documented gap).

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json`
- [x] Tested on a live dev server + real repo
- [x] PROGRES updated with dated entry
- [x] No duplicate logic (normalization is new; detectors reused unchanged)
- [x] No empty files introduced
- [ ] Not visually verified in browser (noted above)