### PR TITLE
feat(terminal): implement packages/terminal/ managed shell layer (issue #351)

### DIFF
--- a/packages/security/Sandbox.ts
+++ b/packages/security/Sandbox.ts
@@ -14,7 +14,7 @@
 
 import type { ProcessSpec } from "../runtime/ProcessSpec";
 import { PermissionManager } from "./PermissionManager";
-import { Capability } from "./Capability";
+import { Capability, type CapabilityValue } from "./Capability";
 
 export interface SandboxCheckResult {
   allowed: boolean;
@@ -30,7 +30,7 @@ export class Sandbox {
    * injecting/overriding env vars for the child).
    */
   checkSpec(spec: ProcessSpec): SandboxCheckResult {
-    const required = [Capability.EXEC];
+    const required: CapabilityValue[] = [Capability.EXEC];
     if (spec.env && Object.keys(spec.env).length > 0) {
       required.push(Capability.ENV_WRITE);
     }

--- a/packages/terminal/CommandExecutor.ts
+++ b/packages/terminal/CommandExecutor.ts
@@ -8,4 +8,86 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: terminal/CommandExecutor — not yet implemented.
+import { spawn } from "node:child_process";
+import type { Sandbox } from "../security/Sandbox";
+import type { ProcessSpec } from "../runtime/ProcessSpec";
+import type { CommandSession } from "./CommandSession";
+import { buildShellEnvironment } from "./ShellEnvironment";
+
+export interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  durationMs: number;
+}
+
+export interface CommandExecutorOptions {
+  /** Kill the child after this many ms and resolve with whatever was captured. */
+  timeoutMs?: number;
+}
+
+/**
+ * Executes a single command through the Sandbox's capability checks instead
+ * of calling child_process directly (issue #351). The sandbox is enforced
+ * BEFORE spawn: a command whose capabilities are not granted never starts.
+ * The request is a ProcessSpec because Sandbox's checkSpec/enforce are
+ * typed against it — a session is one executed ProcessSpec.
+ */
+export class CommandExecutor {
+  constructor(private readonly sandbox: Sandbox) {}
+
+  async execute(spec: ProcessSpec, options: CommandExecutorOptions = {}): Promise<CommandResult> {
+    // Enforce BEFORE spawn — a denied command never starts.
+    this.sandbox.enforce(spec);
+
+    const startedAt = Date.now();
+    const child = spawn(spec.command, spec.args ?? [], {
+      cwd: spec.cwd ?? process.cwd(),
+      env: buildShellEnvironment(spec.env),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timer: NodeJS.Timeout | null = null;
+
+    if (options.timeoutMs && options.timeoutMs > 0) {
+      timer = setTimeout(() => {
+        child.kill("SIGKILL");
+      }, options.timeoutMs);
+    }
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+
+      const finish = (exitCode: number | null) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve({ stdout, stderr, exitCode, durationMs: Date.now() - startedAt });
+      };
+
+      // Spawn failure (ENOENT, permission denied, ...): reject so the caller
+      // can mark the session "error" — not a clean exit with null code.
+      child.once("error", (err) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        reject(err);
+      });
+
+      child.once("close", (code) => {
+        finish(code);
+      });
+    });
+  }
+}
+
+export type { CommandSession } from "./CommandSession";

--- a/packages/terminal/CommandSession.ts
+++ b/packages/terminal/CommandSession.ts
@@ -8,4 +8,26 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: terminal/CommandSession — not yet implemented.
+// The shape of one managed command run, as recorded by TerminalManager.
+// A session starts as "running", ends as "exited" (clean exit, exitCode
+// set) or "error" (spawn failure / sandbox denial / explicit stop). The
+// accumulated stdout/stderr are captured so callers (e.g. a future
+// `arclux run`) can render them without re-deriving from child_process
+// events.
+
+export type CommandStatus = "running" | "exited" | "error";
+
+export interface CommandSession {
+  id: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  /** The full environment the child was launched with (process.env + overrides). */
+  env: Record<string, string>;
+  status: CommandStatus;
+  exitCode: number | null;
+  startedAt: number;
+  endedAt: number | null;
+  stdout: string;
+  stderr: string;
+}

--- a/packages/terminal/ShellEnvironment.ts
+++ b/packages/terminal/ShellEnvironment.ts
@@ -8,4 +8,17 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: terminal/ShellEnvironment — not yet implemented.
+// Builds the environment a managed shell/command runs with: the current
+// process env merged with caller-provided overrides. Kept as a separate
+// module so the merge/override policy lives in one place and can be
+// tested without spawning anything.
+
+export function buildShellEnvironment(overrides: Record<string, string> = {}): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    // process.env values are typed string | undefined; spawn would
+    // serialize undefined as the literal string "undefined", so drop them.
+    if (value !== undefined) env[key] = value;
+  }
+  return { ...env, ...overrides };
+}

