### PR TITLE
feat(web): FilesPanel real file tree — interactive ProjectStructure wired to workspace selection

### DIFF
--- a/apps/web/components/workspace/Workspace.tsx
+++ b/apps/web/components/workspace/Workspace.tsx
@@ -38,11 +38,12 @@ export interface WorkspaceProps {
  * typecheck" rather than also being "and now the main repo page
  * redesign", which would be a much bigger review surface.
  *
- * FilesPanel and IssuesPanel are honest "coming soon" placeholders (see
- * their own files for why) -- ImpactPanel is the only one backed by real
- * data (ImpactSummary.tsx + /api/impact), so it needs a moduleId, which
- * currently only comes from WorkspaceSearch selection since there's no
- * file tree yet to click into.
+ * FilesPanel and IssuesPanel were honest "coming soon" placeholders when
+ * this file was written; both are now real (FilesPanel = folderTree from
+ * /api/analyze + ProjectStructure, IssuesPanel = /api/doctor findings —
+ * see their own headers). ImpactPanel is backed by real data
+ * (ImpactSummary.tsx + /api/impact) and needs a moduleId, which comes
+ * from WorkspaceSearch OR a click in the FilesPanel tree.
  */
 export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null)
@@ -59,7 +60,14 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
       <WorkspaceCommand org={org} repo={repo} />
       <div className="flex-1 overflow-hidden">
         <SplitPane
-          left={<FilesPanel />}
+          left={
+            <FilesPanel
+              repoUrl={repoUrl}
+              branch={branch}
+              selectedModuleId={selectedModuleId}
+              onSelectFile={setSelectedModuleId}
+            />
+          }
           right={
             <Tabs defaultValue="impact" className="flex h-full flex-col">
               <TabsList className="mx-4 mt-2 w-fit">

--- a/apps/web/components/workspace/panels/FilesPanel.tsx
+++ b/apps/web/components/workspace/panels/FilesPanel.tsx
@@ -6,28 +6,90 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-import { EmptyState } from "@/components/patterns/EmptyState"
+"use client";
+
+import { useEffect, useState } from "react";
+import { postJson } from "@/lib/api";
+import { LoadingState } from "@/components/patterns/LoadingState";
+import { ErrorState } from "@/components/patterns/ErrorState";
+import { ProjectStructure } from "@/components/overview/ProjectStructure";
+import type { FileTreeNode } from "@/packages/graph/buildFolderGraph";
+
+export interface FilesPanelProps {
+  repoUrl: string;
+  branch?: string;
+  /** Currently selected module id — highlighted in the tree. */
+  selectedModuleId?: string | null;
+  /** Called with the selected file's path (= moduleId) when a file is clicked. */
+  onSelectFile?: (moduleId: string) => void;
+}
+
+interface AnalyzeResponse {
+  folderTree: FileTreeNode;
+}
 
 /**
- * STATUS: honest placeholder, not a real file browser yet. Deliberately
- * NOT faking a file tree -- there is no dedicated file-listing API route
- * (apps/web/app/api only has analyze/file/graph/impact/search) and no
- * shared file-tree data source in this repo yet.
+ * Workspace Files tab: an interactive file tree of the analyzed repo.
  *
- * The graph API (packages/graph/*) does contain per-module info that could
- * back a real tree, and vendor-ui/magic-ui/file-tree.tsx exists as a UI
- * primitive, but that component currently fails tsc --noEmit (missing
- * @radix-ui/react-accordion + a not-yet-written scroll-area.tsx -- see
- * PROGRES-status.md's known pre-existing errors). Wiring FilesPanel for
- * real is blocked on one of: (a) fixing file-tree.tsx's missing deps, or
- * (b) building a simpler tree view directly from graph data. Follow-up
- * work, intentionally out of scope here.
+ * The tree comes from POST /api/analyze's server-side `folderTree`
+ * (buildFolderGraph — added in #330; it needs the Repository, which never
+ * leaves the server). This replaced the old "blocked on a file-listing
+ * API" placeholder — the folderTree IS that data source. Cost note: this
+ * triggers a full clone+index per call, same as the other workspace
+ * panels (no caching yet — see /api/analyze's comment).
+ *
+ * Selection is lifted to the parent (Workspace.tsx's selectedModuleId,
+ * shared with ImpactPanel via WorkspaceSearch) — clicking a file here
+ * also drives the Impact tab.
  */
-export function FilesPanel() {
+export function FilesPanel({ repoUrl, branch, selectedModuleId, onSelectFile }: FilesPanelProps) {
+  const [tree, setTree] = useState<FileTreeNode | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [retryCount, setRetryCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await postJson<AnalyzeResponse>("/api/analyze", { repoUrl, branch });
+        if (!cancelled) setTree(result.folderTree);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load file tree");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoUrl, branch, retryCount]);
+
+  if (isLoading) return <LoadingState label="Loading file tree..." />;
+  if (error || !tree) {
+    return (
+      <ErrorState
+        title="Could not load file tree"
+        message={error ?? "No folderTree returned from /api/analyze."}
+        onRetry={() => setRetryCount((count) => count + 1)}
+      />
+    );
+  }
+
   return (
-    <EmptyState
-      title="File browser coming soon"
-      message="A real file tree isn't wired up yet -- see FilesPanel.tsx for what's blocking it."
-    />
-  )
+    <div className="h-full overflow-auto p-3">
+      <ProjectStructure
+        tree={tree}
+        selectedPath={selectedModuleId}
+        onSelectFile={onSelectFile}
+      />
+    </div>
+  );
 }

--- a/docs-site/progres/progres-status-web.mdx
+++ b/docs-site/progres/progres-status-web.mdx
@@ -285,6 +285,11 @@ Real vs honest-placeholder breakdown:
   Blocked on either fixing vendor-ui/magic-ui/file-tree.tsx's missing
   deps (@radix-ui/react-accordion, scroll-area.tsx) or building a simpler
   tree view from graph data directly.
+
+> **[STATUS UPDATE, 2026-08-14]: resolved — the "building a simpler tree
+> view" option won: POST /api/analyze gained a server-side `folderTree`
+> (issue #330) and FilesPanel renders it via ProjectStructure, wired to
+> the workspace selection state. See "FilesPanel real file tree" below.**
 - IssuesPanel.tsx: honest "coming soon" EmptyState, NOT fake detector
   data. Detectors themselves are 18/18 done and already run via `apps/cli
   doctor`, but nothing exposes them over HTTP yet -- needs a new
@@ -512,3 +517,17 @@ visually verified in a real browser (standard gap).
   432 unused exports, 326 orphans; 386 warnings; 50 info). 6 unit tests
   (tests/runDoctor.test.ts); tsc 0, eslint 0, vitest 202/202. Not
   visually verified in a real browser (standard gap).
+
+## 2026-08-14 — FilesPanel real file tree (last workspace placeholder resolved)
+
+**Status:** Done
+
+FilesPanel (was "file browser coming soon") now renders the interactive
+file tree: POST /api/analyze's server-side `folderTree` (buildFolderGraph,
+added in the Overview work) → ProjectStructure. Selection is lifted to
+Workspace's `selectedModuleId` (shared with ImpactPanel) — clicking a
+file in the tree drives the Impact tab, same as WorkspaceSearch.
+Cost note: triggers a full clone+index per call, consistent with the
+other panels (no caching yet). Verified: /workspace page HTTP 200 on a
+dev server, no errors; tsc 0, eslint 0, vitest 202/202. Not visually
+verified in a real browser (standard gap).

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -278,6 +278,11 @@ Real vs honest-placeholder breakdown:
   Blocked on either fixing vendor-ui/magic-ui/file-tree.tsx's missing
   deps (@radix-ui/react-accordion, scroll-area.tsx) or building a simpler
   tree view from graph data directly.
+
+> **[STATUS UPDATE, 2026-08-14]: resolved — the "building a simpler tree
+> view" option won: POST /api/analyze gained a server-side `folderTree`
+> (issue #330) and FilesPanel renders it via ProjectStructure, wired to
+> the workspace selection state. See "FilesPanel real file tree" below.**
 - IssuesPanel.tsx: honest "coming soon" EmptyState, NOT fake detector
   data. Detectors themselves are 18/18 done and already run via `apps/cli
   doctor`, but nothing exposes them over HTTP yet -- needs a new
@@ -505,3 +510,17 @@ visually verified in a real browser (standard gap).
   432 unused exports, 326 orphans; 386 warnings; 50 info). 6 unit tests
   (tests/runDoctor.test.ts); tsc 0, eslint 0, vitest 202/202. Not
   visually verified in a real browser (standard gap).
+
+## 2026-08-14 — FilesPanel real file tree (last workspace placeholder resolved)
+
+**Status:** Done
+
+FilesPanel (was "file browser coming soon") now renders the interactive
+file tree: POST /api/analyze's server-side `folderTree` (buildFolderGraph,
+added in the Overview work) → ProjectStructure. Selection is lifted to
+Workspace's `selectedModuleId` (shared with ImpactPanel) — clicking a
+file in the tree drives the Impact tab, same as WorkspaceSearch.
+Cost note: triggers a full clone+index per call, consistent with the
+other panels (no caching yet). Verified: /workspace page HTTP 200 on a
+dev server, no errors; tsc 0, eslint 0, vitest 202/202. Not visually
+verified in a real browser (standard gap).


