### PR TITLE
feat: workspace branch switcher — getBranches/detectDefaultBranch + /api/branches + dropdown

### DIFF
--- a/apps/web/app/api/branches/route.ts
+++ b/apps/web/app/api/branches/route.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { getBranches } from "@/packages/git/getBranches";
+import { detectDefaultBranch } from "@/packages/git/detectDefaultBranch";
+
+/**
+ * GET /api/branches?repoUrl=...
+ *
+ * Lists a repo's remote branches WITHOUT cloning (git ls-remote) and
+ * detects its default branch. Lightweight — unlike the analysis routes,
+ * this never clones or indexes. Used by the workspace branch switcher.
+ */
+export async function GET(request: NextRequest) {
+  const repoUrl = request.nextUrl.searchParams.get("repoUrl");
+
+  if (!repoUrl) {
+    return NextResponse.json({ error: "`repoUrl` query param is required" }, { status: 400 });
+  }
+
+  try {
+    const branches = getBranches(repoUrl);
+    const defaultBranch = detectDefaultBranch(repoUrl);
+    return NextResponse.json({ repoUrl, branches, defaultBranch }, { status: 200 });
+  } catch (err) {
+    // git ls-remote failures (unreachable repo, bad URL) — caller's repo
+    // URL is wrong or the host is unreachable, not the API's fault.
+    console.error("Unexpected error in /api/branches:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to list branches" },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/web/components/workspace/Workspace.tsx
+++ b/apps/web/components/workspace/Workspace.tsx
@@ -47,6 +47,10 @@ export interface WorkspaceProps {
  */
 export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
   const [selectedModuleId, setSelectedModuleId] = useState<string | null>(null)
+  // Active branch: defaults to the prop (e.g. from a future URL param),
+  // then the branch switcher sets it (which also seeds it from the repo's
+  // default via WorkspaceSwitcher). Panels refetch when it changes.
+  const [activeBranch, setActiveBranch] = useState<string | undefined>(branch)
 
   return (
     <div className="flex h-full flex-col">
@@ -54,8 +58,9 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
         org={org}
         repo={repo}
         repoUrl={repoUrl}
-        branch={branch}
+        branch={activeBranch}
         onSelectFile={setSelectedModuleId}
+        onBranchChange={setActiveBranch}
       />
       <WorkspaceCommand org={org} repo={repo} />
       <div className="flex-1 overflow-hidden">
@@ -63,7 +68,7 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
           left={
             <FilesPanel
               repoUrl={repoUrl}
-              branch={branch}
+              branch={activeBranch}
               selectedModuleId={selectedModuleId}
               onSelectFile={setSelectedModuleId}
             />
@@ -75,10 +80,10 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
                 <TabsTrigger value="issues">Issues</TabsTrigger>
               </TabsList>
               <TabsContent value="impact" className="flex-1 overflow-auto">
-                <ImpactPanel repoUrl={repoUrl} moduleId={selectedModuleId} />
+                <ImpactPanel repoUrl={repoUrl} moduleId={selectedModuleId} branch={activeBranch} />
               </TabsContent>
               <TabsContent value="issues" className="flex-1 overflow-auto">
-                <IssuesPanel repoUrl={repoUrl} branch={branch} />
+                <IssuesPanel repoUrl={repoUrl} branch={activeBranch} />
               </TabsContent>
             </Tabs>
           }

--- a/apps/web/components/workspace/WorkspaceHeader.tsx
+++ b/apps/web/components/workspace/WorkspaceHeader.tsx
@@ -15,6 +15,7 @@ export interface WorkspaceHeaderProps {
   repoUrl: string
   branch?: string
   onSelectFile?: (moduleId: string) => void
+  onBranchChange?: (branch: string) => void
 }
 
 /**
@@ -24,10 +25,10 @@ export interface WorkspaceHeaderProps {
  * shell, which stays outside this. This is workspace-internal chrome
  * only (repo switcher + file search), one level down from the page shell.
  */
-export function WorkspaceHeader({ org, repo, repoUrl, branch, onSelectFile }: WorkspaceHeaderProps) {
+export function WorkspaceHeader({ org, repo, repoUrl, branch, onSelectFile, onBranchChange }: WorkspaceHeaderProps) {
   return (
     <div className="flex items-center justify-between gap-4 border-b px-4 py-2">
-      <WorkspaceSwitcher org={org} repo={repo} branch={branch} />
+      <WorkspaceSwitcher org={org} repo={repo} branch={branch} onBranchChange={onBranchChange} />
       <WorkspaceSearch repoUrl={repoUrl} branch={branch} onSelect={onSelectFile} />
     </div>
   )

--- a/apps/web/components/workspace/WorkspaceSwitcher.tsx
+++ b/apps/web/components/workspace/WorkspaceSwitcher.tsx
@@ -8,8 +8,9 @@
 
 "use client"
 
+import { useEffect, useState } from "react"
 import Link from "next/link"
-import { ChevronsUpDown, GitBranch } from "lucide-react"
+import { ChevronsUpDown, GitBranch, Check } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,28 +20,60 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
+import { fetchJson } from "@/lib/api"
+import { cn } from "@/lib/cn"
 
 export interface WorkspaceSwitcherProps {
   org: string
   repo: string
   branch?: string
+  /** Called when the user picks a branch from the dropdown. */
+  onBranchChange?: (branch: string) => void
   /** Other repos previously analyzed in this session/browser, for quick switching. */
   recentRepos?: { org: string; repo: string }[]
+}
+
+interface BranchesResponse {
+  branches: string[]
+  defaultBranch: string | null
 }
 
 /**
  * Repo/branch switcher for the workspace header. Concept (dropdown listing
  * known options, current selection shown as the trigger label) inspired by
- * git-truck's RevisionSelect.tsx (MIT) -- not a port, that component is a
- * native <select> wired to react-router loader data specific to git-truck's
- * own server-rendered branch list, which has no equivalent here yet.
+ * git-truck's RevisionSelect.tsx (MIT) -- not a port.
  *
- * Branch switching is NOT functional yet -- ARCLUX's pipeline
- * (packages/engine/pipeline.ts) accepts a branch param, but no route
- * currently lets the user pick one in the UI. This only switches between
- * recently-analyzed repos for now.
+ * Branch list comes from GET /api/branches (git ls-remote --heads, no
+ * clone — packages/git/getBranches.ts + detectDefaultBranch.ts, both were
+ * stubs). Selecting a branch calls onBranchChange; the parent
+ * (Workspace.tsx) owns the active branch and refetches the panels with it.
  */
-export function WorkspaceSwitcher({ org, repo, branch, recentRepos = [] }: WorkspaceSwitcherProps) {
+export function WorkspaceSwitcher({ org, repo, branch, onBranchChange, recentRepos = [] }: WorkspaceSwitcherProps) {
+  const repoUrl = `https://github.com/${org}/${repo}.git`
+  const [branches, setBranches] = useState<string[]>([])
+  const [branchesLoaded, setBranchesLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    fetchJson<BranchesResponse>("/api/branches", { repoUrl })
+      .then((data) => {
+        if (cancelled) return
+        setBranches(data.branches)
+        // If no branch is active yet, fall back to the repo's default.
+        if (!branch && data.defaultBranch) onBranchChange?.(data.defaultBranch)
+      })
+      .catch(() => {
+        // Silent: a failed branch listing just means the branch section
+        // stays hidden — the repo switcher still works.
+      })
+      .finally(() => {
+        if (!cancelled) setBranchesLoaded(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [repoUrl]) // eslint-disable-line react-hooks/exhaustive-deps -- onBranchChange is a stable setState from the parent
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -83,6 +116,25 @@ export function WorkspaceSwitcher({ org, repo, branch, recentRepos = [] }: Works
         <DropdownMenuItem render={<Link href="/new" />}>
           Analyze another repository
         </DropdownMenuItem>
+
+        {branchesLoaded && branches.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Branches</DropdownMenuLabel>
+            <div className="max-h-48 overflow-y-auto">
+              {branches.map((name) => (
+                <DropdownMenuItem
+                  key={name}
+                  onSelect={() => onBranchChange?.(name)}
+                  className={cn("font-mono text-xs", name === branch && "text-primary")}
+                >
+                  <span className="truncate">{name}</span>
+                  {name === branch && <Check className="ml-auto h-3.5 w-3.5 shrink-0" />}
+                </DropdownMenuItem>
+              ))}
+            </div>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/apps/web/components/workspace/panels/ImpactPanel.tsx
+++ b/apps/web/components/workspace/panels/ImpactPanel.tsx
@@ -13,16 +13,16 @@ export interface ImpactPanelProps {
   repoUrl: string
   /** Selected module id (relativePath in the graph), e.g. "src/utils/format.ts". */
   moduleId: string | null
+  branch?: string
 }
 
 /**
  * Thin wrapper around ImpactSummary.tsx (already built and browser-verified,
  * see PROGRES-status.md) for the workspace layout. Requires a moduleId --
- * the workspace's file selection state (WorkspaceSwitcher / FilesPanel) is
- * expected to feed this. Not yet wired to a real file-selection flow, since
- * FilesPanel.tsx is still a "coming soon" placeholder -- see its own file.
+ * the workspace's file selection state (WorkspaceSearch / FilesPanel) is
+ * expected to feed this; branch comes from the workspace branch switcher.
  */
-export function ImpactPanel({ repoUrl, moduleId }: ImpactPanelProps) {
+export function ImpactPanel({ repoUrl, moduleId, branch }: ImpactPanelProps) {
   if (!moduleId) {
     return (
       <EmptyState
@@ -32,5 +32,5 @@ export function ImpactPanel({ repoUrl, moduleId }: ImpactPanelProps) {
     )
   }
 
-  return <ImpactSummary repoUrl={repoUrl} moduleId={moduleId} />
+  return <ImpactSummary repoUrl={repoUrl} moduleId={moduleId} branch={branch} />
 }

--- a/docs-site/progres/progres-status-web.mdx
+++ b/docs-site/progres/progres-status-web.mdx
@@ -273,6 +273,12 @@ Real vs honest-placeholder breakdown:
 - WorkspaceSwitcher.tsx: functional for switching between recently-viewed
   repos (client-side list), but branch switching is NOT functional yet --
   pipeline.ts accepts a branch param but no UI lets the user pick one.
+
+> **[STATUS UPDATE, 2026-08-14]: resolved — branch switching works.
+> packages/git/getBranches.ts + detectDefaultBranch.ts implemented
+> (git ls-remote, no clone) behind GET /api/branches; WorkspaceSwitcher
+> lists branches and the workspace refetches panels on change. See
+> "Branch switcher" below.**
 - WorkspaceSearch.tsx: real, hits GET /api/search (fuzzyScore.ts stopgap,
   same caveats as documented on that route -- file-path-only, no caching,
   re-indexes whole repo per call).
@@ -531,3 +537,23 @@ Cost note: triggers a full clone+index per call, consistent with the
 other panels (no caching yet). Verified: /workspace page HTTP 200 on a
 dev server, no errors; tsc 0, eslint 0, vitest 202/202. Not visually
 verified in a real browser (standard gap).
+
+## 2026-08-14 — Branch switcher (workspace; last WorkspaceSwitcher gap)
+
+**Status:** Done
+
+- `packages/git/getBranches.ts` + `detectDefaultBranch.ts` implemented
+  (both were 8-line stubs): `git ls-remote --heads` / `--symref HEAD`
+  via execFileSync array args (no shell, no injection — same pattern as
+  KI-010).
+- `GET /api/branches?repoUrl=` (new route): `&#123; branches, defaultBranch
+  &#125;` — lightweight, never clones.
+- WorkspaceSwitcher: branch section in the dropdown (list from
+  /api/branches, current branch checkmarked); seeds the active branch
+  from the repo default when none is set. Workspace owns `activeBranch`
+  state and passes it to FilesPanel/ImpactPanel/IssuesPanel — panels
+  refetch when it changes.
+- Verified live: /api/branches on ARCLUX → 200 with the real branch
+  list; missing-repoUrl → 400; /workspace 200, no errors. tsc 0,
+  eslint 0, vitest 202/202. Not visually verified in a real browser
+  (standard gap).

--- a/packages/git/detectDefaultBranch.ts
+++ b/packages/git/detectDefaultBranch.ts
@@ -6,3 +6,21 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { execFileSync } from "node:child_process";
+
+/**
+ * Detects the default branch (HEAD symref target) of repoUrl without
+ * cloning, via `git ls-remote --symref <url> HEAD`, whose first line is
+ * `ref: refs/heads/<name>\tHEAD`. Returns null when HEAD isn't a symref
+ * (unusual). Same execFileSync-array pattern as getBranches.ts — no
+ * shell, no injection surface.
+ */
+export function detectDefaultBranch(repoUrl: string): string | null {
+  const output = execFileSync("git", ["ls-remote", "--symref", repoUrl, "HEAD"], {
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+
+  const match = output.match(/^ref:\s+refs\/heads\/(\S+)\s+HEAD/m);
+  return match ? match[1] : null;
+}

--- a/packages/git/getBranches.ts
+++ b/packages/git/getBranches.ts
@@ -6,3 +6,29 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { execFileSync } from "node:child_process";
+
+/**
+ * Lists the remote branches of repoUrl WITHOUT cloning, via
+ * `git ls-remote --heads`. execFileSync with an argument array (no shell)
+ * means repoUrl never reaches a shell — no command-injection surface
+ * (same pattern as the git-diff exec in KI-010).
+ *
+ * Throws (execFileSync) if the URL isn't a reachable git repo — callers
+ * decide how to surface that.
+ */
+export function getBranches(repoUrl: string): string[] {
+  const output = execFileSync("git", ["ls-remote", "--heads", repoUrl], {
+    encoding: "utf-8",
+    // ls-remote of a large repo can take a few seconds; cap it so a
+    // misbehaving host can't hang a request forever.
+    timeout: 30_000,
+  });
+
+  const branches: string[] = [];
+  for (const line of output.split("\n")) {
+    const match = line.match(/^[0-9a-f]+\s+refs\/heads\/(.+)$/);
+    if (match) branches.push(match[1]);
+  }
+  return branches.sort();
+}

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -266,6 +266,12 @@ Real vs honest-placeholder breakdown:
 - WorkspaceSwitcher.tsx: functional for switching between recently-viewed
   repos (client-side list), but branch switching is NOT functional yet --
   pipeline.ts accepts a branch param but no UI lets the user pick one.
+
+> **[STATUS UPDATE, 2026-08-14]: resolved — branch switching works.
+> packages/git/getBranches.ts + detectDefaultBranch.ts implemented
+> (git ls-remote, no clone) behind GET /api/branches; WorkspaceSwitcher
+> lists branches and the workspace refetches panels on change. See
+> "Branch switcher" below.**
 - WorkspaceSearch.tsx: real, hits GET /api/search (fuzzyScore.ts stopgap,
   same caveats as documented on that route -- file-path-only, no caching,
   re-indexes whole repo per call).
@@ -524,3 +530,23 @@ Cost note: triggers a full clone+index per call, consistent with the
 other panels (no caching yet). Verified: /workspace page HTTP 200 on a
 dev server, no errors; tsc 0, eslint 0, vitest 202/202. Not visually
 verified in a real browser (standard gap).
+
+## 2026-08-14 — Branch switcher (workspace; last WorkspaceSwitcher gap)
+
+**Status:** Done
+
+- `packages/git/getBranches.ts` + `detectDefaultBranch.ts` implemented
+  (both were 8-line stubs): `git ls-remote --heads` / `--symref HEAD`
+  via execFileSync array args (no shell, no injection — same pattern as
+  KI-010).
+- `GET /api/branches?repoUrl=` (new route): `{ branches, defaultBranch
+  }` — lightweight, never clones.
+- WorkspaceSwitcher: branch section in the dropdown (list from
+  /api/branches, current branch checkmarked); seeds the active branch
+  from the repo default when none is set. Workspace owns `activeBranch`
+  state and passes it to FilesPanel/ImpactPanel/IssuesPanel — panels
+  refetch when it changes.
+- Verified live: /api/branches on ARCLUX → 200 with the real branch
+  list; missing-repoUrl → 400; /workspace 200, no errors. tsc 0,
+  eslint 0, vitest 202/202. Not visually verified in a real browser
+  (standard gap).


### PR DESCRIPTION
## What changed

The last WorkspaceSwitcher gap: branch switching was NOT functional ('pipeline accepts a branch param but no UI lets the user pick one'). Now:

- **`packages/git/getBranches.ts` + `detectDefaultBranch.ts`** implemented (both were 8-line stubs): `git ls-remote --heads` / `--symref HEAD` via `execFileSync` with an argument array — no shell, no command-injection surface from the URL (same pattern as the git-diff exec, KI-010).
- **`GET /api/branches?repoUrl=`** (new route): `{ repoUrl, branches, defaultBranch }` — lightweight, never clones (unlike the analysis routes).
- **`WorkspaceSwitcher`**: a Branches section in the dropdown (list from /api/branches, current branch checkmarked); seeds the active branch from the repo's default when none is set yet.
- **`Workspace`** owns `activeBranch` state and passes it to FilesPanel / ImpactPanel / IssuesPanel — panels refetch when the branch changes; ImpactPanel now forwards `branch` to ImpactSummary.

## How was this verified

- Live dev server: `GET /api/branches?repoUrl=...ARCLUX.git` → HTTP 200 with the real branch list (ARCLUX.main, feat/*, docs/*...); missing repoUrl → 400 `repoUrl query param is required`; `/workspace` page → 200, no server errors.
- `npx tsc --noEmit -p apps/web/tsconfig.json`: exit 0. `npx eslint` on changed files: 0 problems. `npx vitest run`: 202/202.
- NOTE: dropdown interaction not visually confirmed in a real browser (standard documented gap).

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json`
- [x] Tested on a live dev server
- [x] PROGRES updated with dated entry
- [x] No duplicate logic (functions were stubs; route + wiring are new)
- [x] No empty files introduced
- [ ] Not visually verified in browser (noted above)