### PR TITLE
Daemon Phase 4: background process

### DIFF
--- a/apps/cli/daemon.ts
+++ b/apps/cli/daemon.ts
@@ -17,15 +17,43 @@ import * as p from "@clack/prompts";
 import { ArcluxDaemon } from "../../packages/daemon/ArcluxDaemon";
 import { resolveWorkingRepositoryRoot } from "../../packages/environment/EnvironmentDetector";
 import { resolve } from "node:path";
+import { spawnDetached, stopDetached, getDaemonStatus } from "../../packages/daemon/DaemonProcess";
+import { fileURLToPath } from "node:url";
 
 export function registerDaemonCommand(program: Command): void {
   program
     .command("daemon")
     .description("Start ARCLUX as a long-running process: watches the repo and re-analyzes on every change")
     .argument("[path]", "path to the repository root -- auto-detected (walks up to the nearest .git) if omitted", "")
-    .action(async (pathArg: string) => {
+    .option("--detach", "run the daemon as a background process instead of foreground")
+    .option("--stop", "stop a running detached daemon for this repository")
+    .option("--status", "check whether a detached daemon is running for this repository")
+    .action(async (pathArg: string, options: { detach?: boolean; stop?: boolean; status?: boolean }) => {
       const startPath = pathArg ? resolve(pathArg) : process.cwd();
       const targetPath = pathArg ? startPath : resolveWorkingRepositoryRoot(startPath);
+
+      if (options.stop) {
+        const stopped = stopDetached(targetPath);
+        if (stopped) p.log.success(`Stopped daemon for ${targetPath}`);
+        else p.log.warn(`No running daemon found for ${targetPath}`);
+        return;
+      }
+
+      if (options.status) {
+        const status = getDaemonStatus(targetPath);
+        if (status) p.log.success(`Daemon running (pid ${status.pid}, since ${new Date(status.startedAt).toLocaleTimeString()})`);
+        else p.log.warn(`No running daemon for ${targetPath}`);
+        return;
+      }
+
+      if (options.detach) {
+        const cliEntry = fileURLToPath(new URL("index.ts", import.meta.url));
+        const { pid, logFile } = spawnDetached(targetPath, cliEntry);
+        p.log.success(`Daemon started in background (pid ${pid})`);
+        p.log.info(`Logs: ${logFile}`);
+        return;
+      }
+
       const daemon = new ArcluxDaemon({ rootPath: targetPath });
 
       daemon.kernel.signalBus.on("daemon:started", () => {

--- a/packages/daemon/ArcluxDaemon.ts
+++ b/packages/daemon/ArcluxDaemon.ts
@@ -20,7 +20,7 @@ import { runDiagnostics } from "../diagnostics/DiagnosticEngine";
 import { findFreePort } from "../networking/PortManager";
 import { createServiceEndpoint, writeServiceEndpoint, removeServiceEndpoint } from "../networking/ServiceEndpoint";
 import { startLocalBridgeServer, type LocalBridgeServer } from "./LocalBridgeServer";
-import { createHash } from "node:crypto";
+import { computeDaemonId } from "./DaemonProcess";
 
 export interface ArcluxDaemonOptions {
   rootPath: string;
@@ -37,7 +37,7 @@ export class ArcluxDaemon {
     this.rootPath = options.rootPath;
     // Stable id derived from rootPath, so restarting the daemon on the same
     // repo reuses the same endpoint file instead of accumulating stale ones.
-    this.daemonId = createHash("sha1").update(this.rootPath).digest("hex").slice(0, 12);
+    this.daemonId = computeDaemonId(this.rootPath);
   }
 
   /** Delegates to the underlying DaemonRepositoryWatcher -- see LocalBridgeServer.ts's GET /analysis. */

--- a/packages/daemon/DaemonProcess.ts
+++ b/packages/daemon/DaemonProcess.ts
@@ -1,0 +1,117 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Detaches the daemon into a real background process, same pattern PM2
+// (already referenced for packages/runtime/ProcessManager.ts) uses:
+// spawn with detached:true + unref() so the child outlives the parent
+// CLI invocation, stdio redirected to a log file since there's no
+// terminal to write to once detached, and a pid file so `daemon stop`/
+// `daemon status` from a LATER, unrelated CLI invocation can find it.
+
+import { spawn } from "node:child_process";
+import { openSync, existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from "node:fs";
+import { createHash } from "node:crypto";
+import * as os from "os";
+import * as path from "path";
+
+function arcluxRoot(): string {
+  return process.env.ARCLUX_ROOT || path.join(os.homedir(), ".arclux");
+}
+
+/**
+ * Stable id derived from a repository root path. Used to key the pid file
+ * here AND the service endpoint file in packages/networking/ServiceEndpoint.ts
+ * -- same id, so `daemon status` and a future editor extension agree on
+ * which daemon instance they're talking about for a given repo.
+ */
+export function computeDaemonId(rootPath: string): string {
+  return createHash("sha1").update(rootPath).digest("hex").slice(0, 12);
+}
+
+function pidFilePath(daemonId: string): string {
+  return path.join(arcluxRoot(), "daemons", `${daemonId}.pid.json`);
+}
+
+function logFilePath(daemonId: string): string {
+  return path.join(arcluxRoot(), "daemons", `${daemonId}.log`);
+}
+
+interface DaemonPidRecord {
+  pid: number;
+  rootPath: string;
+  startedAt: number;
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Spawns `node <cliEntry> daemon <rootPath>` as a detached background
+ * process and returns immediately -- does not wait for the daemon to
+ * finish starting (the caller should check ServiceEndpoint / daemon
+ * status separately if it needs to confirm the bridge is listening).
+ */
+export function spawnDetached(rootPath: string, cliEntry: string): { pid: number; logFile: string } {
+  const daemonId = computeDaemonId(rootPath);
+  const dir = path.join(arcluxRoot(), "daemons");
+  mkdirSync(dir, { recursive: true });
+
+  const logFile = logFilePath(daemonId);
+  const logFd = openSync(logFile, "a");
+
+  const child = spawn(process.execPath, [cliEntry, "daemon", rootPath], {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+    env: { ...process.env, ARCLUX_DAEMON_CHILD: "1" },
+  });
+
+  child.unref();
+
+  const record: DaemonPidRecord = { pid: child.pid!, rootPath, startedAt: Date.now() };
+  writeFileSync(pidFilePath(daemonId), JSON.stringify(record, null, 2), "utf8");
+
+  return { pid: child.pid!, logFile };
+}
+
+/** Returns the pid record for rootPath's daemon if it's currently running, null otherwise (also cleans up a stale pid file if the process has died). */
+export function getDaemonStatus(rootPath: string): DaemonPidRecord | null {
+  const daemonId = computeDaemonId(rootPath);
+  const file = pidFilePath(daemonId);
+  if (!existsSync(file)) return null;
+
+  let record: DaemonPidRecord;
+  try {
+    record = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    unlinkSync(file);
+    return null;
+  }
+
+  if (!isPidAlive(record.pid)) {
+    unlinkSync(file);
+    return null;
+  }
+
+  return record;
+}
+
+/** Sends SIGTERM to a running detached daemon for rootPath. Returns false if none was running. */
+export function stopDetached(rootPath: string): boolean {
+  const status = getDaemonStatus(rootPath);
+  if (!status) return false;
+
+  process.kill(status.pid, "SIGTERM");
+  unlinkSync(pidFilePath(computeDaemonId(rootPath)));
+  return true;
+}


### PR DESCRIPTION
Adds packages/daemon/DaemonProcess.ts (spawn detached via same pattern as ProcessManager/PM2 reference: detached:true + unref(), stdio to log file, pid file for cross-invocation discovery). Adds --detach/--stop/--status flags to 'arclux daemon'. Refactored ArcluxDaemon's daemonId derivation into a shared computeDaemonId() so the pid file and ServiceEndpoint discovery file agree on the same id per repo root.