### PR TITLE
feat(git): implement checkoutBranch, getCommitHistory, getContributors (last git stubs)

### DIFF
--- a/docs-site/progres/progres-status-backlog.mdx
+++ b/docs-site/progres/progres-status-backlog.mdx
@@ -36,10 +36,16 @@ see "packages/impact/* already done" update below**
 
 **Medium priority**:
 - `packages/cache/*`, `packages/watcher/*` (5 & 4 files respectively)
-- Remaining `packages/git/*` (`checkoutBranch`, `detectDefaultBranch`,
+- `packages/git/*` (`checkoutBranch`, `detectDefaultBranch`,
   `getBranches`, `getCommitHistory`, `getContributors` — different from
   `cloneRepository`/`cleanupRepository`/`readGitignore`, which are already
   done)
+
+> **[STATUS UPDATE, 2026-08-14]: resolved — all 5 are implemented.
+> getBranches + detectDefaultBranch (git ls-remote, no clone) power GET
+> /api/branches and the workspace branch switcher (see status-web.md);
+> checkoutBranch/getCommitHistory/getContributors operate on a local
+> clone (see status-core.md "packages/git history helpers").**
 - `packages/graph/buildCallGraph/buildExportGraph/buildImportGraph.ts`
 - Remaining `packages/indexer/*` (`indexSchema`, `resolveComponents/Exports/
   Hooks/Providers/Routes`, `updateIndex`, `watchIndex`) — **the empty

--- a/docs-site/progres/progres-status-core.mdx
+++ b/docs-site/progres/progres-status-core.mdx
@@ -563,3 +563,22 @@ graph-callgraph.test.ts +2). Test count: 196.
 **Status:** Done
 
 apps/cli/commands/work.ts added: arclux work &lt;file> &lt;newContentFile> reads current + replacement content, builds PatchSet -> ChangePlan -> executes via ChangeExecutor (writeTransactional, transactional/recoverable write). This is the first real caller of packages/change/, proving the pipeline works end-to-end without needing intent parsing (ContextResolver), which doesn't exist yet. Registered in apps/cli/index.ts. Verified with tsc -p apps/cli/tsconfig.json (root tsc --noEmit picks up the wrong/Next.js-oriented tsconfig.json for CLI code -- use -p apps/cli/tsconfig.json when checking apps/cli specifically).
