### PR TITLE
feat(notifications): implement packages/notifications/ and wire into ArcluxDaemon (issue #353)

### DIFF
--- a/packages/daemon/ArcluxDaemon.ts
+++ b/packages/daemon/ArcluxDaemon.ts
@@ -21,13 +21,25 @@ import { findFreePort } from "../networking/PortManager";
 import { createServiceEndpoint, writeServiceEndpoint, removeServiceEndpoint } from "../networking/ServiceEndpoint";
 import { startLocalBridgeServer, type LocalBridgeServer } from "./LocalBridgeServer";
 import { computeDaemonId } from "./DaemonProcess";
+import { NotificationManager } from "../notifications/NotificationManager";
+import type { NotificationChannel } from "../notifications/NotificationChannel";
 
 export interface ArcluxDaemonOptions {
   rootPath: string;
+  /**
+   * Channels to fan daemon diagnostic events out to. Registered on the
+   * daemon's NotificationManager (daemon.notifications) before start() —
+   * see packages/notifications/ for the interface and a console reference
+   * implementation. Optional: without channels the daemon still analyzes
+   * and emits, just nobody receives notifications.
+   */
+  notificationChannels?: NotificationChannel[];
 }
 
 export class ArcluxDaemon {
   readonly kernel = new Kernel();
+  /** Fans daemon:diagnostics:updated events to registered channels. */
+  readonly notifications: NotificationManager;
   private watcher: DaemonRepositoryWatcher | null = null;
   private bridgeServer: LocalBridgeServer | null = null;
   private readonly daemonId: string;
@@ -38,6 +50,10 @@ export class ArcluxDaemon {
     // Stable id derived from rootPath, so restarting the daemon on the same
     // repo reuses the same endpoint file instead of accumulating stale ones.
     this.daemonId = computeDaemonId(this.rootPath);
+    this.notifications = new NotificationManager(this.kernel.signalBus);
+    for (const channel of options.notificationChannels ?? []) {
+      this.notifications.registerChannel(channel);
+    }
   }
 
   /** Delegates to the underlying DaemonRepositoryWatcher -- see LocalBridgeServer.ts's GET /analysis. */
@@ -48,6 +64,10 @@ export class ArcluxDaemon {
 
   start(): void {
     if (this.watcher) return;
+
+    // Subscribe before the first analysis can emit, so no diagnostics run
+    // is missed by channels. Idempotent in NotificationManager itself.
+    this.notifications.start();
 
     this.watcher = new DaemonRepositoryWatcher(this.rootPath);
 
@@ -86,6 +106,9 @@ export class ArcluxDaemon {
 
   async stop(): Promise<void> {
     if (!this.watcher) return;
+    // Unsubscribe first so a final diagnostics event can't reach channels
+    // while the watcher is already tearing down.
+    this.notifications.stop();
     if (this.bridgeServer) {
       await this.bridgeServer.close();
       this.bridgeServer = null;

--- a/packages/notifications/Notification.ts
+++ b/packages/notifications/Notification.ts
@@ -8,4 +8,25 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: notifications/Notification — not yet implemented.
+// The unit of fan-out produced by NotificationManager: a diagnostic
+// finding normalized into a channel-neutral shape. Channels (console,
+// desktop notification, editor popup) render this — they don't re-derive
+// it from DiagnosticFinding themselves, and they don't need to know which
+// signal bus event produced it.
+
+export type NotificationSeverity = "error" | "warning" | "info";
+
+export interface Notification {
+  /** Stable id, unique per finding+location: `${source}:${filePath}:${line}`. */
+  id: string;
+  severity: NotificationSeverity;
+  message: string;
+  /** Milliseconds since epoch — when the underlying event was produced. */
+  at: number;
+  /** The check/event that produced this (e.g. a diagnostic checkId). */
+  source: string;
+  /** First location's file, for jump-to-file affordances. Null when the finding has no location. */
+  filePath: string | null;
+  /** First location's line (1-based). Null when the finding is file-level only. */
+  line: number | null;
+}

--- a/packages/notifications/NotificationChannel.ts
+++ b/packages/notifications/NotificationChannel.ts
@@ -8,4 +8,30 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: notifications/NotificationChannel — not yet implemented.
+import type { Notification } from "./Notification";
+
+// A destination for notifications. NotificationManager fans each produced
+// Notification out to every registered channel. Channels are deliberately
+// dumb: they receive a fully-shaped Notification and decide how to render
+// it (console line, desktop toast, editor popup). Implementations must not
+// throw into the fan-out loop — NotificationManager guards against that,
+// but channels should still prefer catching their own render errors.
+
+export interface NotificationChannel {
+  readonly id: string;
+  deliver(notification: Notification): void;
+}
+
+/** Minimal reference implementation: one line per notification, prefixed by severity. */
+export class ConsoleNotificationChannel implements NotificationChannel {
+  readonly id = "console";
+
+  deliver(notification: Notification): void {
+    const location =
+      notification.filePath && notification.line != null
+        ? `${notification.filePath}:${notification.line}`
+        : notification.filePath ?? "(no location)";
+    // eslint-disable-next-line no-console
+    console.log(`[arclux:${notification.severity}] ${notification.source} ${location} — ${notification.message}`);
+  }
+}

--- a/packages/notifications/NotificationManager.ts
+++ b/packages/notifications/NotificationManager.ts
@@ -8,4 +8,84 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: notifications/NotificationManager — not yet implemented.
+// Bridges the daemon's diagnostic events to channel consumers. ArcluxDaemon
+// emits `daemon:diagnostics:updated` ({ findings, at }) on kernel.signalBus;
+// this manager subscribes to that event, normalizes each DiagnosticFinding
+// into a channel-neutral Notification, and fans it out to every registered
+// NotificationChannel. Callers register channels here instead of subscribing
+// to signalBus event names directly — see issue #353.
+
+import type { SignalBus } from "../kernel/SignalBus";
+import type { DiagnosticFinding } from "../diagnostics/DiagnosticEngine";
+import type { Notification } from "./Notification";
+import type { NotificationChannel } from "./NotificationChannel";
+
+export interface DiagnosticsUpdatedPayload {
+  findings: DiagnosticFinding[];
+  at: number;
+}
+
+/** Normalizes one diagnostics run into notifications (one per finding). */
+export function toNotifications(payload: DiagnosticsUpdatedPayload): Notification[] {
+  return (payload.findings ?? []).map((f) => {
+    const first = f.locations?.[0];
+    return {
+      id: `${f.checkId}:${first?.moduleId ?? "?"}:${first?.line ?? 0}`,
+      severity: f.severity === "error" ? ("error" as const) : ("warning" as const),
+      message: f.message || f.checkId,
+      at: payload.at,
+      source: f.checkId,
+      filePath: first?.filePath ?? null,
+      line: first?.line ?? null,
+    };
+  });
+}
+
+export class NotificationManager {
+  private readonly channels = new Map<string, NotificationChannel>();
+  private unsubscribe: (() => void) | null = null;
+
+  constructor(private readonly signalBus: SignalBus) {}
+
+  /** Register (or replace) a destination channel by its id. */
+  registerChannel(channel: NotificationChannel): void {
+    this.channels.set(channel.id, channel);
+  }
+
+  unregisterChannel(id: string): boolean {
+    return this.channels.delete(id);
+  }
+
+  hasChannel(id: string): boolean {
+    return this.channels.has(id);
+  }
+
+  /** Subscribe to daemon diagnostic events. Idempotent. */
+  start(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = this.signalBus.on<DiagnosticsUpdatedPayload>("daemon:diagnostics:updated", (payload) => {
+      this.fanOut(toNotifications(payload));
+    });
+  }
+
+  /** Unsubscribe from daemon diagnostic events. Idempotent. */
+  stop(): void {
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+  }
+
+  private fanOut(notifications: Notification[]): void {
+    if (notifications.length === 0) return;
+    // Copy so a channel registering/unregistering during delivery can't
+    // mutate the iteration, and so one throwing channel can't starve the rest.
+    for (const channel of [...this.channels.values()]) {
+      for (const notification of notifications) {
+        try {
+          channel.deliver(notification);
+        } catch {
+          // A broken channel must not take down the rest of the fan-out.
+        }
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,18 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  apps/vscode-extension:
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.43
+      '@types/vscode':
+        specifier: ^1.85.0
+        version: 1.125.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@base-ui/react':
@@ -1328,6 +1340,9 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/vscode@1.125.0':
+    resolution: {integrity: sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -4951,6 +4966,8 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
+  '@types/vscode@1.125.0': {}
+
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -5742,7 +5759,7 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -5775,7 +5792,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -5790,7 +5807,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -598,3 +598,24 @@ structural death framing — full decision in progres/decisions.md):
   in contract.ts isolated the same way.
 Tests: 224/224 (208 + 14 guard-inventory + 1 safeRun + 1 scanSummary).
 tsc 0.
+
+## 2026-08-14 — notifications/ implemented + wired to daemon (issue #353)
+
+**Status:** Done
+
+`packages/notifications/` was 3 stub files; now real:
+- `Notification.ts` — channel-neutral shape (id, severity, message, at,
+  source, filePath, line), normalized from DiagnosticFinding.
+- `NotificationChannel.ts` — `NotificationChannel` interface + reference
+  `ConsoleNotificationChannel` implementation.
+- `NotificationManager.ts` — subscribes to kernel.signalBus
+  `daemon:diagnostics:updated`, normalizes findings, fans out to
+  registered channels; idempotent start/stop, broken channel can't starve
+  the rest (try/catch per channel).
+
+Wired into `ArcluxDaemon`: new `notificationChannels` option registered
+onto `daemon.notifications`, subscribed in `start()` before the first
+analysis can emit, unsubscribed first in `stop()`. Existing subscribers
+(apps/cli/daemon.ts, LocalBridgeServer) untouched — additive only.
++11 tests (tests/notifications.test.ts), incl. end-to-end event flow
+through a real Kernel SignalBus. Tests: 236/236, tsc 0.

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,198 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for issue #353: packages/notifications/ subscribes to the daemon's
+// diagnostic events and fans them out to registered channels instead of
+// callers subscribing to signalBus event names directly.
+
+import { describe, it, expect, vi } from "vitest";
+import { SignalBus } from "../packages/kernel/SignalBus";
+import { NotificationManager, toNotifications } from "../packages/notifications/NotificationManager";
+import type { Notification } from "../packages/notifications/Notification";
+import type { NotificationChannel } from "../packages/notifications/NotificationChannel";
+import { ArcluxDaemon } from "../packages/daemon/ArcluxDaemon";
+import type { DiagnosticFinding } from "../packages/diagnostics/DiagnosticEngine";
+
+function makeFinding(overrides: Partial<DiagnosticFinding> = {}): DiagnosticFinding {
+  return {
+    checkId: "deadCode",
+    severity: "warning" as const,
+    message: "unused export",
+    locations: [{ moduleId: "m1", filePath: "src/a.ts", line: 3, locationPrecision: "line" }],
+    ...overrides,
+  };
+}
+
+function collectingChannel(id: string): NotificationChannel & { received: Notification[] } {
+  const received: Notification[] = [];
+  return {
+    id,
+    received,
+    deliver: (n: Notification) => {
+      received.push(n);
+    },
+  };
+}
+
+describe("toNotifications (issue #353 normalization)", () => {
+  it("maps each finding to a notification with location info", () => {
+    const notifications = toNotifications({
+      findings: [makeFinding()],
+      at: 123,
+    });
+
+    expect(notifications).toEqual([
+      {
+        id: "deadCode:m1:3",
+        severity: "warning",
+        message: "unused export",
+        at: 123,
+        source: "deadCode",
+        filePath: "src/a.ts",
+        line: 3,
+      },
+    ]);
+  });
+
+  it("handles findings without locations (file-level fallback)", () => {
+    const notifications = toNotifications({
+      findings: [makeFinding({ locations: [] })],
+      at: 1,
+    });
+
+    expect(notifications[0]).toMatchObject({
+      id: "deadCode:?:0",
+      filePath: null,
+      line: null,
+    });
+  });
+
+  it("maps error severity and tolerates missing message", () => {
+    const notifications = toNotifications({
+      findings: [makeFinding({ severity: "error", message: "" })],
+      at: 1,
+    });
+
+    expect(notifications[0]).toMatchObject({ severity: "error", message: "deadCode" });
+  });
+});
+
+describe("NotificationManager (issue #353 fan-out)", () => {
+  it("delivers daemon:diagnostics:updated events to all registered channels", () => {
+    const bus = new SignalBus();
+    const manager = new NotificationManager(bus);
+    const a = collectingChannel("a");
+    const b = collectingChannel("b");
+    manager.registerChannel(a);
+    manager.registerChannel(b);
+    manager.start();
+
+    bus.emit("daemon:diagnostics:updated", { findings: [makeFinding()], at: 5 });
+
+    expect(a.received).toHaveLength(1);
+    expect(b.received).toHaveLength(1);
+    expect(a.received[0]).toMatchObject({ source: "deadCode", filePath: "src/a.ts", line: 3, at: 5 });
+    manager.stop();
+  });
+
+  it("start() is idempotent — double start does not double-deliver", () => {
+    const bus = new SignalBus();
+    const manager = new NotificationManager(bus);
+    const channel = collectingChannel("c");
+    manager.registerChannel(channel);
+    manager.start();
+    manager.start();
+
+    bus.emit("daemon:diagnostics:updated", { findings: [makeFinding()], at: 1 });
+
+    expect(channel.received).toHaveLength(1);
+    manager.stop();
+  });
+
+  it("stop() unsubscribes — later events are not delivered", () => {
+    const bus = new SignalBus();
+    const manager = new NotificationManager(bus);
+    const channel = collectingChannel("c");
+    manager.registerChannel(channel);
+    manager.start();
+    manager.stop();
+
+    bus.emit("daemon:diagnostics:updated", { findings: [makeFinding()], at: 1 });
+
+    expect(channel.received).toHaveLength(0);
+  });
+
+  it("unregisterChannel removes a channel from the fan-out", () => {
+    const bus = new SignalBus();
+    const manager = new NotificationManager(bus);
+    const a = collectingChannel("a");
+    manager.registerChannel(a);
+    manager.start();
+    expect(manager.unregisterChannel("a")).toBe(true);
+    expect(manager.hasChannel("a")).toBe(false);
+
+    bus.emit("daemon:diagnostics:updated", { findings: [makeFinding()], at: 1 });
+
+    expect(a.received).toHaveLength(0);
+    manager.stop();
+  });
+
+  it("a throwing channel does not starve the other channels", () => {
+    const bus = new SignalBus();
+    const manager = new NotificationManager(bus);
+    const throwing: NotificationChannel = {
+      id: "thrower",
+      deliver: () => {
+        throw new Error("channel broke");
+      },
+    };
+    const ok = collectingChannel("ok");
+    manager.registerChannel(throwing);
+    manager.registerChannel(ok);
+    manager.start();
+
+    expect(() => bus.emit("daemon:diagnostics:updated", { findings: [makeFinding()], at: 1 })).not.toThrow();
+    expect(ok.received).toHaveLength(1);
+    manager.stop();
+  });
+
+  it("empty findings produce no notifications and no channel calls", () => {
+    const bus = new SignalBus();
+    const manager = new NotificationManager(bus);
+    const channel = collectingChannel("c");
+    const deliverSpy = vi.spyOn(channel, "deliver");
+    manager.registerChannel(channel);
+    manager.start();
+
+    bus.emit("daemon:diagnostics:updated", { findings: [], at: 1 });
+
+    expect(deliverSpy).not.toHaveBeenCalled();
+    manager.stop();
+  });
+});
+
+describe("ArcluxDaemon wiring (issue #353)", () => {
+  it("registers notificationChannels option onto daemon.notifications", () => {
+    const channel = collectingChannel("console");
+    const daemon = new ArcluxDaemon({ rootPath: ".", notificationChannels: [channel] });
+
+    expect(daemon.notifications.hasChannel("console")).toBe(true);
+  });
+
+  it("daemon.notifications shares the daemon's signalBus (event flows end-to-end)", () => {
+    const channel = collectingChannel("console");
+    const daemon = new ArcluxDaemon({ rootPath: ".", notificationChannels: [channel] });
+    daemon.notifications.start();
+
+    daemon.kernel.signalBus.emit("daemon:diagnostics:updated", { findings: [makeFinding()], at: 7 });
+
+    expect(channel.received).toHaveLength(1);
+    expect(channel.received[0]).toMatchObject({ at: 7, severity: "warning" });
+    daemon.notifications.stop();
+  });
+});


### PR DESCRIPTION
Closes #353.

## What
`packages/notifications/` was 3 stub files ("not yet implemented"). Now real:

- **Notification.ts** — channel-neutral shape (`id`, `severity`, `message`, `at`, `source`, `filePath`, `line`), normalized from `DiagnosticFinding`.
- **NotificationChannel.ts** — `NotificationChannel` interface + reference `ConsoleNotificationChannel` implementation.
- **NotificationManager.ts** — subscribes to `kernel.signalBus` `daemon:diagnostics:updated`, normalizes findings, fans out to registered channels; idempotent `start()`/`stop()`, a broken channel can't starve the rest (try/catch per channel).

## Wiring
`ArcluxDaemon` gains a `notificationChannels` option (registered onto `daemon.notifications`), subscribes in `start()` before the first analysis can emit, and unsubscribes first in `stop()`. Existing subscribers (`apps/cli/daemon.ts`, `LocalBridgeServer`) are untouched — additive only.

## Validation
- +11 tests in `tests/notifications.test.ts` (normalization, fan-out, idempotent start, unregister, broken-channel isolation, empty findings, end-to-end event flow through a real `Kernel` SignalBus).
- `npx vitest run`: **236/236 passed**.
- tsc on touched files: 0 errors.