--- a/packages/terminal/TerminalManager.ts
+++ b/packages/terminal/TerminalManager.ts
@@ -8,4 +8,90 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: terminal/TerminalManager — not yet implemented.
+import type { ProcessSpec } from "../runtime/ProcessSpec";
+import { Sandbox } from "../security/Sandbox";
+import { PermissionManager } from "../security/PermissionManager";
+import { Capability, type CapabilityValue } from "../security/Capability";
+import { CommandExecutor, type CommandExecutorOptions } from "./CommandExecutor";
+import type { CommandSession } from "./CommandSession";
+import { buildShellEnvironment } from "./ShellEnvironment";
+
+// Managed shell execution layer (issue #351): runs ProcessSpecs through
+// the Sandbox's capability checks instead of calling child_process directly.
+// TerminalManager owns the PermissionManager + Sandbox pair (same wiring as
+// ProcessManager in packages/runtime) and tracks every run as a session.
+
+export interface TerminalManagerOptions {
+  /**
+   * Capabilities granted to a session id on first run. Defaults to the
+   * same baseline ProcessManager grants: EXEC always, ENV_WRITE when the
+   * spec carries env overrides. Callers wanting a tighter policy should
+   * pre-grant their own set for the session id before run().
+   */
+  defaultCapabilities?: CapabilityValue[];
+}
+
+export class TerminalManager {
+  readonly permissions = new PermissionManager();
+  private readonly sandbox = new Sandbox(this.permissions);
+  private readonly executor = new CommandExecutor(this.sandbox);
+  private readonly sessions = new Map<string, CommandSession>();
+  private readonly defaultCapabilities: CapabilityValue[];
+
+  constructor(options: TerminalManagerOptions = {}) {
+    this.defaultCapabilities =
+      options.defaultCapabilities ?? [Capability.EXEC, Capability.ENV_WRITE];
+  }
+
+  /** Run a command to completion, recording it as a session. */
+  async run(spec: ProcessSpec, options: CommandExecutorOptions = {}): Promise<CommandSession> {
+    if (this.sessions.has(spec.id)) {
+      throw new Error(`Terminal: session "${spec.id}" already exists — pick a unique id`);
+    }
+
+    // Grant the baseline on first run (mirrors ProcessManager.start()).
+    if (!this.permissions.getCapabilitySet(spec.id)) {
+      this.permissions.grant(spec.id, this.defaultCapabilities);
+    }
+
+    const session: CommandSession = {
+      id: spec.id,
+      command: spec.command,
+      args: spec.args ?? [],
+      cwd: spec.cwd ?? process.cwd(),
+      env: buildShellEnvironment(spec.env),
+      status: "running",
+      exitCode: null,
+      startedAt: Date.now(),
+      endedAt: null,
+      stdout: "",
+      stderr: "",
+    };
+    this.sessions.set(spec.id, session);
+
+    try {
+      const result = await this.executor.execute(spec, options);
+      session.status = "exited";
+      session.exitCode = result.exitCode;
+      session.stdout = result.stdout;
+      session.stderr = result.stderr;
+      session.endedAt = Date.now();
+    } catch (err) {
+      // Sandbox denial / spawn error: the session is recorded as failed so
+      // callers can see WHY, not silently dropped.
+      session.status = "error";
+      session.endedAt = Date.now();
+      session.stderr = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+    return session;
+  }
+
+  get(id: string): CommandSession | undefined {
+    return this.sessions.get(id);
+  }
+
+  list(): CommandSession[] {
+    return [...this.sessions.values()];
+  }
+}

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -620,6 +620,32 @@ analysis can emit, unsubscribed first in `stop()`. Existing subscribers
 +11 tests (tests/notifications.test.ts), incl. end-to-end event flow
 through a real Kernel SignalBus. Tests: 236/236, tsc 0.
 
+## 2026-08-14 — packages/terminal/ implemented (issue #351)
+
+**Status:** Done
+
+`packages/terminal/` was 4 stub files; now a managed shell execution layer
+(issue #351): runs commands through Sandbox capability checks instead of
+calling child_process directly.
+- `ShellEnvironment.ts` — `buildShellEnvironment()` (process.env + overrides,
+  drops undefined values).
+- `CommandSession.ts` — session shape (status running/exited/error,
+  exitCode, stdout/stderr, timestamps).
+- `CommandExecutor.ts` — spawns a ProcessSpec with `sandbox.enforce()`
+  BEFORE the process starts (denied commands never launch); spawn
+  `error` → reject (session marked "error", not fake clean exit);
+  optional timeoutMs → SIGKILL; settled-guard against error+close double-fire.
+- `TerminalManager.ts` — owns PermissionManager + Sandbox (same wiring as
+  ProcessManager), default-grants EXEC+ENV_WRITE on first run,
+  rejects duplicate session ids, records every run as a session.
+
++15 tests (tests/terminal.test.ts): env merge, stdout/stderr capture,
+non-zero exit, timeout kill, sandbox deny (no capability / wrong set),
+spawn-error, session lifecycle, duplicate id, list, env override.
+Bonus: fixed pre-existing type error in Sandbox.ts:35 (required array
+needed `CapabilityValue[]` annotation — was in KNOWN_ISSUES as owner
+error). Tests: 251/251, tsc 0.
+
 ## 2026-08-14 — Daemon verified end-to-end (issue #347) + 2 runtime bugs fixed
 
 **Status:** Done

--- a/tests/terminal.test.ts
+++ b/tests/terminal.test.ts
@@ -1,0 +1,167 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for issue #351: packages/terminal/ is a managed shell execution
+// layer — runs commands through Sandbox capability checks instead of
+// calling child_process directly, and records each run as a session.
+
+import { describe, it, expect } from "vitest";
+import { CommandExecutor } from "../packages/terminal/CommandExecutor";
+import { TerminalManager } from "../packages/terminal/TerminalManager";
+import { buildShellEnvironment } from "../packages/terminal/ShellEnvironment";
+import { Sandbox } from "../packages/security/Sandbox";
+import { PermissionManager } from "../packages/security/PermissionManager";
+import { Capability, type CapabilityValue } from "../packages/security/Capability";
+import type { ProcessSpec } from "../packages/runtime/ProcessSpec";
+
+// process.execPath so tests pass on any platform without assuming `node` on PATH.
+function nodeSpec(overrides: Partial<ProcessSpec> = {}): ProcessSpec {
+  return {
+    id: "test",
+    name: "test",
+    command: process.execPath,
+    args: ["-e", "console.log('hi')"],
+    ...overrides,
+  };
+}
+
+function grantedSandbox(caps: CapabilityValue[] = [Capability.EXEC, Capability.ENV_WRITE], id = "test") {
+  const permissions = new PermissionManager();
+  permissions.grant(id, caps);
+  return new Sandbox(permissions);
+}
+
+describe("ShellEnvironment", () => {
+  it("merges overrides on top of the process env", () => {
+    const env = buildShellEnvironment({ ARCLUX_TEST: "1" });
+    expect(env.ARCLUX_TEST).toBe("1");
+    // Base process env is still there (PATH at minimum).
+    expect(Object.keys(env).length).toBeGreaterThan(0);
+  });
+
+  it("accepts no overrides (returns a copy of process.env)", () => {
+    const env = buildShellEnvironment();
+    expect(env.PATH ?? env.Path).toBeTruthy();
+  });
+});
+
+describe("CommandExecutor (issue #351)", () => {
+  it("runs a permitted command and captures stdout", async () => {
+    const executor = new CommandExecutor(grantedSandbox());
+    const result = await executor.execute(nodeSpec());
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hi");
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("captures stderr and non-zero exit code", async () => {
+    const executor = new CommandExecutor(grantedSandbox());
+    const result = await executor.execute(
+      nodeSpec({ args: ["-e", "console.error('boom'); process.exit(3)"] })
+    );
+
+    expect(result.exitCode).toBe(3);
+    expect(result.stderr).toContain("boom");
+  });
+
+  it("kills a hung command after timeoutMs", async () => {
+    const executor = new CommandExecutor(grantedSandbox());
+    const started = Date.now();
+    const result = await executor.execute(
+      nodeSpec({ args: ["-e", "setTimeout(() => {}, 5000)"] }),
+      { timeoutMs: 300 }
+    );
+
+    expect(Date.now() - started).toBeGreaterThanOrEqual(300);
+    // SIGKILL means no clean exit code — but the promise must resolve, not hang.
+    expect(result.exitCode).toBeNull();
+  });
+
+  it("rejects when the command binary does not exist (spawn error)", async () => {
+    const executor = new CommandExecutor(grantedSandbox());
+    await expect(
+      executor.execute(nodeSpec({ command: "arclux-definitely-not-a-real-binary-xyz" }))
+    ).rejects.toThrow();
+  });
+
+  it("denies a command without the EXEC capability (sandbox gate)", async () => {
+    const executor = new CommandExecutor(grantedSandbox([Capability.FS_READ]));
+    await expect(executor.execute(nodeSpec())).rejects.toThrow(/denied/);
+  });
+
+  it("denies a command whose capability set is not registered at all", async () => {
+    const executor = new CommandExecutor(new Sandbox(new PermissionManager()));
+    await expect(executor.execute(nodeSpec())).rejects.toThrow(/denied/);
+  });
+});
+
+describe("TerminalManager (issue #351)", () => {
+  it("runs a command and records the session with stdout", async () => {
+    const manager = new TerminalManager();
+    const session = await manager.run(nodeSpec());
+
+    expect(session.status).toBe("exited");
+    expect(session.exitCode).toBe(0);
+    expect(session.stdout).toContain("hi");
+    expect(manager.get("test")).toBe(session);
+  });
+
+  it("default-grants EXEC+ENV_WRITE so run() works without pre-granting", async () => {
+    const manager = new TerminalManager();
+    const session = await manager.run(nodeSpec({ id: "auto" }));
+    expect(session.status).toBe("exited");
+  });
+
+  it("records sandbox denial as an errored session, not a silent drop", async () => {
+    const manager = new TerminalManager({ defaultCapabilities: [Capability.FS_READ] });
+    await expect(manager.run(nodeSpec())).rejects.toThrow(/denied/);
+
+    const session = manager.get("test");
+    expect(session?.status).toBe("error");
+    expect(session?.stderr).toMatch(/denied/);
+  });
+
+  it("rejects duplicate session ids", async () => {
+    const manager = new TerminalManager();
+    await manager.run(nodeSpec());
+    await expect(manager.run(nodeSpec())).rejects.toThrow(/already exists/);
+  });
+
+  it("records a missing-binary spawn error as an errored session", async () => {
+    const manager = new TerminalManager();
+    await expect(
+      manager.run(nodeSpec({ id: "missing", command: "arclux-definitely-not-a-real-binary-xyz" }))
+    ).rejects.toThrow();
+
+    const session = manager.get("missing");
+    expect(session?.status).toBe("error");
+    expect(session?.exitCode).toBeNull();
+  });
+
+  it("lists recorded sessions", async () => {
+    const manager = new TerminalManager();
+    await manager.run(nodeSpec({ id: "one", args: ["-e", "console.log('1')"] }));
+    await manager.run(nodeSpec({ id: "two", args: ["-e", "console.log('2')"] }));
+
+    const ids = manager.list().map((s) => s.id);
+    expect(ids).toEqual(["one", "two"]);
+  });
+
+  it("applies env overrides from the spec to the child", async () => {
+    const manager = new TerminalManager();
+    const session = await manager.run(
+      nodeSpec({
+        id: "envtest",
+        args: ["-e", "console.log(process.env.ARCLUX_TERM_TEST)"],
+        env: { ARCLUX_TERM_TEST: "from-spec" },
+      })
+    );
+    expect(session.stdout).toContain("from-spec");
+  });
+});


### PR DESCRIPTION
Closes #351.

## What
`packages/terminal/` was 4 stub files ("not yet implemented"). Now a managed shell execution layer — runs commands through the Sandbox's capability checks instead of calling `child_process` directly:

- **ShellEnvironment.ts** — `buildShellEnvironment()`: `process.env` + caller overrides, drops `undefined` values (which `spawn` would otherwise serialize as the string "undefined").
- **CommandSession.ts** — session shape: status (`running`/`exited`/`error`), exitCode, accumulated stdout/stderr, timestamps.
- **CommandExecutor.ts** — spawns a `ProcessSpec` with `sandbox.enforce()` **before** the process starts (a denied command never launches). Spawn failure (ENOENT etc.) **rejects** instead of faking a clean exit with null code. Optional `timeoutMs` → SIGKILL. Settled-guard against `error`+`close` double-fire.
- **TerminalManager.ts** — owns the PermissionManager + Sandbox pair (same wiring as ProcessManager in packages/runtime), default-grants EXEC+ENV_WRITE on first run, rejects duplicate session ids, records every run as a session (errored runs stay visible with the reason, not silently dropped).

## Bonus
Fixed a pre-existing type error in `Sandbox.ts:35` (the `required` array needed a `CapabilityValue[]` annotation; it was tracked in KNOWN_ISSUES as an owner-known error and blocked typechecking of this package). Type-only, no behavior change.

## Validation
- +15 tests in `tests/terminal.test.ts`: env merge, stdout/stderr capture, non-zero exit, timeout kill, sandbox deny (no capability set / wrong capabilities), spawn-error → errored session, session lifecycle, duplicate id, list, env override.
- `npx vitest run`: **251/251 passed** (236 + 15).
- tsc on touched files: 0 errors.