### PR TITLE
docs: sync docs to code after PR wave #328-#335

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,8 +97,9 @@ hooks/useDebounce+useTheme+useClipboard+useCommandPalette+useMediaQuery
    kali (keputusan #6: coarse watchRepository dulu, per-file deferred)
 4. `apps/web/lib/api.ts`/`graph.ts` — beberapa komponen (ImpactSummary,
    GlobalSearch) masih inline `fetch()`, belum consume `fetchJson()`
-5. Dashboard panels (workspace, explorer, overview) belum di-mount ke
-   halaman manapun
+5. Web page untuk commit history / contributors — git helpers
+   (getCommitHistory/getContributors, 08-14) udah siap, UI belum ada
+   (contoh pola: /api/branches → WorkspaceSwitcher)
 
 ## Kalau butuh detail lebih dalam
 `cat PROGRES.md progres/PROGRES-status-*.md progres/bugs.md progres/decisions.md progres/gotchas.md progres/collaborators.md`

--- a/README.md
+++ b/README.md
@@ -43,13 +43,12 @@ What is solid right now:
 - Real search engine (packages/search/* — fuzzy path + export-name matching, used by `/api/search`)
 - Framework convention rules (14 rules: Next.js, NestJS, Express, Vite, Electron, React, Laravel — `arclux verify` gates on them)
 - CLI commands: analyze, graph, impact, doctor, config, diff, diagnose, verify
-- Web dashboard: dependency graph viewer, layout/navigation, most UI patterns and primitives
+- Web dashboard: overview page (stats + project structure tree), graph viewer with a module Explorer panel, real search page, and a workspace (file tree, impact, detector issues, branch switcher) — all backed by live API routes (/api/analyze, /api/graph, /api/search, /api/impact, /api/doctor, /api/branches)
 - Verified against large real-world repositories (microsoft/vscode, facebook/react, vitejs/vite, laravel/laravel) in addition to internal fixtures
 
 What is not there yet:
 - General-purpose source parsers for Rust, C#, C++, PHP, Ruby (dependency-manifest parsing exists for all of these; PHP has route-file parsing — `packages/parser/php/parsePhpRoutes.ts` — but the general `.php` source parser is deliberately deferred, see `progres/decisions.md`)
 - True per-file incremental re-analysis (`packages/incremental` + `packages/watcher` are built and verified standalone; `watchRepository` wraps the pipeline in a coarse change-level cache, but `buildIndex` still does a full rebuild — see `progres/decisions.md`)
-- A handful of dashboard panels (workspace, explorer, some overview components) are not mounted on any page yet
 
 ## What it does
 

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -50,13 +50,12 @@ What is solid right now:
 - Real search engine (packages/search/* — fuzzy path + export-name matching, used by `/api/search`)
 - Framework convention rules (14 rules: Next.js, NestJS, Express, Vite, Electron, React, Laravel — `arclux verify` gates on them)
 - CLI commands: analyze, graph, impact, doctor, config, diff, diagnose, verify
-- Web dashboard: dependency graph viewer, layout/navigation, most UI patterns and primitives
+- Web dashboard: overview page (stats + project structure tree), graph viewer with a module Explorer panel, real search page, and a workspace (file tree, impact, detector issues, branch switcher) — all backed by live API routes (/api/analyze, /api/graph, /api/search, /api/impact, /api/doctor, /api/branches)
 - Verified against large real-world repositories (microsoft/vscode, facebook/react, vitejs/vite, laravel/laravel) in addition to internal fixtures
 
 What is not there yet:
 - General-purpose source parsers for Rust, C#, C++, PHP, Ruby (dependency-manifest parsing exists for all of these; PHP has route-file parsing — `packages/parser/php/parsePhpRoutes.ts` — but the general `.php` source parser is deliberately deferred, see `progres/decisions.md`)
 - True per-file incremental re-analysis (`packages/incremental` + `packages/watcher` are built and verified standalone; `watchRepository` wraps the pipeline in a coarse change-level cache, but `buildIndex` still does a full rebuild — see `progres/decisions.md`)
-- A handful of dashboard panels (workspace, explorer, some overview components) are not mounted on any page yet
 
 ## What it does
 
@@ -182,8 +181,9 @@ hooks/useDebounce+useTheme+useClipboard+useCommandPalette+useMediaQuery
    kali (keputusan #6: coarse watchRepository dulu, per-file deferred)
 4. `apps/web/lib/api.ts`/`graph.ts` — beberapa komponen (ImpactSummary,
    GlobalSearch) masih inline `fetch()`, belum consume `fetchJson()`
-5. Dashboard panels (workspace, explorer, overview) belum di-mount ke
-   halaman manapun
+5. Web page untuk commit history / contributors — git helpers
+   (getCommitHistory/getContributors, 08-14) udah siap, UI belum ada
+   (contoh pola: /api/branches → WorkspaceSwitcher)
 
 ## Kalau butuh detail lebih dalam
 `cat PROGRES.md progres/PROGRES-status-*.md progres/bugs.md progres/decisions.md progres/gotchas.md progres/collaborators.md`

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,7 +29,7 @@ Automated tests, run with Vitest (https://vitest.dev).
 
 ## Status
 
-191 tests across 23 files, all passing (`npx vitest run`).
+208 tests across 25 files, all passing (`npx vitest run`).
 
 ## Test files
 
@@ -43,13 +43,15 @@ Automated tests, run with Vitest (https://vitest.dev).
 | rules-frameworks.test.ts | 37 | the 10 framework rules (nextjs x4, nestjs x2, express, vite, electron x2) |
 | rules-laravel.test.ts | 8 | laravel/requireController (issue #53): controller existence, v1 scope |
 | graph.test.ts | 6 | buildDependencyGraph: dedup, external drops, implicit edges |
-| graph-callgraph.test.ts | 15 | buildCallGraph + extractCallsJs (issue #50): bare calls, weight, calledBy |
+| graph-callgraph.test.ts | 17 | buildCallGraph + extractCallsJs/TS (issues #50/#316): bare calls, weight, calledBy |
+| runDoctor.test.ts | 6 | packages/engine/runDoctor (POST /api/doctor): 19 detectors normalized to one finding list |
+| git-history.test.ts | 6 | packages/git checkoutBranch/getCommitHistory/getContributors against a real temp git repo |
 | impact.test.ts | 5 | calculateAffectedFiles: transitive, diamond, notFound |
 | indexer.test.ts | 5 | buildIndex end-to-end on a real temp dir |
 | pipeline.test.ts | 3 | analyzeRepository localPath: frameworks, index, graph, manifest deps |
 | analyze-summary.test.ts | 2 | CLI analyze summary formatting |
 | search.test.ts | 19 | packages/search engine (issue #9): index build, ranking, filters, session |
-| parser/typescript.test.ts | 7 | parseTs import/export kinds |
+| parser/typescript.test.ts | 10 | parseTs import/export kinds + bare-call extraction (issue #316) |
 | parser/javascript.test.ts | 6 | parseJs / parseJsx / parseCommonJs |
 | parser/python.test.ts | 5 | parsePython (tree-sitter) imports/exports |
 | parser/java.test.ts | 4 | parseJava imports, public-only exports, scopeId |


### PR DESCRIPTION
## What changed

Per the living-documentation protocol, syncing the docs to the code state after the #328-#335 PR wave (Explorer, Overview, workspace shell, search page, /api/doctor, FilesPanel, branch switcher, git helpers):

- **README.md**: removed the stale 'dashboard panels (workspace, explorer, some overview components) are not mounted on any page yet' bullet from *What is not there yet* — all are mounted now; the *What is solid* Web dashboard bullet now lists the live surfaces (overview, graph + Explorer, search, workspace with file tree/impact/issues/branch switcher) and the API routes behind them (/api/analyze, /api/graph, /api/search, /api/impact, /api/doctor, /api/branches).
- **CONTEXT.md**: Prioritas aktif #5 updated — panels are mounted; the next natural item is a commit-history/contributors web page (git helpers getCommitHistory/getContributors landed in #335).
- **tests/README.md**: 191 → 208 tests, 23 → 25 files; added runDoctor.test.ts (6) and git-history.test.ts (6) rows; updated typescript.test.ts 7→10 (call extraction, #316) and graph-callgraph.test.ts 15→17.
- **docs-site** regenerated via both generators.

## How was this verified

- Link check on all updated docs: no broken links
- `npx vitest run`: 208/208 · `npx tsc --noEmit -p apps/web/tsconfig.json`: exit 0
- Final stale-scan of root sources: only the honest alpha disclaimer remains ('stubs that are not wired up yet' — still true for db/, watcher consumer, etc.)

## Checklist

- [x] PROGRES/docs updated
- [x] No broken links
- [x] No duplicate information introduced