### PR TITLE
feat(orchestration): implement packages/orchestration/ glue layer (issue #352)

### DIFF
--- a/packages/daemon/ArcluxDaemon.ts
+++ b/packages/daemon/ArcluxDaemon.ts
@@ -16,13 +16,13 @@
 
 import { Kernel } from "../kernel/Kernel";
 import { DaemonRepositoryWatcher } from "./DaemonRepositoryWatcher";
-import { runDiagnostics } from "../diagnostics/DiagnosticEngine";
 import { findFreePort } from "../networking/PortManager";
 import { createServiceEndpoint, writeServiceEndpoint, removeServiceEndpoint } from "../networking/ServiceEndpoint";
 import { startLocalBridgeServer, type LocalBridgeServer } from "./LocalBridgeServer";
 import { computeDaemonId } from "./DaemonProcess";
 import { NotificationManager } from "../notifications/NotificationManager";
 import type { NotificationChannel } from "../notifications/NotificationChannel";
+import { PlatformOrchestrator } from "../orchestration/PlatformOrchestrator";
 
 export interface ArcluxDaemonOptions {
   rootPath: string;
@@ -40,6 +40,8 @@ export class ArcluxDaemon {
   readonly kernel = new Kernel();
   /** Fans daemon:diagnostics:updated events to registered channels. */
   readonly notifications: NotificationManager;
+  /** Generalizes the watcher→analysis→diagnostics wiring (issue #352). */
+  private orchestrator: PlatformOrchestrator | null = null;
   private watcher: DaemonRepositoryWatcher | null = null;
   private bridgeServer: LocalBridgeServer | null = null;
   private readonly daemonId: string;
@@ -70,24 +72,12 @@ export class ArcluxDaemon {
     this.notifications.start();
 
     this.watcher = new DaemonRepositoryWatcher(this.rootPath);
-
-    this.watcher.on("analysis:updated", (result) => {
-      this.kernel.signalBus.emit("daemon:analysis:updated", {
-        rootPath: this.rootPath,
-        moduleCount: result.moduleCount,
-        at: Date.now(),
-      });
-
-      // Re-run the wired diagnostic adapters (packages/diagnostics/DiagnosticEngine.ts)
-      // on every fresh analysis, so a subscriber gets errors as they appear,
-      // not just graph/module counts.
-      const findings = runDiagnostics(result.repository);
-      this.kernel.signalBus.emit("daemon:diagnostics:updated", { findings, at: Date.now() });
+    this.orchestrator = new PlatformOrchestrator({
+      rootPath: this.rootPath,
+      source: this.watcher,
+      signalBus: this.kernel.signalBus,
     });
-
-    this.watcher.on("analysis:error", (err) => {
-      this.kernel.signalBus.emit("daemon:analysis:error", { message: err.message, at: Date.now() });
-    });
+    this.orchestrator.start();
 
     findFreePort()
       .then((port) => startLocalBridgeServer(this, port))
@@ -109,6 +99,7 @@ export class ArcluxDaemon {
     // Unsubscribe first so a final diagnostics event can't reach channels
     // while the watcher is already tearing down.
     this.notifications.stop();
+    this.orchestrator?.stop();
     if (this.bridgeServer) {
       await this.bridgeServer.close();
       this.bridgeServer = null;

--- a/packages/orchestration/EventRouter.ts
+++ b/packages/orchestration/EventRouter.ts
@@ -8,4 +8,38 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: orchestration/EventRouter — not yet implemented.
+import type { SignalBus } from "../kernel/SignalBus";
+
+// Declarative event routing on top of Kernel's SignalBus (issue #352).
+// Instead of each subsystem hand-wiring "signalBus.on(X, () =>
+// signalBus.emit(Y, ...))", routes are declared as data: an event on
+// `from` is transformed and re-emitted on `to`. Unsubscribing all routes
+// is a single call, which makes tearing a subsystem's wiring down (daemon
+// stop, tests, hot reload) explicit instead of scattered `off` calls.
+
+export interface EventRoute<F = unknown, T = unknown> {
+  from: string;
+  to: string;
+  /** Maps the source payload to the target payload. Identity if omitted. */
+  transform?: (payload: F) => T;
+}
+
+export class EventRouter {
+  constructor(private readonly signalBus: SignalBus) {}
+
+  /** Subscribes one route. Returns an unsubscribe function for that route. */
+  route<F, T>(route: EventRoute<F, T>): () => void {
+    return this.signalBus.on(route.from, (payload: F) => {
+      const transformed = route.transform ? route.transform(payload) : payload;
+      this.signalBus.emit(route.to, transformed as T);
+    });
+  }
+
+  /** Subscribes many routes. Returns a single unsubscribe that removes all of them. */
+  routeMany(routes: EventRoute[]): () => void {
+    const unsubscribes = routes.map((route) => this.route(route));
+    return () => {
+      for (const unsubscribe of unsubscribes) unsubscribe();
+    };
+  }
+}

--- a/packages/orchestration/PlatformOrchestrator.ts
+++ b/packages/orchestration/PlatformOrchestrator.ts
@@ -8,4 +8,72 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: orchestration/PlatformOrchestrator — not yet implemented.
+import type { SignalBus } from "../kernel/SignalBus";
+import type { AnalyzeRepositoryResult } from "../engine/pipeline";
+import { runDiagnostics } from "../diagnostics/DiagnosticEngine";
+
+// The glue layer (issue #352): turns a push-based analysis source (the
+// daemon's repository watcher) into the platform-wide event pipeline
+// (analysis → diagnostics) on the kernel SignalBus. Generalizes the wiring
+// that ArcluxDaemon used to do inline: a new subsystem plugs its source
+// into a PlatformOrchestrator instead of hand-subscribing to every signal
+// name itself. The emitted event names/payload shapes are identical to
+// what the daemon emitted before, so existing subscribers (apps/cli,
+// LocalBridgeServer, NotificationManager) keep working unchanged.
+
+export interface AnalysisEventSource {
+  on(event: "analysis:updated", handler: (result: AnalyzeRepositoryResult) => void): void;
+  on(event: "analysis:error", handler: (err: Error) => void): void;
+  off(event: string, handler: (...args: any[]) => void): void;
+}
+
+export interface PlatformOrchestratorOptions {
+  rootPath: string;
+  source: AnalysisEventSource;
+  signalBus: SignalBus;
+}
+
+export class PlatformOrchestrator {
+  private readonly sourceHandler = {
+    updated: (result: AnalyzeRepositoryResult) => {
+      const { rootPath, signalBus } = this.options;
+      signalBus.emit("daemon:analysis:updated", {
+        rootPath,
+        moduleCount: result.moduleCount,
+        at: Date.now(),
+      });
+
+      // Re-run the wired diagnostic adapters (packages/diagnostics/DiagnosticEngine.ts)
+      // on every fresh analysis, so a subscriber gets errors as they appear,
+      // not just graph/module counts.
+      const findings = runDiagnostics(result.repository);
+      signalBus.emit("daemon:diagnostics:updated", { findings, at: Date.now() });
+    },
+    error: (err: Error) => {
+      this.options.signalBus.emit("daemon:analysis:error", {
+        message: err.message,
+        at: Date.now(),
+      });
+    },
+  };
+
+  private started = false;
+
+  constructor(private readonly options: PlatformOrchestratorOptions) {}
+
+  /** Wires the source events onto the signal bus. Idempotent. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.options.source.on("analysis:updated", this.sourceHandler.updated);
+    this.options.source.on("analysis:error", this.sourceHandler.error);
+  }
+
+  /** Removes all routes from the signal bus. Idempotent. */
+  stop(): void {
+    if (!this.started) return;
+    this.started = false;
+    this.options.source.off("analysis:updated", this.sourceHandler.updated);
+    this.options.source.off("analysis:error", this.sourceHandler.error);
+  }
+}

--- a/packages/orchestration/RecoveryOrchestrator.ts
+++ b/packages/orchestration/RecoveryOrchestrator.ts
@@ -8,4 +8,113 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: orchestration/RecoveryOrchestrator — not yet implemented.
+import type { SignalBus } from "../kernel/SignalBus";
+import { TaskOrchestrator, type TaskRun, type TaskStep } from "./TaskOrchestrator";
+
+// Coordinates recovery when a subsystem reports a failure (issue #352).
+// The orchestrator subscribes to a failure signal, runs a recovery task
+// (a list of steps via TaskOrchestrator), and emits the recovery outcome
+// so the failure is visible instead of silently swallowed. Attempts are
+// capped to prevent a broken recovery from looping forever; the cap is
+// reset on a successful recovery.
+
+export interface RecoveryOrchestratorOptions {
+  signalBus: SignalBus;
+  /** Max recovery attempts before giving up. Default 3. */
+  maxAttempts?: number;
+  taskOrchestrator?: TaskOrchestrator;
+}
+
+export interface RecoveryConfig {
+  /** Signal that triggers recovery (e.g. "daemon:analysis:error"). */
+  failureSignal: string;
+  /** Human-readable name for the recovery task. */
+  name: string;
+  /** Steps run to recover from the failure. */
+  steps: TaskStep[];
+}
+
+export interface RecoveryAttempt {
+  configName: string;
+  attempts: number;
+  lastStatus: "idle" | "recovering" | "succeeded" | "failed";
+  lastError?: string;
+  lastAt: number | null;
+}
+
+export class RecoveryOrchestrator {
+  private readonly signalBus: SignalBus;
+  private readonly maxAttempts: number;
+  private readonly tasks: TaskOrchestrator;
+  private readonly attempts = new Map<string, RecoveryAttempt>();
+  private unsubscribers: (() => void)[] = [];
+
+  constructor(options: RecoveryOrchestratorOptions) {
+    this.signalBus = options.signalBus;
+    this.maxAttempts = options.maxAttempts ?? 3;
+    this.tasks = options.taskOrchestrator ?? new TaskOrchestrator({ signalBus: this.signalBus });
+  }
+
+  /** Registers a recovery for a failure signal. Returns an unsubscribe function. */
+  register(config: RecoveryConfig): () => void {
+    const handler = () => {
+      this.recover(config);
+    };
+    this.signalBus.on(config.failureSignal, handler);
+    const unsubscribe = () => this.signalBus.off(config.failureSignal, handler);
+    this.unsubscribers.push(unsubscribe);
+    return unsubscribe;
+  }
+
+  getAttempt(name: string): RecoveryAttempt | undefined {
+    return this.attempts.get(name);
+  }
+
+  listAttempts(): RecoveryAttempt[] {
+    return [...this.attempts.values()];
+  }
+
+  private async recover(config: RecoveryConfig): Promise<void> {
+    const attempt = this.attempts.get(config.name) ?? {
+      configName: config.name,
+      attempts: 0,
+      lastStatus: "idle" as const,
+      lastAt: null,
+    };
+
+    if (attempt.lastStatus === "recovering") return; // already in flight
+    if (attempt.attempts >= this.maxAttempts) return; // gave up
+
+    attempt.attempts += 1;
+    attempt.lastStatus = "recovering";
+    attempt.lastAt = Date.now();
+    this.attempts.set(config.name, attempt);
+    this.signalBus.emit("recovery:started", { name: config.name, attempt: attempt.attempts, at: Date.now() });
+
+    const run: TaskRun = await this.tasks.execute(`${config.name}-recovery-${attempt.attempts}`, config.steps);
+
+    if (run.status === "completed") {
+      attempt.lastStatus = "succeeded";
+      attempt.attempts = 0; // reset cap on success
+      attempt.lastAt = Date.now();
+      this.signalBus.emit("recovery:succeeded", { name: config.name, at: Date.now() });
+    } else {
+      attempt.lastStatus = "failed";
+      attempt.lastError = run.steps.find((s) => s.status === "failed")?.error;
+      attempt.lastAt = Date.now();
+      this.signalBus.emit("recovery:failed", {
+        name: config.name,
+        attempt: attempt.attempts,
+        error: attempt.lastError,
+        at: Date.now(),
+      });
+    }
+  }
+
+  /** Removes all registered recoveries and clears in-flight state. */
+  dispose(): void {
+    for (const unsubscribe of this.unsubscribers) unsubscribe();
+    this.unsubscribers = [];
+    this.attempts.clear();
+  }
+}

--- a/packages/orchestration/TaskOrchestrator.ts
+++ b/packages/orchestration/TaskOrchestrator.ts
@@ -8,4 +8,110 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: orchestration/TaskOrchestrator — not yet implemented.
+import type { SignalBus } from "../kernel/SignalBus";
+
+// Coordinates multi-step tasks (issue #352): runs a list of steps in
+// order, records per-step state, and stops at the first failure so a
+// broken step can't silently leave later steps half-run. The terminal
+// states (all done / failed at step N) are emitted on the signal bus so
+// orchestrator consumers (recovery, UI) can react without polling.
+//
+// The failure payload mirrors what ProcessManager emits on
+// `process:error` (processId/error shape) so recovery wiring reads the
+// same way across subsystems.
+
+export interface TaskStep {
+  name: string;
+  run: () => Promise<void> | void;
+}
+
+export type TaskStepStatus = "pending" | "running" | "done" | "failed";
+export type TaskStatus = "running" | "completed" | "failed";
+
+export interface TaskStepState {
+  name: string;
+  status: TaskStepStatus;
+  error?: string;
+}
+
+export interface TaskRun {
+  id: string;
+  name: string;
+  status: TaskStatus;
+  steps: TaskStepState[];
+  startedAt: number;
+  finishedAt: number | null;
+}
+
+export interface TaskOrchestratorOptions {
+  signalBus: SignalBus;
+  taskId?: () => string;
+}
+
+let taskCounter = 0;
+
+export class TaskOrchestrator {
+  private readonly signalBus: SignalBus;
+  private readonly taskId: () => string;
+  private runs = new Map<string, TaskRun>();
+
+  constructor(options: TaskOrchestratorOptions) {
+    this.signalBus = options.signalBus;
+    this.taskId =
+      options.taskId ??
+      (() => {
+        taskCounter += 1;
+        return `task-${Date.now()}-${taskCounter}`;
+      });
+  }
+
+  /** Runs steps in order; returns the final TaskRun (completed or failed at step N). */
+  async execute(name: string, steps: TaskStep[]): Promise<TaskRun> {
+    const id = this.taskId();
+    const run: TaskRun = {
+      id,
+      name,
+      status: "running",
+      steps: steps.map((step) => ({ name: step.name, status: "pending" })),
+      startedAt: Date.now(),
+      finishedAt: null,
+    };
+    this.runs.set(id, run);
+    this.signalBus.emit("task:started", { id, name, at: Date.now() });
+
+    for (let i = 0; i < steps.length; i++) {
+      const state = run.steps[i]!;
+      state.status = "running";
+      try {
+        await steps[i]!.run();
+        state.status = "done";
+        this.signalBus.emit("task:step:done", { id, step: steps[i]!.name, at: Date.now() });
+      } catch (err) {
+        state.status = "failed";
+        state.error = err instanceof Error ? err.message : String(err);
+        run.status = "failed";
+        run.finishedAt = Date.now();
+        this.signalBus.emit("task:failed", {
+          id,
+          step: steps[i]!.name,
+          error: state.error,
+          at: Date.now(),
+        });
+        return run;
+      }
+    }
+
+    run.status = "completed";
+    run.finishedAt = Date.now();
+    this.signalBus.emit("task:completed", { id, name, at: Date.now() });
+    return run;
+  }
+
+  get(id: string): TaskRun | undefined {
+    return this.runs.get(id);
+  }
+
+  list(): TaskRun[] {
+    return [...this.runs.values()];
+  }
+}

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -646,6 +646,33 @@ Bonus: fixed pre-existing type error in Sandbox.ts:35 (required array
 needed `CapabilityValue[]` annotation — was in KNOWN_ISSUES as owner
 error). Tests: 251/251, tsc 0.
 
+## 2026-08-14 — packages/orchestration/ implemented (issue #352)
+
+**Status:** Done
+
+`packages/orchestration/` was 4 stub files; now the glue layer that
+generalizes the wiring ArcluxDaemon used to do inline (issue #352):
+- `EventRouter.ts` — declarative routes (`from` → `to` + optional
+  transform) on top of Kernel's SignalBus; `routeMany` + single
+  unsubscribe for teardown.
+- `PlatformOrchestrator.ts` — turns a push-based analysis source into the
+  platform pipeline on the signal bus: `analysis:updated` →
+  `daemon:analysis:updated` (moduleCount) + `runDiagnostics` →
+  `daemon:diagnostics:updated`, `analysis:error` →
+  `daemon:analysis:error`. Emitted names/shapes identical to the old
+  daemon wiring, so existing subscribers are unaffected.
+- `TaskOrchestrator.ts` — runs multi-step tasks in order, per-step state,
+  stops at first failure, emits task:started/step:done/completed/failed.
+- `RecoveryOrchestrator.ts` — subscribes to a failure signal, runs a
+  recovery task via TaskOrchestrator, caps attempts (reset on success),
+  guards against overlapping recoveries.
+
+`ArcluxDaemon` now delegates its watcher→analysis→diagnostics wiring to
+`PlatformOrchestrator` (behavior unchanged — same event names/payloads).
++12 tests (tests/orchestration.test.ts): routing, transforms, single
+unsubscribe, orchestrator wiring + idempotent start/stop, task ordering
++ failure stop, recovery cap/reset/overlap-guard. Tests: 263/263, tsc 0.
+
 ## 2026-08-14 — Daemon verified end-to-end (issue #347) + 2 runtime bugs fixed
 
 **Status:** Done

--- a/tests/orchestration.test.ts
+++ b/tests/orchestration.test.ts
@@ -1,0 +1,323 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for issue #352: packages/orchestration/ generalizes the wiring
+// ArcluxDaemon used to do inline — PlatformOrchestrator turns a
+// push-based analysis source into the platform event pipeline,
+// EventRouter routes signals declaratively, TaskOrchestrator runs
+// multi-step tasks, RecoveryOrchestrator coordinates recovery on failure.
+
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import { SignalBus } from "../packages/kernel/SignalBus";
+import { EventRouter } from "../packages/orchestration/EventRouter";
+import { PlatformOrchestrator } from "../packages/orchestration/PlatformOrchestrator";
+import { TaskOrchestrator } from "../packages/orchestration/TaskOrchestrator";
+import { RecoveryOrchestrator } from "../packages/orchestration/RecoveryOrchestrator";
+import { Repository } from "../packages/repository/Repository";
+import type { AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+import type { DependencyGraph, RepositoryMeta } from "../packages/shared/types";
+
+const meta: RepositoryMeta = {
+  id: "local",
+  org: "local",
+  name: "fixture",
+  defaultBranch: "local",
+  rootPath: "/virtual/fixture",
+  detectedFrameworks: [],
+  packageManager: "npm",
+  analyzedAt: new Date(0).toISOString(),
+};
+
+const emptyGraph: DependencyGraph = {
+  repositoryId: "local",
+  nodes: [],
+  edges: [],
+  builtAt: new Date(0).toISOString(),
+};
+
+function makeResult(moduleCount: number): AnalyzeRepositoryResult {
+  const repository = new Repository(meta);
+  return {
+    meta,
+    moduleCount,
+    graph: emptyGraph,
+    scanSummary: { filesScanned: 0, filesParsed: 0, filesSkippedNoParser: 0, skippedByExtension: {} },
+    repository,
+    dependencies: [],
+  };
+}
+
+/** Minimal push-based source with the same surface as DaemonRepositoryWatcher. */
+function makeSource() {
+  const emitter = new EventEmitter();
+  return {
+    emitUpdated: (result: AnalyzeRepositoryResult) => emitter.emit("analysis:updated", result),
+    emitError: (err: Error) => emitter.emit("analysis:error", err),
+    on: (event: string, handler: (...args: any[]) => void) => emitter.on(event, handler),
+    off: (event: string, handler: (...args: any[]) => void) => emitter.off(event, handler),
+  };
+}
+
+describe("EventRouter (issue #352)", () => {
+  it("routes a signal from `from` to `to` with transform", () => {
+    const bus = new SignalBus();
+    const router = new EventRouter(bus);
+    const seen: unknown[] = [];
+    bus.on("out", (payload: unknown) => seen.push(payload));
+
+    router.route({ from: "in", to: "out", transform: (n: number) => ({ doubled: n * 2 }) });
+    bus.emit("in", 21);
+
+    expect(seen).toEqual([{ doubled: 42 }]);
+  });
+
+  it("identity transform when omitted", () => {
+    const bus = new SignalBus();
+    const router = new EventRouter(bus);
+    const seen: unknown[] = [];
+    bus.on("out", (payload: unknown) => seen.push(payload));
+
+    router.route({ from: "in", to: "out" });
+    bus.emit("in", { x: 1 });
+
+    expect(seen).toEqual([{ x: 1 }]);
+  });
+
+  it("routeMany returns a single unsubscribe that removes all routes", () => {
+    const bus = new SignalBus();
+    const router = new EventRouter(bus);
+    const seen: string[] = [];
+    bus.on("a", () => seen.push("a"));
+    bus.on("b", () => seen.push("b"));
+
+    const unsubscribe = router.routeMany([
+      { from: "in1", to: "a" },
+      { from: "in2", to: "b" },
+    ]);
+    bus.emit("in1", 1);
+    bus.emit("in2", 2);
+    expect(seen).toEqual(["a", "b"]);
+
+    unsubscribe();
+    seen.length = 0;
+    bus.emit("in1", 1);
+    bus.emit("in2", 2);
+    expect(seen).toEqual([]);
+  });
+});
+
+describe("PlatformOrchestrator (issue #352)", () => {
+  it("wires analysis:updated to daemon:analysis:updated and daemon:diagnostics:updated", () => {
+    const bus = new SignalBus();
+    const source = makeSource();
+    const orchestrator = new PlatformOrchestrator({ rootPath: "/repo", source, signalBus: bus });
+    const analysis: unknown[] = [];
+    const diagnostics: unknown[] = [];
+    bus.on("daemon:analysis:updated", (p: unknown) => analysis.push(p));
+    bus.on("daemon:diagnostics:updated", (p: unknown) => diagnostics.push(p));
+
+    orchestrator.start();
+    source.emitUpdated(makeResult(42));
+
+    expect(analysis).toEqual([{ rootPath: "/repo", moduleCount: 42, at: expect.any(Number) }]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({ findings: [] });
+    orchestrator.stop();
+  });
+
+  it("wires analysis:error to daemon:analysis:error", () => {
+    const bus = new SignalBus();
+    const source = makeSource();
+    const orchestrator = new PlatformOrchestrator({ rootPath: "/repo", source, signalBus: bus });
+    const errors: unknown[] = [];
+    bus.on("daemon:analysis:error", (p: unknown) => errors.push(p));
+
+    orchestrator.start();
+    source.emitError(new Error("boom"));
+
+    expect(errors).toEqual([{ message: "boom", at: expect.any(Number) }]);
+    orchestrator.stop();
+  });
+
+  it("start/stop are idempotent — stop removes listeners", () => {
+    const bus = new SignalBus();
+    const source = makeSource();
+    const orchestrator = new PlatformOrchestrator({ rootPath: "/repo", source, signalBus: bus });
+    const analysis: unknown[] = [];
+    bus.on("daemon:analysis:updated", (p: unknown) => analysis.push(p));
+
+    orchestrator.start();
+    orchestrator.start(); // no double subscription
+    source.emitUpdated(makeResult(1));
+    expect(analysis).toHaveLength(1);
+
+    orchestrator.stop();
+    orchestrator.stop(); // idempotent
+    source.emitUpdated(makeResult(2));
+    expect(analysis).toHaveLength(1);
+  });
+});
+
+describe("TaskOrchestrator (issue #352)", () => {
+  it("runs steps in order and completes", async () => {
+    const bus = new SignalBus();
+    const orchestrator = new TaskOrchestrator({ signalBus: bus });
+    const order: string[] = [];
+
+    const run = await orchestrator.execute("demo", [
+      { name: "a", run: () => void order.push("a") },
+      { name: "b", run: () => void order.push("b") },
+    ]);
+
+    expect(order).toEqual(["a", "b"]);
+    expect(run.status).toBe("completed");
+    expect(run.steps.map((s) => s.status)).toEqual(["done", "done"]);
+    expect(run.finishedAt).not.toBeNull();
+  });
+
+  it("stops at the first failing step and records the error", async () => {
+    const bus = new SignalBus();
+    const orchestrator = new TaskOrchestrator({ signalBus: bus });
+    const order: string[] = [];
+
+    const run = await orchestrator.execute("demo", [
+      { name: "ok", run: () => void order.push("ok") },
+      {
+        name: "boom",
+        run: () => {
+          order.push("boom");
+          throw new Error("step failed");
+        },
+      },
+      { name: "never", run: () => void order.push("never") },
+    ]);
+
+    expect(order).toEqual(["ok", "boom"]);
+    expect(run.status).toBe("failed");
+    expect(run.steps[1]).toMatchObject({ status: "failed", error: "step failed" });
+    expect(run.steps[2]).toMatchObject({ status: "pending" });
+  });
+
+  it("emits task:started / task:completed on the signal bus", async () => {
+    const bus = new SignalBus();
+    const orchestrator = new TaskOrchestrator({ signalBus: bus });
+    const events: string[] = [];
+    bus.on("task:started", () => events.push("started"));
+    bus.on("task:completed", () => events.push("completed"));
+    bus.on("task:failed", () => events.push("failed"));
+
+    await orchestrator.execute("demo", [{ name: "a", run: () => {} }]);
+
+    expect(events).toEqual(["started", "completed"]);
+  });
+});
+
+describe("RecoveryOrchestrator (issue #352)", () => {
+  it("runs recovery steps when the failure signal fires", async () => {
+    const bus = new SignalBus();
+    const orchestrator = new RecoveryOrchestrator({ signalBus: bus });
+    const recovered: boolean[] = [];
+    orchestrator.register({
+      failureSignal: "daemon:analysis:error",
+      name: "reanalyze",
+      steps: [
+        {
+          name: "recover",
+          run: () => {
+            recovered.push(true);
+          },
+        },
+      ],
+    });
+
+    bus.emit("daemon:analysis:error", { message: "x", at: 1 });
+    // recover is async — wait for the attempt to settle, not just the step to run.
+    await vi.waitFor(() => {
+      expect(orchestrator.getAttempt("reanalyze")?.lastStatus).toBe("succeeded");
+    });
+
+    expect(recovered).toEqual([true]);
+  });
+
+  it("caps attempts at maxAttempts and gives up", async () => {
+    const bus = new SignalBus();
+    const orchestrator = new RecoveryOrchestrator({ signalBus: bus, maxAttempts: 2 });
+    let attempts = 0;
+    orchestrator.register({
+      failureSignal: "srv:error",
+      name: "restart",
+      steps: [
+        {
+          name: "restart",
+          run: () => {
+            attempts += 1;
+            throw new Error("still down");
+          },
+        },
+      ],
+    });
+
+    // Emit, wait for the attempt to settle, then emit again — recovery is
+    // guarded against overlapping runs, so sync emits would collapse.
+    const settle = () =>
+      vi.waitFor(() => {
+        expect(orchestrator.getAttempt("restart")?.lastStatus).not.toBe("recovering");
+      });
+
+    bus.emit("srv:error", { message: "1", at: 1 });
+    await settle();
+    bus.emit("srv:error", { message: "2", at: 2 });
+    await settle();
+    bus.emit("srv:error", { message: "3", at: 3 });
+    await settle();
+
+    expect(attempts).toBe(2);
+    const attempt = orchestrator.getAttempt("restart");
+    expect(attempt?.lastStatus).toBe("failed");
+    expect(attempt?.lastError).toBe("still down");
+  });
+
+  it("resets the attempt cap after a successful recovery", async () => {
+    const bus = new SignalBus();
+    const orchestrator = new RecoveryOrchestrator({ signalBus: bus, maxAttempts: 2 });
+    let fails = 0;
+    orchestrator.register({
+      failureSignal: "srv:error",
+      name: "retry-once",
+      steps: [
+        {
+          name: "maybe",
+          run: () => {
+            fails += 1;
+            if (fails === 1) throw new Error("first time");
+            // second recovery succeeds
+          },
+        },
+      ],
+    });
+
+    const settle = () =>
+      vi.waitFor(() => {
+        expect(orchestrator.getAttempt("retry-once")?.lastStatus).not.toBe("recovering");
+      });
+
+    bus.emit("srv:error", { message: "1", at: 1 });
+    await settle();
+    expect(orchestrator.getAttempt("retry-once")?.lastStatus).toBe("failed");
+
+    // Second failure is still allowed (attempts 1 < maxAttempts 2), and
+    // succeeding resets the counter back to zero for future failures.
+    bus.emit("srv:error", { message: "2", at: 2 });
+    await settle();
+    expect(orchestrator.getAttempt("retry-once")?.lastStatus).toBe("succeeded");
+    expect(orchestrator.getAttempt("retry-once")?.attempts).toBe(0);
+
+    expect(fails).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #352.

## What
`packages/orchestration/` was 4 stub files ("not yet implemented"). Now the glue layer that generalizes the wiring ArcluxDaemon used to do inline:

- **EventRouter.ts** — declarative routes (`from` → `to` + optional `transform`) on top of Kernel's SignalBus; `routeMany` returns a single unsubscribe so tearing a subsystem's wiring down (daemon stop, tests, hot reload) is one call.
- **PlatformOrchestrator.ts** — turns a push-based analysis source into the platform pipeline on the signal bus: `analysis:updated` → `daemon:analysis:updated` (moduleCount) + `runDiagnostics` → `daemon:diagnostics:updated`; `analysis:error` → `daemon:analysis:error`. Emitted names/shapes are identical to the old daemon wiring, so existing subscribers (apps/cli, LocalBridgeServer, NotificationManager) are unaffected.
- **TaskOrchestrator.ts** — runs multi-step tasks in order, per-step state, stops at first failure, emits `task:started`/`task:step:done`/`task:completed`/`task:failed`.
- **RecoveryOrchestrator.ts** — subscribes to a failure signal, runs a recovery task via TaskOrchestrator, caps attempts (reset on success), guards against overlapping recoveries.

`ArcluxDaemon` now delegates its watcher→analysis→diagnostics wiring to `PlatformOrchestrator` — behavior unchanged (same event names/payloads).

## Validation
- +12 tests in `tests/orchestration.test.ts`: routing + transforms, single-unsubscribe teardown, orchestrator wiring + idempotent start/stop, task ordering + stop-at-failure, recovery cap/reset/overlap-guard.
- `npx vitest run`: **263/263 passed** (251 + 12).
- tsc on touched files: 0 errors.