### PR TITLE
Daemon Phase 3: auto-detect repo root

### DIFF
--- a/apps/cli/daemon.ts
+++ b/apps/cli/daemon.ts
@@ -15,13 +15,17 @@
 import type { Command } from "commander";
 import * as p from "@clack/prompts";
 import { ArcluxDaemon } from "../../packages/daemon/ArcluxDaemon";
+import { resolveWorkingRepositoryRoot } from "../../packages/environment/EnvironmentDetector";
+import { resolve } from "node:path";
 
 export function registerDaemonCommand(program: Command): void {
   program
     .command("daemon")
     .description("Start ARCLUX as a long-running process: watches the repo and re-analyzes on every change")
-    .argument("[path]", "path to the repository root", ".")
-    .action(async (targetPath: string) => {
+    .argument("[path]", "path to the repository root -- auto-detected (walks up to the nearest .git) if omitted", "")
+    .action(async (pathArg: string) => {
+      const startPath = pathArg ? resolve(pathArg) : process.cwd();
+      const targetPath = pathArg ? startPath : resolveWorkingRepositoryRoot(startPath);
       const daemon = new ArcluxDaemon({ rootPath: targetPath });
 
       daemon.kernel.signalBus.on("daemon:started", () => {

--- a/packages/environment/EnvironmentDetector.ts
+++ b/packages/environment/EnvironmentDetector.ts
@@ -1,11 +1,51 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Walks up from a starting directory to find the nearest ancestor
+// containing a .git folder -- same "find the repo root" pattern git
+// itself, ESLint, Prettier, and most dev tools use, so `arclux daemon`
+// run from any subfolder still watches the whole repo, not just the
+// subfolder the developer happened to be in.
 
-// Scaffold: environment/EnvironmentDetector — not yet implemented.
+import { existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+export interface DetectedEnvironment {
+  /** absolute path to the repository root (the directory containing .git) */
+  repositoryRoot: string;
+  /** true if startPath itself was the root; false if a walk-up was needed */
+  wasStartPath: boolean;
+}
+
+/**
+ * Walks up from startPath looking for a .git directory. Returns null if
+ * none is found before reaching the filesystem root (e.g. startPath isn't
+ * inside a git repo at all) -- callers should fall back to startPath itself
+ * in that case, not treat null as an error.
+ */
+export function detectRepositoryRoot(startPath: string): DetectedEnvironment | null {
+  let current = startPath;
+
+  while (true) {
+    if (existsSync(join(current, ".git"))) {
+      return { repositoryRoot: current, wasStartPath: current === startPath };
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      // Reached filesystem root without finding .git.
+      return null;
+    }
+    current = parent;
+  }
+}
+
+/** Convenience wrapper: detectRepositoryRoot(startPath), falling back to startPath itself if no .git is found anywhere above it. */
+export function resolveWorkingRepositoryRoot(startPath: string): string {
+  return detectRepositoryRoot(startPath)?.repositoryRoot ?? startPath;
+}


### PR DESCRIPTION
Implements packages/environment/EnvironmentDetector.ts (walks up from a start path to the nearest .git, same pattern git/ESLint/Prettier use). Wires into apps/cli/daemon.ts: running 'arclux daemon' with no path argument now auto-detects the repository root from cwd instead of requiring an explicit path or defaulting to '.' (which would be wrong if run from a subfolder).