### PR TITLE
feat: OWP-lens hardening — guard inventory (19/19 detectors), scanSummary (eligible_seen), crash isolation

### DIFF
--- a/apps/cli/analyze.ts
+++ b/apps/cli/analyze.ts
@@ -53,7 +53,7 @@ export function registerAnalyzeCommand(program: Command): void {
       spinner.start(`Analyzing ${targetPath}`);
       const startedAt = Date.now();
       try {
-        const { repository, meta, graph } = await analyzeRepository({ localPath: targetPath });
+        const { repository, meta, graph, scanSummary } = await analyzeRepository({ localPath: targetPath });
         const elapsedMs = Date.now() - startedAt;
         spinner.stop("Analysis complete");
 
@@ -61,6 +61,9 @@ export function registerAnalyzeCommand(program: Command): void {
         p.log.info(`Frameworks: ${meta.detectedFrameworks.join(", ") || "none detected"}`);
         p.log.info(`Package manager: ${meta.packageManager}`);
         p.log.success(`${repository.moduleCount} modules indexed`);
+        p.log.info(
+          `Scan: ${result.scanSummary.filesScanned} files, ${result.scanSummary.filesParsed} parsed, ${result.scanSummary.filesSkippedNoParser} skipped (no parser)`
+        );
         p.log.success(`${graph.nodes.length} nodes, ${graph.edges.length} edges in dependency graph`);
 
         const summary = summarizeDetectors(repository);

--- a/docs-site/progres/progres-decisions.mdx
+++ b/docs-site/progres/progres-decisions.mdx
@@ -840,6 +840,39 @@ other TS-family parsers) is a separate, smaller follow-up — file it as
 an issue when a contributor picks it up. Known limitations documented
 in the code: default-imported callees unresolvable, `obj.foo()` /
 `this.foo()` not captured (AST-only, no type info).
+
+## 2026-08-14 — OWP-lens hardening: eligible_seen, negative controls, crash isolation
+
+**Context:** external review (OWP-class analysis, Tom Jones's
+`eligible_seen` / population-rot framing) identified three real gaps in
+ARCLUX: (1) no committed negative controls for 7 of 19 detectors — only
+prose-documented manual "positive control" verifications;
+(2) buildIndex silently dropped unparseable files — no scan-vs-parse
+accounting, so "0 Python modules" was indistinguishable from "Python
+files were skipped"; (3) one detector throwing would kill the whole
+doctor/verify suite and look like "no findings".
+
+**Decision:**
+- **Guard inventory (negative controls):** `tests/guard-inventory.test.ts`
+  — known-bad + clean fixtures for detectDeadCode/detectDuplicateModules/
+  detectEntryPoints/detectIndexFiles/detectLargeModules/
+  detectLayerViolation/detectSharedModules (the 7 without committed
+  tests). All 19 detectors now have committed positive controls; the
+  coverage matrix lives in tests/README.md.
+- **Population rot guard (eligible_seen):** `ScanSummary` in
+  shared/types.ts — filesScanned/filesParsed/filesSkippedNoParser/
+  skippedByExtension, populated by buildIndex pass 1, carried on
+  Repository, surfaced in AnalyzeRepositoryResult (/api/analyze) and the
+  analyze CLI line. Consumers can now see how much of the repo made it
+  into the graph and WHY the rest didn't.
+- **Structural-death guard:** `safeRun` in runDoctor wraps every detector
+  (DETECTOR CRASHED finding instead of killing the suite); runAllChecks
+  in contract.ts got the same try/catch isolation.
+
+**Alternatives rejected:** a meta-test that mechanically asserts every
+detector is covered (fragile — can't introspect "meaningful" coverage);
+a runtime registry of eligible sources (over-engineered for a static
+analyzer — the scan summary covers the population-rot concern).
 ARCLUX.main
 
 ## 2026-08-14 — packages/change: new protocol for applying changes, not workstation duplicate

--- a/docs-site/progres/progres-status-core.mdx
+++ b/docs-site/progres/progres-status-core.mdx
@@ -582,3 +582,26 @@ detectDefaultBranch which landed with the branch switcher):
   [&#123; name, email, commits &#125;] sorted by count.
 6 tests (tests/git-history.test.ts) against a real temp git repo
 (git init + commits); tsc 0, vitest 208/208 (202 + 6).
+
+## 2026-08-14 — OWP-lens hardening: guard inventory, scanSummary, crash isolation
+
+**Status:** Done
+
+Three fixes from an OWP-class review (eligible_seen / population rot /
+structural death framing — full decision in progres/decisions.md):
+- **Guard inventory:** tests/guard-inventory.test.ts — positive + clean
+  fixtures for the 7 detectors that had only prose-documented manual
+  verifications (deadCode, duplicateModules, entryPoints, indexFiles,
+  largeModules, layerViolation, sharedModules). All 19 detectors now
+  have committed negative controls; coverage matrix in tests/README.md.
+- **eligible_seen:** ScanSummary (filesScanned/filesParsed/
+  filesSkippedNoParser/skippedByExtension) populated in buildIndex pass
+  1, carried on Repository, surfaced in AnalyzeRepositoryResult and the
+  analyze CLI. Verified: ARCLUX itself 546 scanned = 546 parsed (0
+  skipped); a mixed .ts/.go/.php/.rb fixture counts the 2 skipped
+  languages explicitly.
+- **Structural-death guard:** safeRun in runDoctor wraps every detector
+  (crash → DETECTOR CRASHED error finding, suite continues); runAllChecks
+  in contract.ts isolated the same way.
+Tests: 224/224 (208 + 14 guard-inventory + 1 safeRun + 1 scanSummary).
+tsc 0.

--- a/packages/engine/contract.ts
+++ b/packages/engine/contract.ts
@@ -92,13 +92,24 @@ export function runAllChecks(repository: Repository): RunAllChecksResult {
   ];
 
   for (const [checkId, run] of detectorRuns) {
-    const findings = run() as unknown[];
-    for (const _finding of findings) {
+    try {
+      const findings = run() as unknown[];
+      for (const _finding of findings) {
+        issues.push({
+          source: "detector",
+          checkId,
+          severity: "error",
+          message: `${checkId} finding (see detector output for detail)`,
+        });
+      }
+    } catch (err) {
+      // Structural-death guard: a detector that throws must not silently
+      // kill the whole check — surface it as an error issue instead.
       issues.push({
         source: "detector",
         checkId,
         severity: "error",
-        message: `${checkId} finding (see detector output for detail)`,
+        message: `DETECTOR CRASHED: ${err instanceof Error ? err.message : String(err)} — ${checkId} findings unreliable.`,
       });
     }
   }

--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -34,7 +34,7 @@ import { parseGradle_, parsePom } from "../parser/java/parseGradlePom";
 import { parseRequirements } from "../parser/python/parseRequirements";
 import { detectFrameworks, detectPackageManager } from "./detectRepositoryMeta";
 import { ArcluxError, isArcluxError } from "../shared/errors";
-import type { DependencyGraph, RepositoryMeta } from "../shared/types";
+import type { DependencyGraph, RepositoryMeta, ScanSummary } from "../shared/types";
 import type { Repository } from "../repository/Repository";
 
 // Register known parsers once, at module load. As more languages get parser
@@ -83,6 +83,12 @@ export interface AnalyzeRepositoryResult {
   meta: RepositoryMeta;
   moduleCount: number;
   graph: DependencyGraph;
+  /**
+   * Scan accounting — files scanned vs parsed vs skipped (no parser for
+   * the language). The population-rot guard: tells consumers how much of
+   * the repo actually made it into the graph (see ScanSummary).
+   */
+  scanSummary: ScanSummary;
   /**
    * Full in-memory Repository, for server-side consumers that need to run
    * detectors/impact analysis (CLI, /api/impact, /api/search) without
@@ -197,6 +203,12 @@ async function analyzeLocalPath(localPath: string): Promise<AnalyzeRepositoryRes
     meta: repository.meta,
     moduleCount: repository.moduleCount,
     graph,
+    scanSummary: repository.scanSummary ?? {
+      filesScanned: 0,
+      filesParsed: 0,
+      filesSkippedNoParser: 0,
+      skippedByExtension: {},
+    },
     repository,
     dependencies: manifestRegistry.detectDependencies(resolvedPath),
   };
@@ -275,6 +287,12 @@ async function analyzeRemoteRepository(
       meta: repository.meta,
       moduleCount: repository.moduleCount,
       graph,
+      scanSummary: repository.scanSummary ?? {
+        filesScanned: 0,
+        filesParsed: 0,
+        filesSkippedNoParser: 0,
+        skippedByExtension: {},
+      },
       repository,
       dependencies: manifestRegistry.detectDependencies(localPath),
     };

--- a/packages/engine/runDoctor.ts
+++ b/packages/engine/runDoctor.ts
@@ -55,6 +55,30 @@ export interface RunDoctorResult {
   infoCount: number;
 }
 
+/**
+ * Runs one detector, isolating crashes (structural-death guard): if a
+ * detector throws, the suite keeps going and the failure is surfaced as
+ * an error finding instead of silently killing the whole run. A detector
+ * that dies on every input would otherwise look like "no findings".
+ * Exported for direct unit testing of the isolation contract.
+ */
+export function safeRun(
+  checkId: string,
+  severity: DoctorSeverity,
+  run: () => void,
+  findings: DoctorFinding[]
+): void {
+  try {
+    run();
+  } catch (err) {
+    findings.push({
+      checkId,
+      severity,
+      message: `DETECTOR CRASHED: ${err instanceof Error ? err.message : String(err)} — findings for this check are unreliable.`,
+    });
+  }
+}
+
 /** Location of a convention finding, mirroring doctor.ts's selection order. */
 function locationOf(f: Record<string, unknown>): string | undefined {
   if ("filePath" in f && typeof f.filePath === "string") return f.filePath;
@@ -66,80 +90,102 @@ function locationOf(f: Record<string, unknown>): string | undefined {
 export function runDoctor(repository: Repository): RunDoctorResult {
   const findings: DoctorFinding[] = [];
 
+  // Every detector is wrapped in safeRun — a detector that throws must
+  // not silently kill the suite or look like "no findings" (structural
+  // death guard, OWP §4.1 lens; see safeRun above).
+
   // ── error: structural problems ──────────────────────────────
-  for (const c of detectCircularDependency(repository)) {
-    findings.push({
-      checkId: "circularDependency",
-      severity: "error",
-      message: c.cycle.join(" \u2192 "),
-    });
-  }
-  for (const f of detectUnusedExports(repository)) {
-    findings.push({
-      checkId: "unusedExports",
-      severity: "error",
-      filePath: f.filePath,
-      message: `${f.exportName} (${f.exportKind}, line ${f.line}) \u2014 ${f.message}`,
-    });
-  }
-  for (const f of detectOrphanFiles(repository)) {
-    findings.push({
-      checkId: "orphanFiles",
-      severity: "error",
-      filePath: f.filePath,
-      message: f.message,
-    });
-  }
-  for (const f of detectLayerViolation(repository)) {
-    findings.push({
-      checkId: "layerViolation",
-      severity: "error",
-      filePath: f.filePath,
-      message: `imports ${f.importedFilePath} [${f.ruleName}] at line ${f.line} \u2014 ${f.message}`,
-    });
-  }
-  for (const f of detectAmbiguousSymbolResolution(repository)) {
-    findings.push({
-      checkId: "ambiguousSymbolResolution",
-      severity: f.severity === "high" ? "error" : "warning",
-      message: `${f.symbolName} — ${f.reason}; definitions: ${f.definitions
-        .map((d) => `${d.modulePath}:${d.line} (${d.category})`)
-        .join(", ")}`,
-    });
-  }
+  safeRun("circularDependency", "error", () => {
+    for (const c of detectCircularDependency(repository)) {
+      findings.push({
+        checkId: "circularDependency",
+        severity: "error",
+        message: c.cycle.join(" \u2192 "),
+      });
+    }
+  }, findings);
+  safeRun("unusedExports", "error", () => {
+    for (const f of detectUnusedExports(repository)) {
+      findings.push({
+        checkId: "unusedExports",
+        severity: "error",
+        filePath: f.filePath,
+        message: `${f.exportName} (${f.exportKind}, line ${f.line}) \u2014 ${f.message}`,
+      });
+    }
+  }, findings);
+  safeRun("orphanFiles", "error", () => {
+    for (const f of detectOrphanFiles(repository)) {
+      findings.push({
+        checkId: "orphanFiles",
+        severity: "error",
+        filePath: f.filePath,
+        message: f.message,
+      });
+    }
+  }, findings);
+  safeRun("layerViolation", "error", () => {
+    for (const f of detectLayerViolation(repository)) {
+      findings.push({
+        checkId: "layerViolation",
+        severity: "error",
+        filePath: f.filePath,
+        message: `imports ${f.importedFilePath} [${f.ruleName}] at line ${f.line} \u2014 ${f.message}`,
+      });
+    }
+  }, findings);
+  safeRun("ambiguousSymbolResolution", "error", () => {
+    for (const f of detectAmbiguousSymbolResolution(repository)) {
+      findings.push({
+        checkId: "ambiguousSymbolResolution",
+        severity: f.severity === "high" ? "error" : "warning",
+        message: `${f.symbolName} — ${f.reason}; definitions: ${f.definitions
+          .map((d) => `${d.modulePath}:${d.line} (${d.category})`)
+          .join(", ")}`,
+      });
+    }
+  }, findings);
 
   // ── warning: hygiene / conventions ──────────────────────────
-  for (const f of detectLargeModules(repository)) {
-    findings.push({
-      checkId: "largeModules",
-      severity: "warning",
-      filePath: f.filePath,
-      message: `${f.sizeBytes.toLocaleString()} bytes \u2014 ${f.message}`,
-    });
-  }
-  for (const g of detectDuplicateModules(repository)) {
-    findings.push({
-      checkId: "duplicateModules",
-      severity: "warning",
-      message: `${g.filePaths.join(", ")} (${g.sizeBytes.toLocaleString()} bytes each)`,
-    });
-  }
-  for (const f of detectIndexFiles(repository)) {
-    findings.push({
-      checkId: "indexFiles",
-      severity: f.isPureBarrel ? "info" : "warning",
-      filePath: f.filePath,
-      message: f.message,
-    });
-  }
-  for (const f of detectDeadCode(repository)) {
-    findings.push({
-      checkId: "deadCode",
-      severity: "warning",
-      filePath: f.filePath,
-      message: `${f.unusedExportCount} unused export(s), imported by ${f.importedByCount} \u2014 ${f.message}`,
-    });
-  }
+  safeRun("largeModules", "warning", () => {
+    for (const f of detectLargeModules(repository)) {
+      findings.push({
+        checkId: "largeModules",
+        severity: "warning",
+        filePath: f.filePath,
+        message: `${f.sizeBytes.toLocaleString()} bytes \u2014 ${f.message}`,
+      });
+    }
+  }, findings);
+  safeRun("duplicateModules", "warning", () => {
+    for (const g of detectDuplicateModules(repository)) {
+      findings.push({
+        checkId: "duplicateModules",
+        severity: "warning",
+        message: `${g.filePaths.join(", ")} (${g.sizeBytes.toLocaleString()} bytes each)`,
+      });
+    }
+  }, findings);
+  safeRun("indexFiles", "warning", () => {
+    for (const f of detectIndexFiles(repository)) {
+      findings.push({
+        checkId: "indexFiles",
+        severity: f.isPureBarrel ? "info" : "warning",
+        filePath: f.filePath,
+        message: f.message,
+      });
+    }
+  }, findings);
+  safeRun("deadCode", "warning", () => {
+    for (const f of detectDeadCode(repository)) {
+      findings.push({
+        checkId: "deadCode",
+        severity: "warning",
+        filePath: f.filePath,
+        message: `${f.unusedExportCount} unused export(s), imported by ${f.importedByCount} \u2014 ${f.message}`,
+      });
+    }
+  }, findings);
 
   const conventionDetectors: Array<{ checkId: string; run: () => unknown[] }> = [
     { checkId: "componentConvention", run: () => detectComponentConvention(repository) },
@@ -152,15 +198,17 @@ export function runDoctor(repository: Repository): RunDoctorResult {
     { checkId: "unusedFiles", run: () => detectUnusedFiles(repository) },
   ];
   for (const { checkId, run } of conventionDetectors) {
-    for (const finding of run()) {
-      const f = finding as Record<string, unknown>;
-      findings.push({
-        checkId,
-        severity: "warning",
-        filePath: locationOf(f),
-        message: typeof f.message === "string" ? f.message : JSON.stringify(finding),
-      });
-    }
+    safeRun(checkId, "warning", () => {
+      for (const finding of run()) {
+        const f = finding as Record<string, unknown>;
+        findings.push({
+          checkId,
+          severity: "warning",
+          filePath: locationOf(f),
+          message: typeof f.message === "string" ? f.message : JSON.stringify(finding),
+        });
+      }
+    }, findings);
   }
 
   // ── info: informational classifiers ─────────────────────────

--- a/packages/indexer/buildIndex.ts
+++ b/packages/indexer/buildIndex.ts
@@ -48,9 +48,19 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
   // need it, only the already-extracted imports/exports.
   const parsedByPath = new Map<string, ParsedFile>();
   const contentByPath = new Map<string, string>();
+  let filesParsed = 0;
+  let filesSkippedNoParser = 0;
+  const skippedByExtension: Record<string, number> = {};
   for (const file of files) {
     const parser = parserRegistry.getParserForExtension(file.extension);
-    if (!parser) continue; // no parser registered yet for this language — skip, don't crash
+    if (!parser) {
+      // No parser registered yet for this language — skip, don't crash.
+      // Counted so consumers can distinguish "0 Python modules" from
+      // "Python files were skipped" (ScanSummary — the population-rot guard).
+      filesSkippedNoParser += 1;
+      skippedByExtension[file.extension] = (skippedByExtension[file.extension] ?? 0) + 1;
+      continue;
+    }
 
     let content: string;
     try {
@@ -70,7 +80,15 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
 
     parsedByPath.set(file.relativePath, parsed);
     contentByPath.set(file.relativePath, content);
+    filesParsed += 1;
   }
+
+  repository.scanSummary = {
+    filesScanned: files.length,
+    filesParsed,
+    filesSkippedNoParser,
+    skippedByExtension,
+  };
 
   // Pass 2: implicit same-scope dependencies (Go/Java files with no import
   // statement between siblings — see resolveSameScopeDependencies.ts).

--- a/packages/repository/Repository.ts
+++ b/packages/repository/Repository.ts
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-import type { RepositoryMeta, ModuleInfo } from "../shared/types";
+import type { RepositoryMeta, ModuleInfo, ScanSummary } from "../shared/types";
 
 /**
  * In-memory representation of one analyzed repository.
@@ -16,6 +16,8 @@ import type { RepositoryMeta, ModuleInfo } from "../shared/types";
 export class Repository {
   readonly meta: RepositoryMeta;
   private modules: Map<string, ModuleInfo> = new Map();
+  /** Scan accounting set by buildIndex pass 1 — see ScanSummary in shared/types.ts. */
+  scanSummary?: ScanSummary;
 
   constructor(meta: RepositoryMeta) {
     this.meta = meta;

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -316,3 +316,26 @@ export interface ExternalDependency {
   /** Total number of import statements referencing this package, across all modules */
   importCount: number;
 }
+
+// ─────────────────────────────────────────────
+// Scan accounting (the "eligible_seen" of ARCLUX — see progres/decisions.md)
+// ─────────────────────────────────────────────
+
+/**
+ * How many files were scanned vs actually made it into the Repository.
+ * The population-rot guard: a graph built from a snapshot silently drops
+ * files whose language has no registered parser — without this, consumers
+ * can't tell "repo has 0 Python modules" from "Python files were skipped".
+ * Populated by buildIndex.ts pass 1; carried on Repository + surfaced in
+ * AnalyzeRepositoryResult / /api/analyze.
+ */
+export interface ScanSummary {
+  /** Total files matched by scanFiles (before parser dispatch). */
+  filesScanned: number;
+  /** Files that a registered parser successfully parsed into a ModuleInfo. */
+  filesParsed: number;
+  /** Files skipped because no parser is registered for their extension. */
+  filesSkippedNoParser: number;
+  /** skipped count per extension, e.g. {".py": 12} — why the population shrank. */
+  skippedByExtension: Record<string, number>;
+}

--- a/progres/decisions.md
+++ b/progres/decisions.md
@@ -833,6 +833,39 @@ other TS-family parsers) is a separate, smaller follow-up — file it as
 an issue when a contributor picks it up. Known limitations documented
 in the code: default-imported callees unresolvable, `obj.foo()` /
 `this.foo()` not captured (AST-only, no type info).
+
+## 2026-08-14 — OWP-lens hardening: eligible_seen, negative controls, crash isolation
+
+**Context:** external review (OWP-class analysis, Tom Jones's
+`eligible_seen` / population-rot framing) identified three real gaps in
+ARCLUX: (1) no committed negative controls for 7 of 19 detectors — only
+prose-documented manual "positive control" verifications;
+(2) buildIndex silently dropped unparseable files — no scan-vs-parse
+accounting, so "0 Python modules" was indistinguishable from "Python
+files were skipped"; (3) one detector throwing would kill the whole
+doctor/verify suite and look like "no findings".
+
+**Decision:**
+- **Guard inventory (negative controls):** `tests/guard-inventory.test.ts`
+  — known-bad + clean fixtures for detectDeadCode/detectDuplicateModules/
+  detectEntryPoints/detectIndexFiles/detectLargeModules/
+  detectLayerViolation/detectSharedModules (the 7 without committed
+  tests). All 19 detectors now have committed positive controls; the
+  coverage matrix lives in tests/README.md.
+- **Population rot guard (eligible_seen):** `ScanSummary` in
+  shared/types.ts — filesScanned/filesParsed/filesSkippedNoParser/
+  skippedByExtension, populated by buildIndex pass 1, carried on
+  Repository, surfaced in AnalyzeRepositoryResult (/api/analyze) and the
+  analyze CLI line. Consumers can now see how much of the repo made it
+  into the graph and WHY the rest didn't.
+- **Structural-death guard:** `safeRun` in runDoctor wraps every detector
+  (DETECTOR CRASHED finding instead of killing the suite); runAllChecks
+  in contract.ts got the same try/catch isolation.
+
+**Alternatives rejected:** a meta-test that mechanically asserts every
+detector is covered (fragile — can't introspect "meaningful" coverage);
+a runtime registry of eligible sources (over-engineered for a static
+analyzer — the scan summary covers the population-rot concern).
 ARCLUX.main
 
 ## 2026-08-14 — packages/change: new protocol for applying changes, not workstation duplicate

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -575,3 +575,26 @@ detectDefaultBranch which landed with the branch switcher):
   [{ name, email, commits }] sorted by count.
 6 tests (tests/git-history.test.ts) against a real temp git repo
 (git init + commits); tsc 0, vitest 208/208 (202 + 6).
+
+## 2026-08-14 — OWP-lens hardening: guard inventory, scanSummary, crash isolation
+
+**Status:** Done
+
+Three fixes from an OWP-class review (eligible_seen / population rot /
+structural death framing — full decision in progres/decisions.md):
+- **Guard inventory:** tests/guard-inventory.test.ts — positive + clean
+  fixtures for the 7 detectors that had only prose-documented manual
+  verifications (deadCode, duplicateModules, entryPoints, indexFiles,
+  largeModules, layerViolation, sharedModules). All 19 detectors now
+  have committed negative controls; coverage matrix in tests/README.md.
+- **eligible_seen:** ScanSummary (filesScanned/filesParsed/
+  filesSkippedNoParser/skippedByExtension) populated in buildIndex pass
+  1, carried on Repository, surfaced in AnalyzeRepositoryResult and the
+  analyze CLI. Verified: ARCLUX itself 546 scanned = 546 parsed (0
+  skipped); a mixed .ts/.go/.php/.rb fixture counts the 2 skipped
+  languages explicitly.
+- **Structural-death guard:** safeRun in runDoctor wraps every detector
+  (crash → DETECTOR CRASHED error finding, suite continues); runAllChecks
+  in contract.ts isolated the same way.
+Tests: 224/224 (208 + 14 guard-inventory + 1 safeRun + 1 scanSummary).
+tsc 0.

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,7 +29,7 @@ Automated tests, run with Vitest (https://vitest.dev).
 
 ## Status
 
-208 tests across 25 files, all passing (`npx vitest run`).
+224 tests across 26 files, all passing (`npx vitest run`).
 
 ## Test files
 
@@ -44,10 +44,11 @@ Automated tests, run with Vitest (https://vitest.dev).
 | rules-laravel.test.ts | 8 | laravel/requireController (issue #53): controller existence, v1 scope |
 | graph.test.ts | 6 | buildDependencyGraph: dedup, external drops, implicit edges |
 | graph-callgraph.test.ts | 17 | buildCallGraph + extractCallsJs/TS (issues #50/#316): bare calls, weight, calledBy |
-| runDoctor.test.ts | 6 | packages/engine/runDoctor (POST /api/doctor): 19 detectors normalized to one finding list |
+| runDoctor.test.ts | 7 | packages/engine/runDoctor (POST /api/doctor): 19 detectors normalized + safeRun crash isolation |
 | git-history.test.ts | 6 | packages/git checkoutBranch/getCommitHistory/getContributors against a real temp git repo |
+| guard-inventory.test.ts | 14 | negative controls for the 7 detectors that had none (deadCode, duplicateModules, entryPoints, indexFiles, largeModules, layerViolation, sharedModules) |
 | impact.test.ts | 5 | calculateAffectedFiles: transitive, diamond, notFound |
-| indexer.test.ts | 5 | buildIndex end-to-end on a real temp dir |
+| indexer.test.ts | 6 | buildIndex end-to-end on a real temp dir (incl. scanSummary eligible_seen accounting) |
 | pipeline.test.ts | 3 | analyzeRepository localPath: frameworks, index, graph, manifest deps |
 | analyze-summary.test.ts | 2 | CLI analyze summary formatting |
 | search.test.ts | 19 | packages/search engine (issue #9): index build, ranking, filters, session |
@@ -60,6 +61,21 @@ Automated tests, run with Vitest (https://vitest.dev).
 | parser/rust.test.ts | 4 | parseCargoToml against tokio's real Cargo.toml |
 | indexer/resolveSameScopeDependencies.test.ts | 6 | Go same-package implicit dependency resolution |
 | watcher/changeQueue.test.ts | 5 | change queue debounce/dedup (fake timers) |
+
+## Guard inventory — detector coverage matrix
+
+Every detector has at least one committed negative control (a KNOWN-BAD
+fixture that must fire). This is the "detector definitely fires"
+guarantee — see tests/guard-inventory.test.ts for the 7 detectors that
+previously had only manual verifications.
+
+| Detector | Covered in |
+|---|---|
+| detectCircularDependency, detectUnusedExports, detectOrphanFiles | core-detectors.test.ts |
+| detectAmbiguousSymbolResolution | detector.test.ts |
+| detectComponentConvention, detectFeatureStructure, detectMissingExports, detectRepositoryPattern, detectRouteConvention, detectStoryConvention, detectTestConvention, detectUnusedFiles | detectors-wired.test.ts |
+| detectDeadCode, detectDuplicateModules, detectEntryPoints, detectIndexFiles, detectLargeModules, detectLayerViolation, detectSharedModules | guard-inventory.test.ts |
+| runDoctor normalization (all 19 via runDoctor) | runDoctor.test.ts |
 
 ## Fixtures
 

--- a/tests/guard-inventory.test.ts
+++ b/tests/guard-inventory.test.ts
@@ -1,0 +1,234 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// GUARD INVENTORY — negative controls for the detectors that had NO
+// committed positive-control test (2026-08-14 audit, OWP §4.1 lens):
+// detectDeadCode, detectDuplicateModules, detectEntryPoints,
+// detectIndexFiles, detectLargeModules, detectLayerViolation,
+// detectSharedModules. Each detector gets a KNOWN-BAD fixture (must
+// fire) and a clean fixture (must not fire) — the "detector definitely
+// fires on a planted violation" guarantee. Full 19-detector coverage
+// matrix lives in tests/README.md.
+//
+// NOTE: detectLayerViolation + detectDeadCode were previously verified
+// manually with positive controls (see progres/status-detectors.md) but
+// never committed — this file makes those regressions permanent.
+
+import { describe, it, expect } from "vitest";
+import { Repository } from "../packages/repository/Repository";
+import { detectDeadCode } from "../packages/detectors/detectDeadCode";
+import { detectDuplicateModules } from "../packages/detectors/detectDuplicateModules";
+import { detectEntryPoints } from "../packages/detectors/detectEntryPoints";
+import { detectIndexFiles } from "../packages/detectors/detectIndexFiles";
+import { detectLargeModules } from "../packages/detectors/detectLargeModules";
+import { detectLayerViolation } from "../packages/detectors/detectLayerViolation";
+import { detectSharedModules } from "../packages/detectors/detectSharedModules";
+import type { ModuleInfo, RepositoryMeta, FileInfo, RawExport } from "../packages/shared/types";
+
+function makeFile(relativePath: string, sizeBytes = 100): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "typescript",
+    extension: ".ts",
+    sizeBytes,
+    hash: `hash-${relativePath}`,
+  };
+}
+
+function named(name: string, line = 1): RawExport {
+  return { name, kind: "named", line };
+}
+
+function reExport(name: string, source: string, line = 1): RawExport {
+  return { name, kind: "re-export", reExportSource: source, line };
+}
+
+interface ResolvedImport {
+  moduleId: string;
+  namedImports: string[];
+  hasDefaultImport: boolean;
+  hasNamespaceImport: boolean;
+  line: number;
+}
+
+function makeModule(
+  relativePath: string,
+  opts: {
+    exports?: RawExport[];
+    imports?: string[];
+    resolvedImports?: ResolvedImport[];
+    importedBy?: string[];
+    sizeBytes?: number;
+    hash?: string;
+  } = {}
+): ModuleInfo {
+  const imports = opts.imports ?? [];
+  return {
+    id: relativePath,
+    file: { ...makeFile(relativePath, opts.sizeBytes), hash: opts.hash ?? `hash-${relativePath}` },
+    exports: opts.exports ?? [],
+    resolvedReExports: {},
+    importedBy: opts.importedBy ?? [],
+    imports,
+    resolvedImports: opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 })),
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "guard-inventory",
+    org: "test-org",
+    name: "guard-inventory",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+describe("detectLargeModules — positive control", () => {
+  it("flags a file above the 15,000-byte threshold", () => {
+    const repo = makeRepository([makeModule("src/big.ts", { sizeBytes: 16_000 })]);
+    const findings = detectLargeModules(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePath).toBe("src/big.ts");
+  });
+
+  it("passes a file below the threshold", () => {
+    const repo = makeRepository([makeModule("src/small.ts", { sizeBytes: 1_000 })]);
+    expect(detectLargeModules(repo)).toHaveLength(0);
+  });
+});
+
+describe("detectSharedModules — positive control", () => {
+  it("flags a module imported by 5+ modules (fan-in >= minImporters)", () => {
+    const importers = Array.from({ length: 5 }, (_, i) => `src/importer-${i}.ts`);
+    const repo = makeRepository([
+      makeModule("src/hub.ts", { importedBy: importers }),
+      ...importers.map((id) => makeModule(id, { imports: ["src/hub.ts"] })),
+    ]);
+    const findings = detectSharedModules(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePath).toBe("src/hub.ts");
+    expect(findings[0].importerCount).toBe(5);
+  });
+
+  it("passes a module with low fan-in", () => {
+    const repo = makeRepository([makeModule("src/quiet.ts", { importedBy: ["src/a.ts"] })]);
+    expect(detectSharedModules(repo)).toHaveLength(0);
+  });
+});
+
+describe("detectDuplicateModules — positive control", () => {
+  it("groups modules with identical content hashes (above min size)", () => {
+    const repo = makeRepository([
+      makeModule("src/copy-a.ts", { hash: "same-content", sizeBytes: 400 }),
+      makeModule("src/copy-b.ts", { hash: "same-content", sizeBytes: 400 }),
+    ]);
+    const findings = detectDuplicateModules(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePaths.sort()).toEqual(["src/copy-a.ts", "src/copy-b.ts"]);
+  });
+
+  it("passes modules with distinct hashes", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { hash: "h-a", sizeBytes: 400 }),
+      makeModule("src/b.ts", { hash: "h-b", sizeBytes: 400 }),
+    ]);
+    expect(detectDuplicateModules(repo)).toHaveLength(0);
+  });
+});
+
+describe("detectIndexFiles — positive control", () => {
+  it("flags an index.ts that mixes re-exports with its own definitions", () => {
+    const repo = makeRepository([
+      makeModule("src/index.ts", { exports: [named("ownHelper"), reExport("thing", "./thing")] }),
+    ]);
+    const findings = detectIndexFiles(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePath).toBe("src/index.ts");
+    expect(findings[0].isPureBarrel).toBe(false);
+  });
+
+  it("passes a pure barrel (all exports are re-exports)", () => {
+    const repo = makeRepository([
+      makeModule("src/index.ts", { exports: [reExport("a", "./a"), reExport("b", "./b")] }),
+    ]);
+    const findings = detectIndexFiles(repo);
+    expect(findings).toHaveLength(1); // still reported, but as a pure barrel
+    expect(findings[0].isPureBarrel).toBe(true);
+  });
+});
+
+describe("detectLayerViolation — positive control", () => {
+  it("flags packages/shared importing a sibling package", () => {
+    const repo = makeRepository([
+      makeModule("packages/shared/utils.ts", { imports: ["packages/other/thing.ts"] }),
+      makeModule("packages/other/thing.ts"),
+    ]);
+    const findings = detectLayerViolation(repo);
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0].filePath).toBe("packages/shared/utils.ts");
+  });
+
+  it("passes packages/shared importing only itself", () => {
+    const repo = makeRepository([makeModule("packages/shared/a.ts", { imports: ["packages/shared/b.ts"] })]);
+    expect(detectLayerViolation(repo)).toHaveLength(0);
+  });
+});
+
+describe("detectDeadCode — positive control", () => {
+  it("flags a module that is imported (side-effect) but every own export is unused", () => {
+    const repo = makeRepository([
+      makeModule("src/effects.ts", { exports: [named("helper")], importedBy: ["src/consumer.ts"] }),
+      makeModule("src/consumer.ts", {
+        imports: ["src/effects.ts"],
+        // side-effect import: namedImports empty, so "helper" stays unused
+        resolvedImports: [{ moduleId: "src/effects.ts", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+      }),
+    ]);
+    const findings = detectDeadCode(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePath).toBe("src/effects.ts");
+  });
+
+  it("passes a module whose export IS imported by name", () => {
+    const repo = makeRepository([
+      makeModule("src/used.ts", { exports: [named("helper")] }),
+      makeModule("src/consumer.ts", {
+        imports: ["src/used.ts"],
+        resolvedImports: [{ moduleId: "src/used.ts", namedImports: ["helper"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+      }),
+    ]);
+    expect(detectDeadCode(repo)).toHaveLength(0);
+  });
+});
+
+describe("detectEntryPoints — positive control", () => {
+  it("classifies an orphaned CLI entry file as an entry point", () => {
+    const repo = makeRepository([makeModule("apps/cli/index.ts")]);
+    const findings = detectEntryPoints(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePath).toBe("apps/cli/index.ts");
+  });
+
+  it("passes an orphaned file with no entry-point convention", () => {
+    const repo = makeRepository([makeModule("src/plain.ts")]);
+    expect(detectEntryPoints(repo)).toHaveLength(0);
+  });
+});

--- a/tests/indexer.test.ts
+++ b/tests/indexer.test.ts
@@ -77,6 +77,29 @@ describe("buildIndex", () => {
     expect(a!.exports.map((e) => e.name)).toEqual(["a"]);
   });
 
+  it("records scan accounting: parsed vs skipped-by-no-parser (eligible_seen guard)", async () => {
+    const dir = track(
+      makeRepoDir({
+        "src/a.ts": "export const a = 1;",
+        "src/b.go": "package b\n",
+        // .php/.rb languages are KNOWN (scanFiles includes them) but no
+        // parser is registered — they must be counted, not silently dropped.
+        "src/c.php": "<?php echo 'x';\n",
+        "src/d.rb": "puts 'x'\n",
+      })
+    );
+
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+    expect(repository.scanSummary).toEqual({
+      filesScanned: 4,
+      filesParsed: 2,
+      filesSkippedNoParser: 2,
+      skippedByExtension: { ".php": 1, ".rb": 1 },
+    });
+    // and the modules map reflects only the parsed ones
+    expect(repository.moduleCount).toBe(2);
+  });
+
   it("resolves extensionless imports to the .ts sibling", async () => {
     const dir = track(
       makeRepoDir({

--- a/tests/runDoctor.test.ts
+++ b/tests/runDoctor.test.ts
@@ -11,7 +11,8 @@
 
 import { describe, it, expect } from "vitest";
 import { Repository } from "../packages/repository/Repository";
-import { runDoctor } from "../packages/engine/runDoctor";
+import { runDoctor, safeRun } from "../packages/engine/runDoctor";
+import type { DoctorFinding } from "../packages/engine/runDoctor";
 import type { ModuleInfo, RepositoryMeta, FileInfo, RawExport } from "../packages/shared/types";
 
 function makeFile(relativePath: string, language = "typescript"): FileInfo {
@@ -150,5 +151,18 @@ describe("runDoctor", () => {
     ]);
     const result = runDoctor(repo);
     expect(result.errorCount + result.warningCount + result.infoCount).toBe(result.findings.length);
+  });
+
+  it("safeRun surfaces a detector crash as a finding instead of throwing (structural-death guard)", () => {
+    const findings: DoctorFinding[] = [];
+    safeRun("crashingCheck", "error", () => {
+      throw new Error("boom");
+    }, findings);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].checkId).toBe("crashingCheck");
+    expect(findings[0].severity).toBe("error");
+    expect(findings[0].message).toContain("DETECTOR CRASHED");
+    expect(findings[0].message).toContain("boom");
   });
 });


### PR DESCRIPTION
## What changed

Applying the OWP-class review lens (population rot / eligible_seen / structural death / guard inventory) to ARCLUX. Three real gaps closed:

1. **Guard inventory — negative controls for ALL 19 detectors.** Audit found 7 detectors (detectDeadCode, detectDuplicateModules, detectEntryPoints, detectIndexFiles, detectLargeModules, detectLayerViolation, detectSharedModules) with NO committed positive-control test — only prose-documented manual verifications. New `tests/guard-inventory.test.ts` gives each a KNOWN-BAD fixture (must fire) + a clean fixture (must not fire). Coverage matrix in tests/README.md.

2. **Population-rot guard (eligible_seen).** `ScanSummary` (filesScanned / filesParsed / filesSkippedNoParser / skippedByExtension) — populated by buildIndex pass 1, carried on Repository, surfaced in AnalyzeRepositoryResult + /api/analyze + the analyze CLI. Now "0 Python modules" is distinguishable from "Python files were skipped".

3. **Structural-death guard.** `safeRun` in runDoctor wraps every detector (a crash becomes a `DETECTOR CRASHED` error finding instead of silently killing the suite and looking like "no findings"); `runAllChecks` in contract.ts got the same isolation.

## How was this verified

- Guard-inventory: 14 new tests, all passing (one fixture bug caught and fixed: importedBy must be backfilled manually in fixtures — same as buildIndex pass 4).
- scanSummary live: `analyzeRepository({ localPath: '.' })` on ARCLUX → 546 scanned = 546 parsed, 0 skipped; a mixed .ts/.go/.php/.rb fixture counts the 2 skipped languages explicitly.
- safeRun unit test (crash → finding, no throw).
- `npx vitest run`: **224 passed / 26 files** (208 + 16). `npx tsc --noEmit -p apps/web/tsconfig.json`: exit 0.
- docs: decisions.md (OWP-lens decision with rejected alternatives), status-core entry, tests/README matrix, docs-site regenerated.

## Checklist

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json`
- [x] Tested against real repos + fixtures
- [x] PROGRES updated with dated entry
- [x] No duplicate logic
- [x] No empty files introduced