### PR DESCRIPTION
## What changed

FilesPanel was the last honest 'file browser coming soon' placeholder in the workspace. Now:

- **FilesPanel** fetches POST /api/analyze's server-side `folderTree` (buildFolderGraph — added in the Overview work, #330) and renders the interactive **ProjectStructure** tree (expand/collapse).
- **Selection is lifted** to `Workspace.tsx`'s `selectedModuleId` (already shared with ImpactPanel) — clicking a file in the tree drives the **Impact tab**, exactly like a WorkspaceSearch selection. So the workspace now has a real browse→impact flow.
- `Workspace.tsx` header comment updated (FilesPanel/IssuesPanel are no longer placeholders).
- Cost note (same as other panels): full clone+index per call — no caching yet.

## How was this verified

- Live dev server: `/GSF-001/ARCLUX/workspace` → HTTP 200, no server errors
- `npx tsc --noEmit -p apps/web/tsconfig.json`: exit 0
- `npx eslint` on changed files: 0 problems
- `npx vitest run`: 202/202 (web-only change; no backend tests affected)
- NOTE: tree rendering/interaction not visually confirmed in a real browser (standard documented gap)

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json`
- [x] Tested on a live dev server
- [x] PROGRES updated with dated entry
- [x] No duplicate logic (ProjectStructure + folderTree are pre-existing; only wiring is new)
- [x] No empty files introduced
- [ ] Not visually verified in browser (noted above)