+
+## 2026-08-14 — packages/git history helpers implemented (last git stubs)
+
+**Status:** Done
+
+checkoutBranch/getCommitHistory/getContributors implemented (all were
+8-line stubs; the remaining backlog git items, alongside getBranches +
+detectDefaultBranch which landed with the branch switcher):
+- `checkoutBranch(localPath, branch)` — no-op if already on it;
+  otherwise fetch origin + `checkout -b branch origin/branch`, falling
+  back to plain `checkout branch` for local-only branches.
+- `getCommitHistory(localPath, { maxCount?, branch?, path? })` —
+  simple-git log → &#123; hash, date, message, authorName, authorEmail &#125;.
+  NOTE: requires a full (non-shallow) clone — the pipeline defaults to
+  depth 1, so history callers must clone with depth: undefined.
+- `getContributors(localPath)` — `git shortlog -sne --no-merges` →
+  [&#123; name, email, commits &#125;] sorted by count.
+6 tests (tests/git-history.test.ts) against a real temp git repo
+(git init + commits); tsc 0, vitest 208/208 (202 + 6).

--- a/packages/git/checkoutBranch.ts
+++ b/packages/git/checkoutBranch.ts
@@ -6,3 +6,30 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { simpleGit } from "simple-git";
+
+/**
+ * Checks out `branch` in an existing local clone at localPath.
+ *
+ * Order of attempts (first success wins):
+ * 1. Already on `branch` — no-op.
+ * 2. Create a local tracking branch from origin (`checkout -b branch
+ *    origin/branch`) — first fetches so a shallow clone (depth 1, the
+ *    pipeline's default) can see the remote branch at all.
+ * 3. Plain `checkout branch` — for branches that exist only locally.
+ *
+ * Throws if none succeed (simple-git error propagates to the caller).
+ */
+export async function checkoutBranch(localPath: string, branch: string): Promise<void> {
+  const git = simpleGit(localPath);
+
+  const status = await git.status();
+  if (status.current === branch) return;
+
+  try {
+    await git.fetch(["origin", branch]);
+    await git.checkoutBranch(branch, `origin/${branch}`);
+  } catch {
+    await git.checkout(branch);
+  }
+}

--- a/packages/git/getCommitHistory.ts
+++ b/packages/git/getCommitHistory.ts
@@ -6,3 +6,50 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { simpleGit } from "simple-git";
+
+export interface CommitInfo {
+  hash: string;
+  /** ISO date of the commit */
+  date: string;
+  message: string;
+  authorName: string;
+  authorEmail: string;
+}
+
+export interface GetCommitHistoryOptions {
+  /** Max commits to return. Default: 20. */
+  maxCount?: number;
+  /** Branch/ref to log (default: current branch). */
+  branch?: string;
+  /** Only commits touching this path (file or directory, repo-relative). */
+  path?: string;
+}
+
+/**
+ * Returns commit history for a local clone at localPath via
+ * `git log`. Requires a full (non-shallow) clone to see history — the
+ * pipeline's cloneRepository defaults to depth 1, so callers wanting
+ * history should clone with `depth: undefined` or fetch first.
+ */
+export async function getCommitHistory(
+  localPath: string,
+  options: GetCommitHistoryOptions = {}
+): Promise<CommitInfo[]> {
+  const { maxCount = 20, branch, path } = options;
+  const git = simpleGit(localPath);
+
+  const log = await git.log({
+    maxCount,
+    from: branch,
+    file: path,
+  });
+
+  return log.all.map((commit) => ({
+    hash: commit.hash,
+    date: commit.date,
+    message: commit.message,
+    authorName: commit.author_name,
+    authorEmail: commit.author_email,
+  }));
+}

--- a/packages/git/getContributors.ts
+++ b/packages/git/getContributors.ts
@@ -6,3 +6,34 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { simpleGit } from "simple-git";
+
+export interface Contributor {
+  name: string;
+  email: string;
+  /** Total commits by this contributor (excluding merges). */
+  commits: number;
+}
+
+/**
+ * Aggregates commit authors for a local clone at localPath via
+ * `git shortlog -sne --no-merges` — one entry per author, sorted by
+ * commit count descending. Requires a full (non-shallow) clone; see
+ * getCommitHistory.ts's note.
+ */
+export async function getContributors(localPath: string): Promise<Contributor[]> {
+  const git = simpleGit(localPath);
+  const output = await git.raw(["shortlog", "-sne", "--no-merges", "HEAD"]);
+
+  const contributors: Contributor[] = [];
+  for (const line of output.split("\n")) {
+    const match = line.trim().match(/^(\d+)\s+(.+?)\s*<([^>]+)>$/);
+    if (!match) continue;
+    contributors.push({
+      commits: Number(match[1]),
+      name: match[2],
+      email: match[3],
+    });
+  }
+  return contributors;
+}

--- a/progres/status-backlog.md
+++ b/progres/status-backlog.md
@@ -29,10 +29,16 @@ see "packages/impact/* already done" update below**
 
 **Medium priority**:
 - `packages/cache/*`, `packages/watcher/*` (5 & 4 files respectively)
-- Remaining `packages/git/*` (`checkoutBranch`, `detectDefaultBranch`,
+- `packages/git/*` (`checkoutBranch`, `detectDefaultBranch`,
   `getBranches`, `getCommitHistory`, `getContributors` — different from
   `cloneRepository`/`cleanupRepository`/`readGitignore`, which are already
   done)
+
+> **[STATUS UPDATE, 2026-08-14]: resolved — all 5 are implemented.
+> getBranches + detectDefaultBranch (git ls-remote, no clone) power GET
+> /api/branches and the workspace branch switcher (see status-web.md);
+> checkoutBranch/getCommitHistory/getContributors operate on a local
+> clone (see status-core.md "packages/git history helpers").**
 - `packages/graph/buildCallGraph/buildExportGraph/buildImportGraph.ts`
 - Remaining `packages/indexer/*` (`indexSchema`, `resolveComponents/Exports/
   Hooks/Providers/Routes`, `updateIndex`, `watchIndex`) — **the empty

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -556,3 +556,22 @@ graph-callgraph.test.ts +2). Test count: 196.
 **Status:** Done
 
 apps/cli/commands/work.ts added: arclux work <file> <newContentFile> reads current + replacement content, builds PatchSet -> ChangePlan -> executes via ChangeExecutor (writeTransactional, transactional/recoverable write). This is the first real caller of packages/change/, proving the pipeline works end-to-end without needing intent parsing (ContextResolver), which doesn't exist yet. Registered in apps/cli/index.ts. Verified with tsc -p apps/cli/tsconfig.json (root tsc --noEmit picks up the wrong/Next.js-oriented tsconfig.json for CLI code -- use -p apps/cli/tsconfig.json when checking apps/cli specifically).
+
+## 2026-08-14 — packages/git history helpers implemented (last git stubs)
+
+**Status:** Done
+
+checkoutBranch/getCommitHistory/getContributors implemented (all were
+8-line stubs; the remaining backlog git items, alongside getBranches +
+detectDefaultBranch which landed with the branch switcher):
+- `checkoutBranch(localPath, branch)` — no-op if already on it;
+  otherwise fetch origin + `checkout -b branch origin/branch`, falling
+  back to plain `checkout branch` for local-only branches.
+- `getCommitHistory(localPath, { maxCount?, branch?, path? })` —
+  simple-git log → { hash, date, message, authorName, authorEmail }.
+  NOTE: requires a full (non-shallow) clone — the pipeline defaults to
+  depth 1, so history callers must clone with depth: undefined.
+- `getContributors(localPath)` — `git shortlog -sne --no-merges` →
+  [{ name, email, commits }] sorted by count.
+6 tests (tests/git-history.test.ts) against a real temp git repo
+(git init + commits); tsc 0, vitest 208/208 (202 + 6).

--- a/tests/git-history.test.ts
+++ b/tests/git-history.test.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for packages/git/{checkoutBranch,getCommitHistory,getContributors}.
+// These run against a REAL git repository built in a temp dir (git is
+// required in the test environment), not mocks — same spirit as the
+// indexer tmp-dir tests.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkoutBranch } from "../packages/git/checkoutBranch";
+import { getCommitHistory } from "../packages/git/getCommitHistory";
+import { getContributors } from "../packages/git/getContributors";
+
+function run(dir: string, cmd: string): string {
+  return execSync(cmd, { cwd: dir, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+describe("packages/git history helpers", () => {
+  let dir: string;
+  let created = false;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "arclux-git-test-"));
+    run(dir, "git init -b main");
+    run(dir, 'git config user.email "tester@arclux.test"');
+    run(dir, 'git config user.name "Test User"');
+    writeFileSync(join(dir, "a.txt"), "one");
+    run(dir, 'git add a.txt && git commit -m "first commit"');
+    run(dir, 'git config user.name "Second Author"');
+    run(dir, 'git config user.email "second@arclux.test"');
+    writeFileSync(join(dir, "b.txt"), "two");
+    run(dir, 'git add b.txt && git commit -m "second commit"');
+    created = true;
+  });
+
+  afterAll(() => {
+    if (created) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("getCommitHistory returns commits newest-first with author info", async () => {
+    const history = await getCommitHistory(dir);
+    expect(history).toHaveLength(2);
+    expect(history[0].message).toBe("second commit");
+    expect(history[0].authorName).toBe("Second Author");
+    expect(history[0].hash).toMatch(/^[0-9a-f]{40}$/);
+    expect(history[1].message).toBe("first commit");
+    expect(history[1].authorEmail).toBe("tester@arclux.test");
+  });
+
+  it("getCommitHistory honors maxCount", async () => {
+    const history = await getCommitHistory(dir, { maxCount: 1 });
+    expect(history).toHaveLength(1);
+    expect(history[0].message).toBe("second commit");
+  });
+
+  it("getCommitHistory honors the path filter", async () => {
+    const history = await getCommitHistory(dir, { path: "a.txt" });
+    expect(history).toHaveLength(1);
+    expect(history[0].message).toBe("first commit");
+  });
+
+  it("getContributors aggregates per-author commit counts, merges excluded", async () => {
+    const contributors = await getContributors(dir);
+    expect(contributors).toHaveLength(2);
+    // sorted by count descending (both 1 here) — check contents regardless
+    const byName = Object.fromEntries(contributors.map((c) => [c.name, c]));
+    expect(byName["Test User"]).toEqual({ name: "Test User", email: "tester@arclux.test", commits: 1 });
+    expect(byName["Second Author"]).toEqual({ name: "Second Author", email: "second@arclux.test", commits: 1 });
+  });
+
+  it("checkoutBranch is a no-op when already on the branch", async () => {
+    await expect(checkoutBranch(dir, "main")).resolves.toBeUndefined();
+    expect(run(dir, "git branch --show-current").trim()).toBe("main");
+  });
+
+  it("checkoutBranch switches to a local branch", async () => {
+    run(dir, "git checkout -b feature");
+    expect(run(dir, "git branch --show-current").trim()).toBe("feature");
+    await checkoutBranch(dir, "main");
+    expect(run(dir, "git branch --show-current").trim()).toBe("main");
+  });
+});


### PR DESCRIPTION
## What changed

Closes the last 'Remaining packages/git/*' backlog item (all 5 were 8-line stubs; getBranches + detectDefaultBranch landed with the branch switcher #334). Now:

- **`checkoutBranch(localPath, branch)`** — no-op when already on the branch; otherwise fetch origin + `checkout -b branch origin/branch`, falling back to plain `checkout branch` for local-only branches.
- **`getCommitHistory(localPath, { maxCount?, branch?, path? })`** — simple-git log → `{ hash, date, message, authorName, authorEmail }`. Documented caveat: requires a full (non-shallow) clone — the pipeline defaults to depth 1, so history callers must clone with `depth: undefined`.
- **`getContributors(localPath)`** — `git shortlog -sne --no-merges` → `[{ name, email, commits }]` sorted by commit count.

## How was this verified

- **6 new tests** (tests/git-history.test.ts) against a REAL temp git repo (git init + 2 commits by 2 authors): history order + maxCount + path filter + author aggregation + checkout no-op + branch switch. All pass.
- `npx vitest run`: **208 passed / 25 files** (202 + 6).
- `npx tsc --noEmit -p apps/web/tsconfig.json`: exit 0.
- NOTE: a pre-existing `tsc -p apps/cli/tsconfig.json` error in `packages/security/Sandbox.ts` (owner's platform work, untouched here).

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json`
- [x] Tested against real git operations (temp repo), not mocks
- [x] PROGRES updated with dated entry
- [x] No duplicate logic (functions were stubs)
- [x] No empty files introduced