### PR TITLE
ARCLUX daemon: push-based watcher

### DIFF
--- a/apps/cli/daemon.ts
+++ b/apps/cli/daemon.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Entry point for "arclux daemon": starts ArcluxDaemon and keeps the
+// process alive, logging signal bus events to the terminal. This is the
+// minimal foreground version -- background/detached process management
+// is a follow-up, not built here (see progres/decisions.md entry logged
+// alongside this command for why foreground-first was chosen).
+
+import type { Command } from "commander";
+import * as p from "@clack/prompts";
+import { ArcluxDaemon } from "../../packages/daemon/ArcluxDaemon";
+
+export function registerDaemonCommand(program: Command): void {
+  program
+    .command("daemon")
+    .description("Start ARCLUX as a long-running process: watches the repo and re-analyzes on every change")
+    .argument("[path]", "path to the repository root", ".")
+    .action(async (targetPath: string) => {
+      const daemon = new ArcluxDaemon({ rootPath: targetPath });
+
+      daemon.kernel.signalBus.on("daemon:started", () => {
+        p.log.success(`ARCLUX daemon watching ${targetPath}`);
+      });
+
+      daemon.kernel.signalBus.on("daemon:analysis:updated", (data: any) => {
+        p.log.info(`Re-analyzed: ${data.moduleCount} modules`);
+      });
+
+      daemon.kernel.signalBus.on("daemon:diagnostics:updated", (data: any) => {
+        if (data.findings.length > 0) {
+          p.log.warn(`${data.findings.length} diagnostic finding(s)`);
+        }
+      });
+
+      daemon.kernel.signalBus.on("daemon:analysis:error", (data: any) => {
+        p.log.error(`Analysis error: ${data.message}`);
+      });
+
+      daemon.start();
+
+      const shutdown = async () => {
+        p.log.info("Stopping daemon...");
+        await daemon.stop();
+        process.exit(0);
+      };
+      process.on("SIGINT", shutdown);
+      process.on("SIGTERM", shutdown);
+    });
+}

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -16,6 +16,7 @@ import { registerVerifyCommand } from "./verify";
 import { registerDoctorCommand } from "./doctor";
 import { registerConfigCommand } from "./config";
 import { registerDiagnoseCommand } from "./diagnose";
+import { registerDaemonCommand } from "./daemon";
 import { registerPsCommand } from "./commands/ps";
 import { registerWorkCommand } from "./commands/work";
 
@@ -30,6 +31,7 @@ registerVerifyCommand(program);
 registerDoctorCommand(program);
 registerConfigCommand(program);
 registerDiagnoseCommand(program);
+registerDaemonCommand(program);
 registerPsCommand(program);
 registerWorkCommand(program);
 

--- a/packages/daemon/ArcluxDaemon.ts
+++ b/packages/daemon/ArcluxDaemon.ts
@@ -1,0 +1,67 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// The long-running process: "install once, ARCLUX stays alive, developer
+// just codes". Wires DaemonRepositoryWatcher (push-based re-analysis) to
+// Kernel's SignalBus (packages/kernel/Kernel.ts) so other subsystems
+// (diagnostics, notifications) can subscribe without knowing about the
+// watcher directly -- mirrors how ProcessManager already emits onto
+// kernel.signalBus rather than exposing its own separate event API.
+// Does not reimplement watching/analysis -- wraps existing pieces.
+
+import { Kernel } from "../kernel/Kernel";
+import { DaemonRepositoryWatcher } from "./DaemonRepositoryWatcher";
+import { runDiagnostics } from "../diagnostics/DiagnosticEngine";
+
+export interface ArcluxDaemonOptions {
+  rootPath: string;
+}
+
+export class ArcluxDaemon {
+  readonly kernel = new Kernel();
+  private watcher: DaemonRepositoryWatcher | null = null;
+  private readonly rootPath: string;
+
+  constructor(options: ArcluxDaemonOptions) {
+    this.rootPath = options.rootPath;
+  }
+
+  start(): void {
+    if (this.watcher) return;
+
+    this.watcher = new DaemonRepositoryWatcher(this.rootPath);
+
+    this.watcher.on("analysis:updated", (result) => {
+      this.kernel.signalBus.emit("daemon:analysis:updated", {
+        rootPath: this.rootPath,
+        moduleCount: result.moduleCount,
+        at: Date.now(),
+      });
+
+      // Re-run the wired diagnostic adapters (packages/diagnostics/DiagnosticEngine.ts)
+      // on every fresh analysis, so a subscriber gets errors as they appear,
+      // not just graph/module counts.
+      const findings = runDiagnostics(result.repository);
+      this.kernel.signalBus.emit("daemon:diagnostics:updated", { findings, at: Date.now() });
+    });
+
+    this.watcher.on("analysis:error", (err) => {
+      this.kernel.signalBus.emit("daemon:analysis:error", { message: err.message, at: Date.now() });
+    });
+
+    this.kernel.signalBus.emit("daemon:started", { rootPath: this.rootPath, at: Date.now() });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.watcher) return;
+    await this.watcher.close();
+    this.watcher = null;
+    this.kernel.signalBus.emit("daemon:stopped", { rootPath: this.rootPath, at: Date.now() });
+    this.kernel.shutdown();
+  }
+}

