### PR TITLE
feat: activity page — commit history + contributors (/api/history, full clone support)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -97,9 +97,8 @@ hooks/useDebounce+useTheme+useClipboard+useCommandPalette+useMediaQuery
    kali (keputusan #6: coarse watchRepository dulu, per-file deferred)
 4. `apps/web/lib/api.ts`/`graph.ts` — beberapa komponen (ImpactSummary,
    GlobalSearch) masih inline `fetch()`, belum consume `fetchJson()`
-5. Web page untuk commit history / contributors — git helpers
-   (getCommitHistory/getContributors, 08-14) udah siap, UI belum ada
-   (contoh pola: /api/branches → WorkspaceSwitcher)
+5. (closed 08-14) Web page commit history/contributors — done:
+   /api/history + /[org]/[repo]/activity (lihat status-web.md)
 
 ## Kalau butuh detail lebih dalam
 `cat PROGRES.md progres/PROGRES-status-*.md progres/bugs.md progres/decisions.md progres/gotchas.md progres/collaborators.md`

--- a/apps/web/app/[org]/[repo]/activity/page.tsx
+++ b/apps/web/app/[org]/[repo]/activity/page.tsx
@@ -1,0 +1,24 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { ActivityView } from "@/components/activity/ActivityView";
+
+interface ActivityPageProps {
+  params: Promise<{ org: string; repo: string }>;
+}
+
+export default async function ActivityPage({ params }: ActivityPageProps) {
+  const { org, repo } = await params;
+  const repoUrl = `https://github.com/${org}/${repo}.git`;
+
+  return (
+    <div className="h-full overflow-auto p-8 text-neutral-200">
+      <ActivityView org={org} repo={repo} repoUrl={repoUrl} />
+    </div>
+  );
+}

--- a/apps/web/app/api/history/route.ts
+++ b/apps/web/app/api/history/route.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { cloneRepository } from "@/packages/git/cloneRepository";
+import { cleanupRepository } from "@/packages/git/cleanupRepository";
+import { getCommitHistory, type CommitInfo } from "@/packages/git/getCommitHistory";
+import { getContributors, type Contributor } from "@/packages/git/getContributors";
+import { isArcluxError } from "@/packages/shared/errors";
+
+/**
+ * GET /api/history?repoUrl=...&maxCount=50&branch=...
+ *
+ * Commit history + contributor aggregation for a repo. Unlike the
+ * analysis routes this needs git LOG data, so it does a FULL clone
+ * (cloneRepository depth: 0 — no --depth flag), reads history, then
+ * cleans up. Full clone is slower than a shallow one; maxCount caps the
+ * returned commits (default 50).
+ */
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams;
+  const repoUrl = searchParams.get("repoUrl");
+  const branch = searchParams.get("branch") ?? undefined;
+  const rawMaxCount = searchParams.get("maxCount");
+  const maxCount = rawMaxCount ? Math.max(1, Math.min(100, Number(rawMaxCount) || 50)) : 50;
+
+  if (!repoUrl) {
+    return NextResponse.json({ error: "`repoUrl` query param is required" }, { status: 400 });
+  }
+
+  let localPath: string | undefined;
+  try {
+    const cloneResult = await cloneRepository({ repoUrl, branch, depth: 0 });
+    localPath = cloneResult.localPath;
+
+    const commits: CommitInfo[] = await getCommitHistory(localPath, { maxCount, branch });
+    const contributors: Contributor[] = await getContributors(localPath);
+
+    return NextResponse.json(
+      { repoUrl, defaultBranch: cloneResult.branch, commits, contributors },
+      { status: 200 }
+    );
+  } catch (err) {
+    if (isArcluxError(err)) {
+      return NextResponse.json(
+        { error: err.message, code: err.code, filePath: err.filePath },
+        { status: 502 }
+      );
+    }
+    console.error("Unexpected error in /api/history:", err);
+    return NextResponse.json({ error: "Failed to load commit history" }, { status: 502 });
+  } finally {
+    if (localPath) {
+      await cleanupRepository(localPath).catch(() => {
+        // best-effort cleanup — never mask the real error
+      });
+    }
+  }
+}

