### PR TITLE
Daemon Phase 5: VS Code extension (unbuilt)

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "arclux-vscode",
+  "displayName": "ARCLUX",
+  "description": "Live dependency graph, impact analysis, and diagnostics -- connects to a running ARCLUX daemon (arclux daemon --detach)",
+  "version": "0.1.0",
+  "private": true,
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": ["onStartupFinished"],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "arclux.showAnalysis",
+        "title": "ARCLUX: Show Analysis"
+      },
+      {
+        "command": "arclux.connectDaemon",
+        "title": "ARCLUX: Connect to Daemon"
+      }
+    ]
+  },
+  "scripts": {
+    "build": "tsc -p .",
+    "watch": "tsc -p . --watch"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5"
+  }
+}

--- a/apps/vscode-extension/src/daemonClient.ts
+++ b/apps/vscode-extension/src/daemonClient.ts
@@ -1,0 +1,80 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Reads the daemon's ServiceEndpoint discovery file (same file
+// packages/networking/ServiceEndpoint.ts writes -- see
+// computeDaemonId in packages/daemon/DaemonProcess.ts for how the id
+// is derived from a repo root path) and subscribes to its SSE stream.
+// NOT built/typechecked here -- this repo's Termux environment has no
+// network access to install the `vscode` API types package, so this
+// file is written against the documented VS Code Extension API but has
+// only been reviewed, not compiled. Build with `pnpm install && pnpm
+// build` in an environment with npm registry access before relying on it.
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import * as https from "https";
+import * as http from "http";
+
+export interface DaemonEndpoint {
+  host: string;
+  port: number;
+  baseUrl: string;
+}
+
+function arcluxRoot(): string {
+  return process.env.ARCLUX_ROOT || path.join(os.homedir(), ".arclux");
+}
+
+/** Same id derivation as packages/daemon/DaemonProcess.ts's computeDaemonId -- duplicated here (not imported) because the extension is a separate npm package with no dependency on the monorepo's packages/*. */
+function computeDaemonId(rootPath: string): string {
+  const crypto = require("crypto");
+  return crypto.createHash("sha1").update(rootPath).digest("hex").slice(0, 12);
+}
+
+export function findDaemonEndpoint(repositoryRoot: string): DaemonEndpoint | null {
+  const daemonId = computeDaemonId(repositoryRoot);
+  const file = path.join(arcluxRoot(), "endpoints", `${daemonId}.json`);
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export interface DaemonSseHandlers {
+  onAnalysis?: (data: unknown) => void;
+  onDiagnostics?: (data: unknown) => void;
+  onError?: (err: Error) => void;
+}
+
+/** Subscribes to the daemon's GET /events SSE stream. Returns a function to close the connection. */
+export function subscribeDaemonEvents(endpoint: DaemonEndpoint, handlers: DaemonSseHandlers): () => void {
+  const req = http.get(`${endpoint.baseUrl}/events`, (res) => {
+    let buffer = "";
+    res.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const parts = buffer.split("\n\n");
+      buffer = parts.pop() ?? "";
+      for (const part of parts) {
+        const eventLine = part.split("\n").find((l) => l.startsWith("event: "));
+        const dataLine = part.split("\n").find((l) => l.startsWith("data: "));
+        if (!eventLine || !dataLine) continue;
+        const event = eventLine.slice("event: ".length);
+        const data = JSON.parse(dataLine.slice("data: ".length));
+        if (event === "analysis") handlers.onAnalysis?.(data);
+        if (event === "diagnostics") handlers.onDiagnostics?.(data);
+      }
+    });
+  });
+
+  req.on("error", (err) => handlers.onError?.(err));
+
+  return () => req.destroy();
+}

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// NOT built/typechecked here -- see daemonClient.ts's header for why
+// (no network access to install @types/vscode in this environment).
+// Written against the documented VS Code Extension API; build in an
+// environment with npm registry access before relying on it.
+//
+// Minimal viable extension: connects to a running `arclux daemon
+// --detach` for the open workspace, shows module count in the status
+// bar, and surfaces diagnostics findings (packages/diagnostics/
+// DiagnosticEngine.ts's output, forwarded by ArcluxDaemon over SSE) in
+// VS Code's built-in Problems panel via a DiagnosticCollection --
+// reuses VS Code's own UI for this instead of building a custom panel.
+
+import * as vscode from "vscode";
+import { findDaemonEndpoint, subscribeDaemonEvents } from "./daemonClient";
+
+let statusBarItem: vscode.StatusBarItem;
+let diagnosticCollection: vscode.DiagnosticCollection;
+let closeSse: (() => void) | null = null;
+
+function connect(workspaceRoot: string): void {
+  const endpoint = findDaemonEndpoint(workspaceRoot);
+
+  if (!endpoint) {
+    statusBarItem.text = "$(circle-slash) ARCLUX: not running";
+    statusBarItem.tooltip = "Run `arclux daemon --detach` in this repository's terminal";
+    return;
+  }
+
+  statusBarItem.text = "$(sync~spin) ARCLUX: connecting...";
+
+  closeSse = subscribeDaemonEvents(endpoint, {
+    onAnalysis: (data: any) => {
+      statusBarItem.text = `$(check) ARCLUX: ${data.moduleCount} modules`;
+    },
+    onDiagnostics: (data: any) => {
+      diagnosticCollection.clear();
+      const byFile = new Map<string, vscode.Diagnostic[]>();
+
+      for (const finding of data.findings ?? []) {
+        for (const loc of finding.locations ?? []) {
+          const list = byFile.get(loc.filePath) ?? [];
+          const line = Math.max(0, (loc.line ?? 1) - 1);
+          const range = new vscode.Range(line, 0, line, 0);
+          const severity =
+            finding.severity === "error" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning;
+          list.push(new vscode.Diagnostic(range, finding.message, severity));
+          byFile.set(loc.filePath, list);
+        }
+      }
+
+      for (const [filePath, diagnostics] of byFile) {
+        const uri = vscode.Uri.file(`${workspaceRoot}/${filePath}`);
+        diagnosticCollection.set(uri, diagnostics);
+      }
+    },
+    onError: () => {
+      statusBarItem.text = "$(warning) ARCLUX: connection lost";
+    },
+  });
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+  statusBarItem.show();
+  context.subscriptions.push(statusBarItem);
+
+  diagnosticCollection = vscode.languages.createDiagnosticCollection("arclux");
+  context.subscriptions.push(diagnosticCollection);
+
+  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  if (workspaceRoot) {
+    connect(workspaceRoot);
+  } else {
+    statusBarItem.text = "$(circle-slash) ARCLUX: no workspace open";
+  }
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("arclux.connectDaemon", () => {
+      if (workspaceRoot) connect(workspaceRoot);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("arclux.showAnalysis", () => {
+      vscode.window.showInformationMessage(statusBarItem.text);
+    })
+  );
+}
+
+export function deactivate(): void {
+  closeSse?.();
+  diagnosticCollection?.dispose();
+}

--- a/apps/vscode-extension/tsconfig.json
+++ b/apps/vscode-extension/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Adds apps/vscode-extension/: minimal viable VS Code extension connecting to a running 'arclux daemon --detach' via its ServiceEndpoint discovery file + SSE /events stream (packages/daemon/LocalBridgeServer.ts). Shows module count in status bar, forwards diagnostics findings to VS Code's built-in Problems panel via DiagnosticCollection.

IMPORTANT: written against the documented VS Code Extension API but NOT built or typechecked -- this session's environment (Termux, no network access to bash_tool) cannot install @types/vscode from npm. Needs 'pnpm install && pnpm build' in an environment with npm registry access, plus manual testing in VS Code's Extension Development Host, before considered verified. Logged as a status-infra entry with this caveat.