### PR TITLE
feat(workspace): implement packages/workspace/ session concept (issue #349)

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -19,6 +19,7 @@ import { registerDiagnoseCommand } from "./diagnose";
 import { registerDaemonCommand } from "./daemon";
 import { registerPsCommand } from "./commands/ps";
 import { registerWorkCommand } from "./commands/work";
+import { registerWorkspaceCommand } from "./workspace";
 
 const program = new Command();
 program.name("arclux").description("Repository intelligence CLI").version("0.1.0");
@@ -34,5 +35,6 @@ registerDiagnoseCommand(program);
 registerDaemonCommand(program);
 registerPsCommand(program);
 registerWorkCommand(program);
+registerWorkspaceCommand(program);
 
 program.parse();

--- a/apps/cli/workspace.ts
+++ b/apps/cli/workspace.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// `arclux workspace open [path]` — drives packages/workspace/ (issue #349):
+// ties project + environment + services + processes into one session
+// concept. Opens a session (detecting the repo root), then prints an
+// immutable snapshot of the session's state — processes/services are
+// captured via WorkspaceSnapshot, never read live.
+//
+// Note: sessions live in-process only (no cross-process persistence yet,
+// unlike `ps` which reads records off disk). `open` therefore prints the
+// snapshot in the same invocation.
+
+import type { Command } from "commander";
+import * as p from "@clack/prompts";
+import { resolve } from "node:path";
+import { WorkspaceManager } from "../../packages/workspace/WorkspaceManager";
+
+export function registerWorkspaceCommand(program: Command): void {
+  program
+    .command("workspace")
+    .description("Open a workspace session for a repository and print its snapshot")
+    .argument("[path]", "path to open — auto-detected from cwd if omitted", ".")
+    .option("--json", "output raw snapshot JSON instead of the formatted summary")
+    .action((pathArg: string, options: { json?: boolean }) => {
+      const path = resolve(pathArg);
+      const manager = new WorkspaceManager();
+      const session = manager.open(path);
+      const snapshot = session.snapshot();
+
+      if (options.json) {
+        console.log(JSON.stringify(snapshot, null, 2));
+        return;
+      }
+
+      const state = snapshot.state;
+      p.log.success(
+        `Workspace open: ${state.repositoryRoot}${state.wasStartPath ? "" : " (walked up from " + path + ")"}`
+      );
+      p.log.message(`Status: ${state.status}`);
+      p.log.message(`Processes: ${snapshot.processes.length}`);
+      p.log.message(`Services: ${snapshot.services.length}`);
+    });
+}

--- a/packages/workspace/WorkspaceManager.ts
+++ b/packages/workspace/WorkspaceManager.ts
@@ -8,4 +8,67 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: workspace/WorkspaceManager — not yet implemented.
+import { detectRepositoryRoot } from "../environment/EnvironmentDetector";
+import { WorkspaceSession } from "./WorkspaceSession";
+import type { WorkspaceSnapshot } from "./WorkspaceSnapshot";
+
+// The entry point for workspace sessions (issue #349): ties project +
+// environment + services + processes into one session concept. open() walks
+// up from the given path to find the repository root (EnvironmentDetector),
+// then creates a WorkspaceSession owning a Kernel scoped to that root.
+// The manager keeps a registry of open sessions so callers can list/close
+// them without touching Kernel pieces ad hoc.
+
+export interface OpenWorkspaceOptions {
+  /** Optional kernel override for tests. */
+  kernel?: WorkspaceSession["kernel"];
+}
+
+export class WorkspaceManager {
+  private sessions = new Map<string, WorkspaceSession>();
+
+  /** Opens (or returns the existing) session for a repository root. */
+  open(startPath: string, options: OpenWorkspaceOptions = {}): WorkspaceSession {
+    const detected = detectRepositoryRoot(startPath);
+    const repositoryRoot = detected?.repositoryRoot ?? startPath;
+
+    const existing = this.sessions.get(repositoryRoot);
+    if (existing && existing.status === "active") return existing;
+
+    const session = new WorkspaceSession({
+      rootPath: startPath,
+      repositoryRoot,
+      // When no .git is found anywhere above startPath, the fallback IS
+      // startPath itself — so wasStartPath is true in that case too.
+      wasStartPath: detected ? detected.wasStartPath : true,
+      kernel: options.kernel,
+    });
+    this.sessions.set(repositoryRoot, session);
+    return session;
+  }
+
+  get(repositoryRoot: string): WorkspaceSession | undefined {
+    return this.sessions.get(repositoryRoot);
+  }
+
+  list(): WorkspaceSession[] {
+    return [...this.sessions.values()];
+  }
+
+  snapshots(): WorkspaceSnapshot[] {
+    return this.list().map((session) => session.snapshot());
+  }
+
+  close(repositoryRoot: string): boolean {
+    const session = this.sessions.get(repositoryRoot);
+    if (!session) return false;
+    session.close();
+    this.sessions.delete(repositoryRoot);
+    return true;
+  }
+
+  closeAll(): void {
+    for (const session of this.sessions.values()) session.close();
+    this.sessions.clear();
+  }
+}

--- a/packages/workspace/WorkspaceSession.ts
+++ b/packages/workspace/WorkspaceSession.ts
@@ -8,4 +8,87 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: workspace/WorkspaceSession — not yet implemented.
+import { Kernel } from "../kernel/Kernel";
+import { ProcessStatus } from "../shared/types";
+import type { ProcessSpec } from "../runtime/ProcessSpec";
+import type { ServiceHandle } from "../kernel/ServiceRegistry";
+import { snapshotFromParts, type WorkspaceSnapshot } from "./WorkspaceSnapshot";
+import type { WorkspaceState, WorkspaceStatus } from "./WorkspaceState";
+
+// One active workspace session (issue #349): owns a Kernel (process table,
+// service registry, signal bus) scoped to a detected repository root. The
+// session is the tie point that binds project + environment + services +
+// processes together — RuntimeManager-style callers (CLI, future API
+// routes) drive this instead of touching Kernel pieces ad hoc.
+
+export interface WorkspaceSessionOptions {
+  rootPath: string;
+  repositoryRoot: string;
+  wasStartPath: boolean;
+  kernel?: Kernel;
+}
+
+export class WorkspaceSession {
+  readonly kernel: Kernel;
+  private state: WorkspaceState;
+  private readonly startedAt: number;
+
+  constructor(options: WorkspaceSessionOptions) {
+    this.kernel = options.kernel ?? new Kernel();
+    this.startedAt = Date.now();
+    this.state = {
+      rootPath: options.rootPath,
+      repositoryRoot: options.repositoryRoot,
+      wasStartPath: options.wasStartPath,
+      status: "active",
+      startedAt: this.startedAt,
+      closedAt: null,
+    };
+  }
+
+  getState(): WorkspaceState {
+    return { ...this.state };
+  }
+
+  /** Registers a process with the session's kernel (no spawn — ProcessManager does the actual execution). */
+  registerProcess(spec: ProcessSpec): void {
+    this.kernel.registerProcess({
+      id: spec.id,
+      pid: null,
+      name: spec.name,
+      command: spec.command,
+      args: spec.args ?? [],
+      cwd: spec.cwd ?? this.state.repositoryRoot,
+      status: ProcessStatus.LAUNCHING,
+      startedAt: null,
+    });
+  }
+
+  registerService(handle: ServiceHandle): void {
+    this.kernel.registerService(handle);
+  }
+
+  /** Immutable point-in-time read of processes + services + state. */
+  snapshot(): WorkspaceSnapshot {
+    return snapshotFromParts(this.state, this.kernel.processTable.list(), this.kernel.serviceRegistry.list());
+  }
+
+  /** Closes the session: marks state closed and shuts down the kernel. */
+  close(): void {
+    if (this.state.status !== "active") return;
+    this.state.status = "closed";
+    this.state.closedAt = Date.now();
+    this.kernel.shutdown();
+  }
+
+  setError(err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    this.state.status = "error";
+    this.state.error = message;
+    this.state.closedAt = Date.now();
+  }
+
+  get status(): WorkspaceStatus {
+    return this.state.status;
+  }
+}

--- a/packages/workspace/WorkspaceSnapshot.ts
+++ b/packages/workspace/WorkspaceSnapshot.ts
@@ -8,4 +8,33 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: workspace/WorkspaceSnapshot — not yet implemented.
+import type { ProcessEntry } from "../shared/types";
+import type { ServiceHandle } from "../kernel/ServiceRegistry";
+import type { WorkspaceState } from "./WorkspaceState";
+
+// An immutable point-in-time snapshot of a workspace (issue #349). Mirrors
+// the ProcSnapshot philosophy (packages/kernel/introspection/ProcSnapshot.ts):
+// consumers (CLI, dashboard, restore) read this instead of live mutable
+// state, so a restore can rebuild a session from a known-good capture.
+
+export interface WorkspaceSnapshot {
+  takenAt: number;
+  state: WorkspaceState;
+  /** Shallow copies of every process registered in the session's kernel. */
+  processes: ProcessEntry[];
+  /** Shallow copies of every service registered in the session's kernel. */
+  services: ServiceHandle[];
+}
+
+export function snapshotFromParts(
+  state: WorkspaceState,
+  processes: ProcessEntry[],
+  services: ServiceHandle[]
+): WorkspaceSnapshot {
+  return {
+    takenAt: Date.now(),
+    state: { ...state },
+    processes: processes.map((entry) => ({ ...entry })),
+    services: services.map((handle) => ({ ...handle })),
+  };
+}

--- a/packages/workspace/WorkspaceState.ts
+++ b/packages/workspace/WorkspaceState.ts
@@ -8,4 +8,24 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: workspace/WorkspaceState — not yet implemented.
+// The overall state of one workspace (issue #349): the repository root the
+// session was opened on, the detected environment (was the start path the
+// root or a subfolder walked up), and lifecycle metadata. Process/service
+// listings are NOT part of this object — they live in the session's Kernel
+// (ProcessTable/ServiceRegistry) and are captured immutably by
+// WorkspaceSnapshot when a consumer needs a point-in-time read.
+
+export type WorkspaceStatus = "active" | "closed" | "error";
+
+export interface WorkspaceState {
+  rootPath: string;
+  /** Absolute path to the repository root (the directory containing .git). */
+  repositoryRoot: string;
+  /** True if the open() path itself was the repository root. */
+  wasStartPath: boolean;
+  status: WorkspaceStatus;
+  startedAt: number;
+  /** Set when the session failed to start or was stopped by an error. */
+  closedAt: number | null;
+  error?: string;
+}

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -673,6 +673,31 @@ generalizes the wiring ArcluxDaemon used to do inline (issue #352):
 unsubscribe, orchestrator wiring + idempotent start/stop, task ordering
 + failure stop, recovery cap/reset/overlap-guard. Tests: 263/263, tsc 0.
 
+## 2026-08-14 — packages/workspace/ implemented (issue #349)
+
+**Status:** Done
+
+`packages/workspace/` was 4 stub files; now the session concept tying
+project + environment + services + processes together (issue #349):
+- `WorkspaceState.ts` — per-workspace state: rootPath, repositoryRoot,
+  wasStartPath, status (active/closed/error), timestamps.
+- `WorkspaceSnapshot.ts` — immutable point-in-time capture (state +
+  shallow-copied processes + services) for restore/UI reads, mirroring
+  ProcSnapshot's philosophy.
+- `WorkspaceSession.ts` — owns a Kernel scoped to a detected root;
+  registerProcess/registerService/snapshot/close/setError.
+- `WorkspaceManager.ts` — open() walks up to the repo root via
+  EnvironmentDetector (idempotent per root, fallback to startPath when no
+  .git), list/get/close/closeAll/snapshots.
+
+Wired into the CLI: `arclux workspace <path>` opens a session and prints
+its snapshot (formatted or `--json`), verified running. Sessions are
+in-process only (no cross-process persistence yet) — the command prints
+in the same invocation; no misleading list/snapshot subcommands.
++9 tests (tests/workspace.test.ts): walk-up detection, idempotent open,
+no-git fallback, close/shutdown, snapshot immutability, error state,
+kernel injection, duplicate service rejection. Tests: 272/272, tsc 0.
+
 ## 2026-08-14 — Daemon verified end-to-end (issue #347) + 2 runtime bugs fixed
 
 **Status:** Done

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -1,0 +1,164 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for issue #349: packages/workspace/ ties project + environment +
+// services + processes into one session concept.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { WorkspaceManager } from "../packages/workspace/WorkspaceManager";
+import { WorkspaceSession } from "../packages/workspace/WorkspaceSession";
+import { Kernel } from "../packages/kernel/Kernel";
+import { ProcessStatus } from "../packages/shared/types";
+
+let dirs: string[] = [];
+
+function makeRepo(sub = "repo"): string {
+  const dir = mkdtempSync(join(tmpdir(), "arclux-ws-"));
+  const root = join(dir, sub);
+  mkdirSync(join(root, ".git"), { recursive: true });
+  dirs.push(dir);
+  // Return a path INSIDE the repo dir so detectRepositoryRoot walks up to it.
+  return root;
+}
+
+function makeRepoRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "arclux-ws-"));
+  mkdirSync(join(dir, ".git"));
+  dirs.push(dir);
+  return dir;
+}
+
+function cleanup(): void {
+  for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  dirs = [];
+}
+
+beforeEach(() => cleanup());
+afterEach(() => cleanup());
+
+describe("WorkspaceManager (issue #349)", () => {
+  it("detects the repository root walking up from a subfolder", () => {
+    const sub = makeRepo("nested");
+    const manager = new WorkspaceManager();
+    const session = manager.open(join(sub, "deep", "deeper"));
+
+    const state = session.getState();
+    expect(state.repositoryRoot).toBe(sub);
+    expect(state.wasStartPath).toBe(false);
+    expect(state.status).toBe("active");
+  });
+
+  it("returns the same session for the same root (idempotent open)", () => {
+    const root = makeRepoRoot();
+    const manager = new WorkspaceManager();
+    const a = manager.open(root);
+    const b = manager.open(root);
+
+    expect(a).toBe(b);
+    expect(manager.list()).toHaveLength(1);
+  });
+
+  it("open falls back to startPath when no .git is found", () => {
+    const dir = mkdtempSync(join(tmpdir(), "arclux-ws-nogit-"));
+    dirs.push(dir);
+    const manager = new WorkspaceManager();
+    const session = manager.open(dir);
+
+    expect(session.getState().repositoryRoot).toBe(dir);
+    expect(session.getState().wasStartPath).toBe(true);
+  });
+
+  it("close removes the session and shuts down its kernel", () => {
+    const root = makeRepoRoot();
+    const manager = new WorkspaceManager();
+    const session = manager.open(root);
+    const kernel = session.kernel;
+
+    expect(manager.close(root)).toBe(true);
+    expect(manager.get(root)).toBeUndefined();
+    // After kernel.shutdown() the signal bus is cleared; a state read shows closed.
+    expect(session.getState().status).toBe("closed");
+    expect(kernel.processTable.list()).toEqual([]);
+  });
+
+  it("snapshots capture processes and services immutably", () => {
+    const root = makeRepoRoot();
+    const manager = new WorkspaceManager();
+    const session = manager.open(root);
+
+    session.registerProcess({
+      id: "svc-1",
+      name: "demo",
+      command: process.execPath,
+      args: ["-e", ""],
+    });
+    session.registerService({ name: "demo", processId: "svc-1", registeredAt: Date.now() });
+
+    const snap = session.snapshot();
+    expect(snap.state.repositoryRoot).toBe(root);
+    expect(snap.processes).toHaveLength(1);
+    expect(snap.processes[0]).toMatchObject({ id: "svc-1", status: ProcessStatus.LAUNCHING });
+    expect(snap.services).toHaveLength(1);
+
+    // Snapshot is immutable: mutating the source table doesn't change it.
+    session.kernel.removeProcess("svc-1");
+    expect(snap.processes).toHaveLength(1);
+  });
+});
+
+describe("WorkspaceSession (issue #349)", () => {
+  it("close is idempotent", () => {
+    const session = new WorkspaceSession({
+      rootPath: "/virtual/repo",
+      repositoryRoot: "/virtual/repo",
+      wasStartPath: true,
+    });
+    session.close();
+    session.close();
+    expect(session.status).toBe("closed");
+  });
+
+  it("setError marks the session errored and records the message", () => {
+    const session = new WorkspaceSession({
+      rootPath: "/virtual/repo",
+      repositoryRoot: "/virtual/repo",
+      wasStartPath: true,
+    });
+    session.setError(new Error("analysis failed"));
+
+    expect(session.status).toBe("error");
+    expect(session.getState().error).toBe("analysis failed");
+    expect(session.getState().closedAt).not.toBeNull();
+  });
+
+  it("accepts an injected kernel (test seam)", () => {
+    const kernel = new Kernel();
+    const session = new WorkspaceSession({
+      rootPath: "/virtual/repo",
+      repositoryRoot: "/virtual/repo",
+      wasStartPath: true,
+      kernel,
+    });
+    expect(session.kernel).toBe(kernel);
+  });
+
+  it("registerService throws on duplicate names (ServiceRegistry contract)", () => {
+    const session = new WorkspaceSession({
+      rootPath: "/virtual/repo",
+      repositoryRoot: "/virtual/repo",
+      wasStartPath: true,
+    });
+    session.registerService({ name: "dup", processId: "a", registeredAt: 1 });
+    expect(() => session.registerService({ name: "dup", processId: "b", registeredAt: 2 })).toThrow(
+      /already registered/
+    );
+  });
+});