--- a/apps/web/components/activity/ActivityView.tsx
+++ b/apps/web/components/activity/ActivityView.tsx
@@ -1,0 +1,156 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client";
+
+import { useEffect, useState } from "react";
+import { GitCommitHorizontal, Users } from "lucide-react";
+import { fetchJson } from "@/lib/api";
+import { LoadingState } from "@/components/patterns/LoadingState";
+import { ErrorState } from "@/components/patterns/ErrorState";
+import { EmptyState } from "@/components/patterns/EmptyState";
+import type { CommitInfo } from "@/packages/git/getCommitHistory";
+import type { Contributor } from "@/packages/git/getContributors";
+
+export interface ActivityViewProps {
+  org: string;
+  repo: string;
+  repoUrl: string;
+  branch?: string;
+}
+
+interface HistoryResponse {
+  repoUrl: string;
+  defaultBranch: string;
+  commits: CommitInfo[];
+  contributors: Contributor[];
+}
+
+function shortHash(hash: string): string {
+  return hash.slice(0, 8);
+}
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+/**
+ * [org]/[repo]/activity page: commit history + contributor aggregation
+ * from GET /api/history (full clone via cloneRepository({ depth: 0 }) +
+ * packages/git getCommitHistory/getContributors — both landed with the
+ * git-helpers PR #335).
+ */
+export function ActivityView({ repoUrl, branch }: ActivityViewProps) {
+  const [data, setData] = useState<HistoryResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [retryCount, setRetryCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const result = await fetchJson<HistoryResponse>("/api/history", {
+          repoUrl,
+          branch,
+          maxCount: "50",
+        });
+        if (!cancelled) setData(result);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load commit history");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoUrl, branch, retryCount]);
+
+  if (isLoading) return <LoadingState label="Cloning repository history (full clone, may take a moment)..." />;
+  if (error || !data) {
+    return (
+      <ErrorState
+        title="Could not load commit history"
+        message={error ?? "No data returned from /api/history."}
+        onRetry={() => setRetryCount((count) => count + 1)}
+      />
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <h1 className="text-lg font-semibold">Activity</h1>
+      <p className="mt-1 text-sm text-neutral-500">
+        {data.commits.length} recent commits on {data.defaultBranch} · {data.contributors.length} contributors
+      </p>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_300px]">
+        <section>
+          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-neutral-400">
+            <GitCommitHorizontal className="h-4 w-4" /> Commit history
+          </h2>
+          {data.commits.length === 0 ? (
+            <EmptyState title="No commits" message="This repository has no commit history." />
+          ) : (
+            <ul className="space-y-1.5">
+              {data.commits.map((commit) => (
+                <li
+                  key={commit.hash}
+                  className="rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
+                    <code className="font-mono text-xs text-neutral-500">{shortHash(commit.hash)}</code>
+                    <span className="text-xs text-neutral-500">{formatDate(commit.date)}</span>
+                    <span className="text-xs text-neutral-500">{commit.authorName}</span>
+                  </div>
+                  <p className="mt-0.5 line-clamp-2 text-sm text-neutral-200">{commit.message}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section>
+          <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-neutral-400">
+            <Users className="h-4 w-4" /> Contributors
+          </h2>
+          {data.contributors.length === 0 ? (
+            <EmptyState title="No contributors" message="No author data found." />
+          ) : (
+            <ul className="space-y-1.5">
+              {data.contributors.map((contributor) => (
+                <li
+                  key={contributor.email}
+                  className="flex items-center justify-between gap-3 rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm text-neutral-200">{contributor.name}</p>
+                    <p className="truncate font-mono text-xs text-neutral-500">{contributor.email}</p>
+                  </div>
+                  <span className="shrink-0 rounded bg-neutral-800 px-1.5 py-0.5 text-xs text-neutral-300">
+                    {contributor.commits}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/layout/Sidebar.tsx
+++ b/apps/web/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, Network, Search, Settings, PanelsTopLeft } from "lucide-react"
+import { LayoutDashboard, Network, Search, Settings, PanelsTopLeft, Activity } from "lucide-react"
 import { cn } from "@/lib/cn"
 
 interface SidebarProps {
@@ -26,6 +26,7 @@ export function Sidebar({ org, repo }: SidebarProps) {
     { label: "Overview", href: base, icon: LayoutDashboard },
     { label: "Graph", href: `${base}/graph`, icon: Network },
     { label: "Search", href: `${base}/search`, icon: Search },
+    { label: "Activity", href: `${base}/activity`, icon: Activity },
     { label: "Workspace", href: `${base}/workspace`, icon: PanelsTopLeft },
     { label: "Settings", href: `${base}/settings`, icon: Settings },
   ]

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -181,9 +181,8 @@ hooks/useDebounce+useTheme+useClipboard+useCommandPalette+useMediaQuery
    kali (keputusan #6: coarse watchRepository dulu, per-file deferred)
 4. `apps/web/lib/api.ts`/`graph.ts` — beberapa komponen (ImpactSummary,
    GlobalSearch) masih inline `fetch()`, belum consume `fetchJson()`
-5. Web page untuk commit history / contributors — git helpers
-   (getCommitHistory/getContributors, 08-14) udah siap, UI belum ada
-   (contoh pola: /api/branches → WorkspaceSwitcher)
+5. (closed 08-14) Web page commit history/contributors — done:
+   /api/history + /[org]/[repo]/activity (lihat status-web.md)
 
 ## Kalau butuh detail lebih dalam
 `cat PROGRES.md progres/PROGRES-status-*.md progres/bugs.md progres/decisions.md progres/gotchas.md progres/collaborators.md`

--- a/docs-site/progres/progres-status-web.mdx
+++ b/docs-site/progres/progres-status-web.mdx
@@ -557,3 +557,23 @@ verified in a real browser (standard gap).
   list; missing-repoUrl → 400; /workspace 200, no errors. tsc 0,
   eslint 0, vitest 202/202. Not visually verified in a real browser
   (standard gap).
+
+## 2026-08-14 — Activity page: commit history + contributors (/api/history)
+
+**Status:** Done
+
+- `cloneRepository` supports full clones now: `depth: 0` means no
+  `--depth` flag (the arg was previously unconditional, so a full clone
+  wasn't expressible). Documented on CloneOptions + the git-history
+  helpers' comments.
+- `GET /api/history?repoUrl=&maxCount=&branch=` (new route): full clone
+  (depth 0) → getCommitHistory + getContributors → cleanup; returns
+  `{ repoUrl, defaultBranch, commits, contributors }`. maxCount capped
+  1..100 (default 50).
+- `/[org]/[repo]/activity` page (new) renders ActivityView: recent
+  commits (short hash, date, author, message) + contributors sorted by
+  commit count; Sidebar gained an Activity link.
+- Verified live: /api/history on ARCLUX → 200, 5 commits (maxCount=5,
+  latest = the #336 merge), 6 contributors (top: GSF-001, 307);
+  /activity page 200, no errors. tsc 0, eslint 0, vitest 208/208. Not
+  visually verified in a real browser (standard gap).

--- a/packages/git/cloneRepository.ts
+++ b/packages/git/cloneRepository.ts
@@ -17,7 +17,9 @@ export interface CloneOptions {
   repoUrl: string;
   /** Branch to checkout. Defaults to the repo's default branch if omitted. */
   branch?: string;
-  /** Shallow clone depth. Defaults to 1 (fastest, no history) */
+  /** Shallow clone depth. Defaults to 1 (fastest, no history).
+   * Pass 0 for a FULL clone (history included) — e.g. for getCommitHistory/
+   * getContributors, which need git log data. */
   depth?: number;
 }
 
@@ -32,13 +34,17 @@ export interface CloneResult {
  * cleanupRepository.ts on `localPath` once analysis is done.
  */
 export async function cloneRepository(options: CloneOptions): Promise<CloneResult> {
-  const { repoUrl, branch, depth = 1 } = options;
+  const { repoUrl, branch } = options;
+  const depth = options.depth ?? 1;
 
   const workDir = mkdtempSync(join(tmpdir(), "arclux-"));
   const git = simpleGit();
 
   try {
-    const cloneArgs = ["--depth", String(depth)];
+    const cloneArgs: string[] = [];
+    if (depth > 0) {
+      cloneArgs.push("--depth", String(depth));
+    }
     if (branch) {
       cloneArgs.push("--branch", branch);
     }

--- a/packages/git/getCommitHistory.ts
+++ b/packages/git/getCommitHistory.ts
@@ -28,9 +28,9 @@ export interface GetCommitHistoryOptions {
 
 /**
  * Returns commit history for a local clone at localPath via
- * `git log`. Requires a full (non-shallow) clone to see history — the
- * pipeline's cloneRepository defaults to depth 1, so callers wanting
- * history should clone with `depth: undefined` or fetch first.
+ * `git log`. Requires a full (non-shallow) clone to see history — use
+ * cloneRepository({ depth: 0 }); the shallow default (depth 1) has no
+ * log data.
  */
 export async function getCommitHistory(
   localPath: string,

--- a/packages/git/getContributors.ts
+++ b/packages/git/getContributors.ts
@@ -18,8 +18,8 @@ export interface Contributor {
 /**
  * Aggregates commit authors for a local clone at localPath via
  * `git shortlog -sne --no-merges` — one entry per author, sorted by
- * commit count descending. Requires a full (non-shallow) clone; see
- * getCommitHistory.ts's note.
+ * commit count descending. Requires a full (non-shallow) clone — use
+ * cloneRepository({ depth: 0 }), see getCommitHistory.ts's note.
  */
 export async function getContributors(localPath: string): Promise<Contributor[]> {
   const git = simpleGit(localPath);

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -550,3 +550,23 @@ verified in a real browser (standard gap).
   list; missing-repoUrl → 400; /workspace 200, no errors. tsc 0,
   eslint 0, vitest 202/202. Not visually verified in a real browser
   (standard gap).
+
+## 2026-08-14 — Activity page: commit history + contributors (/api/history)
+
+**Status:** Done
+
+- `cloneRepository` supports full clones now: `depth: 0` means no
+  `--depth` flag (the arg was previously unconditional, so a full clone
+  wasn't expressible). Documented on CloneOptions + the git-history
+  helpers' comments.
+- `GET /api/history?repoUrl=&maxCount=&branch=` (new route): full clone
+  (depth 0) → getCommitHistory + getContributors → cleanup; returns
+  `{ repoUrl, defaultBranch, commits, contributors }`. maxCount capped
+  1..100 (default 50).
+- `/[org]/[repo]/activity` page (new) renders ActivityView: recent
+  commits (short hash, date, author, message) + contributors sorted by
+  commit count; Sidebar gained an Activity link.
+- Verified live: /api/history on ARCLUX → 200, 5 commits (maxCount=5,
+  latest = the #336 merge), 6 contributors (top: GSF-001, 307);
+  /activity page 200, no errors. tsc 0, eslint 0, vitest 208/208. Not
+  visually verified in a real browser (standard gap).


### PR DESCRIPTION
## What changed

A new repo view backed by the git-history helpers from #335:

- **`cloneRepository` now supports full clones**: `depth: 0` means no `--depth` flag (previously the flag was unconditional, so a full clone wasn't expressible — history needs one). Documented on CloneOptions and the git-history helpers.
- **`GET /api/history?repoUrl=&maxCount=&branch=`** (new route): full clone → `getCommitHistory` + `getContributors` → cleanup in `finally`; returns `{ repoUrl, defaultBranch, commits, contributors }`. maxCount capped 1..100 (default 50).
- **`/[org]/[repo]/activity`** page + `ActivityView`: recent commits (short hash, date, author, message) + contributors sorted by commit count; Sidebar gained an Activity link.

## How was this verified

- Live dev server: `GET /api/history?repoUrl=...ARCLUX.git&maxCount=5` → HTTP 200 — 5 commits (latest = the #336 merge), 6 contributors (top: GSF-001, 307 commits); `/activity` page → 200, no server errors.
- `npx tsc --noEmit -p apps/web/tsconfig.json`: exit 0. `npx vitest run`: 208/208 (incl. git-history tests against a real temp repo).
- NOTE: page rendering not visually confirmed in a real browser (standard documented gap).

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json`
- [x] Tested on a live dev server + real repo
- [x] PROGRES updated with dated entry
- [x] No duplicate logic (helpers reused; only clone-depth + route/UI are new)
- [x] No empty files introduced
- [ ] Not visually verified in browser (noted above)