--- a/packages/daemon/DaemonRepositoryWatcher.ts
+++ b/packages/daemon/DaemonRepositoryWatcher.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Adds a push-based event on top of packages/watcher/watchRepository.ts,
+// which is pull-only by design (see its own header comment + PROGRES.md
+// decisions entry). Does not change watchRepository.ts's behavior --
+// wraps it, calling getAnalysis() once per flushed change batch so
+// consumers (daemon, future IDE bridge) can subscribe instead of polling.
+
+import { EventEmitter } from "node:events";
+import { watchRepository, type RepositoryWatcher } from "../watcher/watchRepository";
+import { watchFilesystem, type FilesystemWatcher } from "../watcher/watchFilesystem";
+import { createChangeQueue, type ChangeQueue } from "../watcher/changeQueue";
+import type { AnalyzeRepositoryResult } from "../engine/pipeline";
+
+export interface DaemonRepositoryEvents {
+  "analysis:updated": [AnalyzeRepositoryResult];
+  "analysis:error": [Error];
+}
+
+/**
+ * Wraps watchRepository() + its own separate filesystem watcher/queue to
+ * push "analysis:updated" whenever a change batch flushes, instead of
+ * requiring the caller to poll getAnalysis(). Runs a SECOND watcher on the
+ * same rootPath rather than modifying watchRepository.ts itself, keeping
+ * that module's pull-only contract intact for existing callers (e.g. the
+ * `work` command) while this one adds push on top.
+ */
+export class DaemonRepositoryWatcher extends EventEmitter {
+  private readonly inner: RepositoryWatcher;
+  private readonly pushFsWatcher: FilesystemWatcher;
+  private readonly pushQueue: ChangeQueue;
+
+  constructor(private readonly rootPath: string) {
+    super();
+    this.inner = watchRepository(rootPath);
+
+    this.pushQueue = createChangeQueue(() => {
+      this.inner
+        .getAnalysis()
+        .then((result) => this.emit("analysis:updated", result))
+        .catch((err) => this.emit("analysis:error", err instanceof Error ? err : new Error(String(err))));
+    });
+
+    this.pushFsWatcher = watchFilesystem(rootPath, (event) => {
+      this.pushQueue.push(event);
+    });
+  }
+
+  /** Same as RepositoryWatcher.getAnalysis() -- for a caller that wants an immediate read without waiting for the next push event. */
+  getAnalysis(): Promise<AnalyzeRepositoryResult> {
+    return this.inner.getAnalysis();
+  }
+
+  async close(): Promise<void> {
+    this.pushQueue.close();
+    await this.pushFsWatcher.close();
+    await this.inner.close();
+  }
+}


### PR DESCRIPTION
Adds packages/daemon/ (DaemonRepositoryWatcher wraps watchRepository.ts with push events instead of pull-only getAnalysis; ArcluxDaemon wires it to Kernel's SignalBus + runs wired diagnostics on every re-analysis) and apps/cli/daemon.ts (foreground CLI entry point). Does not modify watchRepository.ts's pull-only contract -- runs a second watcher alongside it, keeping existing callers (work command) unaffected.