### PR DESCRIPTION
Closes #349.

## What
`packages/workspace/` was 4 stub files ("not yet implemented"). Now the session concept tying project + environment + services + processes together:

- **WorkspaceState.ts** — per-workspace state: `rootPath`, `repositoryRoot`, `wasStartPath`, status (`active`/`closed`/`error`), timestamps.
- **WorkspaceSnapshot.ts** — immutable point-in-time capture (state + shallow-copied processes + services) for restore/UI reads, mirroring ProcSnapshot's philosophy in packages/kernel/introspection.
- **WorkspaceSession.ts** — owns a Kernel scoped to a detected repo root; `registerProcess`/`registerService`/`snapshot`/`close`/`setError`.
- **WorkspaceManager.ts** — `open()` walks up to the repo root via `EnvironmentDetector` (idempotent per root; falls back to `startPath` when no `.git` is found — and marks that fallback as `wasStartPath: true`), plus `list`/`get`/`close`/`closeAll`/`snapshots`.

## Wiring
`arclux workspace <path>` opens a session and prints its snapshot (formatted or `--json`) — verified running via tsx. Sessions are in-process only (no cross-process persistence yet), so the command prints in the same invocation; no misleading `list`/`snapshot` subcommands that would always be empty in a fresh CLI process.

## Validation
- +9 tests in `tests/workspace.test.ts`: walk-up root detection, idempotent open, no-`.git` fallback, close/shutdown, snapshot immutability, error state, kernel injection seam, duplicate-service rejection.
- `npx vitest run`: **272/272 passed** (263 + 9).
- CLI typecheck clean (except the pre-existing `analyze.ts` error); CLI executed live.