### PR TITLE
feat(system): implement packages/system/ central state aggregator (issue #350)

### DIFF
--- a/apps/cli/commands/system.ts
+++ b/apps/cli/commands/system.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// `arclux system status` — reads packages/system/ (issue #350): aggregates
+// kernel processes/services, workspace sessions, jobs, permissions and
+// health into one snapshot. Follows the ps.ts pattern of reading through
+// an immutable snapshot (SystemManager.snapshot()) instead of live pieces.
+
+import type { Command } from "commander";
+import * as p from "@clack/prompts";
+import { Kernel } from "../../../packages/kernel/Kernel";
+import { SystemManager } from "../../../packages/system/SystemManager";
+
+export function registerSystemCommand(program: Command): void {
+  const system = program
+    .command("system")
+    .description("System state and component health (workspaces + processes + services + jobs)");
+
+  system
+    .command("status")
+    .description("Print the aggregated system state snapshot")
+    .option("--json", "output raw JSON instead of the formatted summary")
+    .action((options: { json?: boolean }) => {
+      // No workspaces/jobs wired in a one-shot CLI process (they're
+      // in-process state) — this command aggregates what a fresh Kernel has:
+      // processes/services tables + health. See packages/system/SystemManager.
+      const manager = new SystemManager({ kernel: new Kernel() });
+      const state = manager.snapshot();
+
+      if (options.json) {
+        console.log(JSON.stringify(state, null, 2));
+        return;
+      }
+
+      p.log.message(`System status: ${state.health.overall} (at ${new Date(state.takenAt).toISOString()})`);
+      for (const component of state.health.components) {
+        const marker = component.status === "ok" ? "✓" : component.status === "degraded" ? "⚠" : "✗";
+        p.log.message(`  ${marker} ${component.name}: ${component.detail ?? component.status}`);
+      }
+    });
+}

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -20,6 +20,7 @@ import { registerDaemonCommand } from "./daemon";
 import { registerPsCommand } from "./commands/ps";
 import { registerWorkCommand } from "./commands/work";
 import { registerWorkspaceCommand } from "./workspace";
+import { registerSystemCommand } from "./commands/system";
 
 const program = new Command();
 program.name("arclux").description("Repository intelligence CLI").version("0.1.0");
@@ -36,5 +37,6 @@ registerDaemonCommand(program);
 registerPsCommand(program);
 registerWorkCommand(program);
 registerWorkspaceCommand(program);
+registerSystemCommand(program);
 
 program.parse();

--- a/packages/scheduler/JobScheduler.ts
+++ b/packages/scheduler/JobScheduler.ts
@@ -42,6 +42,11 @@ export class JobScheduler {
     return this.states.get(jobId);
   }
 
+  /** All known job states, for aggregation (e.g. SystemState). */
+  list(): JobStateEntry[] {
+    return [...this.states.values()];
+  }
+
   /** Pulls runnable jobs off the queue until maxActive is reached or the queue is empty. */
   private drain(): void {
     while (this.runningCount < this.maxActive) {

--- a/packages/security/PermissionManager.ts
+++ b/packages/security/PermissionManager.ts
@@ -62,4 +62,9 @@ export class PermissionManager {
   getCapabilitySet(processId: string): CapabilitySet | undefined {
     return this.sets.get(processId);
   }
+
+  /** All registered capability sets, for aggregation (e.g. SystemState). */
+  list(): { processId: string; set: CapabilitySet }[] {
+    return [...this.sets.entries()].map(([processId, set]) => ({ processId, set }));
+  }
 }

--- a/packages/system/ConfigurationStore.ts
+++ b/packages/system/ConfigurationStore.ts
@@ -8,4 +8,50 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: system/ConfigurationStore — not yet implemented.
+// In-memory system configuration store (issue #350). Plain key/value with
+// typed defaults: get(key) falls back to the default for that key, so
+// consumers never see undefined for declared settings. Deliberately
+// process-local — persisted config is out of scope for the scaffold wave
+// (see progres/decisions.md "Platform layer scaffold" entry).
+
+export interface ConfigurationStoreOptions {
+  defaults?: Record<string, unknown>;
+}
+
+export class ConfigurationStore {
+  private values = new Map<string, unknown>();
+  private readonly defaults: Record<string, unknown>;
+
+  constructor(options: ConfigurationStoreOptions = {}) {
+    this.defaults = options.defaults ?? {};
+  }
+
+  /** Returns the stored value, or the default for the key, or undefined if neither exists. */
+  get<T = unknown>(key: string): T | undefined {
+    if (this.values.has(key)) return this.values.get(key) as T;
+    if (key in this.defaults) return this.defaults[key] as T;
+    return undefined;
+  }
+
+  set(key: string, value: unknown): void {
+    this.values.set(key, value);
+  }
+
+  delete(key: string): boolean {
+    return this.values.delete(key);
+  }
+
+  /** All explicitly-set keys (defaults are not materialized here). */
+  listKeys(): string[] {
+    return [...this.values.keys()];
+  }
+
+  /** Explicitly-set entries (defaults are not materialized here). */
+  entries(): [string, unknown][] {
+    return [...this.values.entries()];
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+}

--- a/packages/system/HealthMonitor.ts
+++ b/packages/system/HealthMonitor.ts
@@ -8,4 +8,75 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: system/HealthMonitor — not yet implemented.
+// Component health monitoring (issue #350). Each component registers a
+// check: a synchronous function returning ok + an optional detail string.
+// check() runs all checks and computes an overall status — a component is
+// "degraded" (warning) or "down" (error) based on its check result, and
+// any error makes the overall status "degraded" while any down makes it
+// "down". Checks are deliberately synchronous and cheap (counts, has,
+// exists) — they must not touch the network or the filesystem.
+
+export type ComponentStatus = "ok" | "degraded" | "down";
+
+export interface ComponentHealth {
+  name: string;
+  status: ComponentStatus;
+  detail?: string;
+}
+
+export interface SystemHealth {
+  overall: "ok" | "degraded" | "down";
+  components: ComponentHealth[];
+  checkedAt: number;
+}
+
+export type HealthCheck = () => { ok: boolean; detail?: string };
+
+export class HealthMonitor {
+  private checks = new Map<string, HealthCheck>();
+
+  /** Registers (or replaces) a health check for a named component. */
+  register(name: string, check: HealthCheck): void {
+    this.checks.set(name, check);
+  }
+
+  unregister(name: string): boolean {
+    return this.checks.delete(name);
+  }
+
+  /** Runs all registered checks and produces the aggregate health. */
+  check(): SystemHealth {
+    const components: ComponentHealth[] = [];
+    let hasDown = false;
+    let hasDegraded = false;
+
+    for (const [name, check] of this.checks) {
+      try {
+        const result = check();
+        if (result.ok) {
+          components.push({ name, status: "ok", detail: result.detail });
+        } else {
+          // A failing check is degraded (recoverable) unless it says down.
+          // We don't have a tri-state return from checks, so map: not ok →
+          // degraded, with the detail carrying why.
+          hasDegraded = true;
+          components.push({ name, status: "degraded", detail: result.detail ?? "check failed" });
+        }
+      } catch (err) {
+        // A check that throws means the component is down, not just degraded.
+        hasDown = true;
+        components.push({
+          name,
+          status: "down",
+          detail: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    return {
+      overall: hasDown ? "down" : hasDegraded ? "degraded" : "ok",
+      components,
+      checkedAt: Date.now(),
+    };
+  }
+}

--- a/packages/system/SystemManager.ts
+++ b/packages/system/SystemManager.ts
@@ -8,4 +8,78 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: system/SystemManager — not yet implemented.
+import type { Kernel } from "../kernel/Kernel";
+import type { JobScheduler } from "../scheduler/JobScheduler";
+import type { PermissionManager } from "../security/PermissionManager";
+import type { WorkspaceManager } from "../workspace/WorkspaceManager";
+import type { ConfigurationStore } from "./ConfigurationStore";
+import { HealthMonitor, type HealthCheck } from "./HealthMonitor";
+import type { SystemState } from "./SystemState";
+
+// The central aggregator (issue #350): composes the already-existing
+// pieces — Kernel (processes/services), WorkspaceManager (sessions),
+// JobScheduler (jobs), PermissionManager (capabilities), ConfigurationStore
+// (settings) — into one immutable SystemState snapshot plus a HealthMonitor
+// that reports component health. Does NOT reimplement any of those pieces;
+// it only reads them, mirroring how PlatformOrchestrator wires events
+// without reimplementing analysis.
+
+export interface SystemManagerOptions {
+  kernel: Kernel;
+  workspaces?: WorkspaceManager;
+  jobs?: JobScheduler;
+  permissions?: PermissionManager;
+  configuration?: ConfigurationStore;
+}
+
+export class SystemManager {
+  readonly health = new HealthMonitor();
+
+  constructor(private readonly options: SystemManagerOptions) {
+    // Default health checks wired from whatever is available.
+    this.health.register("kernel", () => ({
+      ok: true,
+      detail: `${options.kernel.processTable.list().length} processes, ${options.kernel.serviceRegistry.list().length} services`,
+    }));
+
+    if (options.workspaces) {
+      this.health.register("workspaces", () => {
+        const active = options.workspaces!.list().filter((s) => s.status === "active").length;
+        return { ok: true, detail: `${active} active workspace(s)` };
+      });
+    }
+
+    if (options.jobs) {
+      this.health.register("jobs", () => {
+        const jobs = options.jobs!.list();
+        const failed = jobs.filter((j) => j.status === "failed").length;
+        return failed === 0
+          ? { ok: true, detail: `${jobs.length} job(s), 0 failed` }
+          : { ok: false, detail: `${failed}/${jobs.length} job(s) failed` };
+      });
+    }
+  }
+
+  registerHealthCheck(name: string, check: HealthCheck): void {
+    this.health.register(name, check);
+  }
+
+  /** Immutable point-in-time snapshot of the whole system. */
+  snapshot(): SystemState {
+    const { kernel, workspaces, jobs, permissions, configuration } = this.options;
+    return {
+      takenAt: Date.now(),
+      workspaces: workspaces?.snapshots() ?? [],
+      processes: kernel.processTable.list(),
+      services: kernel.serviceRegistry.list(),
+      jobs: jobs?.list() ?? [],
+      capabilities: (permissions?.list() ?? []).map(({ processId, set }) => ({
+        processId,
+        permitted: [...set.permitted],
+        effective: [...set.effective],
+      })),
+      configuration: Object.fromEntries(configuration?.entries() ?? []),
+      health: this.health.check(),
+    };
+  }
+}

--- a/packages/system/SystemState.ts
+++ b/packages/system/SystemState.ts
@@ -8,4 +8,29 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: system/SystemState — not yet implemented.
+import type { ProcessEntry } from "../shared/types";
+import type { ServiceHandle } from "../kernel/ServiceRegistry";
+import type { JobStateEntry } from "../scheduler/JobState";
+import type { WorkspaceSnapshot } from "../workspace/WorkspaceSnapshot";
+import type { SystemHealth } from "./HealthMonitor";
+
+// The central system state shape (issue #350): one immutable snapshot
+// aggregating everything the platform knows — workspaces, processes,
+// services, jobs, permissions, configuration and health. Consumers (CLI
+// `system status`, future web dashboard) read this instead of reaching
+// into Kernel/JobScheduler/PermissionManager pieces ad hoc. All fields
+// are shallow copies of the underlying live objects, same philosophy as
+// ProcSnapshot/WorkspaceSnapshot.
+
+export interface SystemState {
+  /** epoch ms when this snapshot was taken */
+  takenAt: number;
+  workspaces: WorkspaceSnapshot[];
+  processes: ProcessEntry[];
+  services: ServiceHandle[];
+  jobs: JobStateEntry[];
+  /** processId → granted capability set (see packages/security/Capability.ts) */
+  capabilities: { processId: string; permitted: string[]; effective: string[] }[];
+  configuration: Record<string, unknown>;
+  health: SystemHealth;
+}

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -698,6 +698,35 @@ in the same invocation; no misleading list/snapshot subcommands.
 no-git fallback, close/shutdown, snapshot immutability, error state,
 kernel injection, duplicate service rejection. Tests: 272/272, tsc 0.
 
+## 2026-08-14 — packages/system/ implemented (issue #350)
+
+**Status:** Done
+
+`packages/system/` was 4 stub files; now the central state aggregator
+(issue #350):
+- `ConfigurationStore.ts` — in-memory key/value with typed defaults
+  (get falls back to default, set overrides, delete restores, listKeys/
+  entries only cover explicit values).
+- `HealthMonitor.ts` — component health checks (register/unregister/
+  check); per-check try/catch so a throwing check marks that component
+  "down" without taking the whole report down; overall ok/degraded/down.
+- `SystemState.ts` — one immutable snapshot aggregating workspaces +
+  processes + services + jobs + capabilities + configuration + health.
+- `SystemManager.ts` — composes the already-existing pieces (Kernel,
+  WorkspaceManager, JobScheduler, PermissionManager, ConfigurationStore)
+  into SystemState.snapshot(); wires default health checks for
+  kernel/workspaces/jobs (failed jobs → degraded).
+
+Additive methods added so aggregation can read them: `JobScheduler.list()`
+and `PermissionManager.list()` (no behavior change).
+Wired into the CLI: `arclux system status` (formatted or `--json`),
+verified running — aggregates a fresh Kernel + health in a one-shot CLI
+process.
++11 tests (tests/system.test.ts): config defaults/override/delete/list,
+health ok/degraded/down (incl. throwing check), full aggregation, workspace
+inclusion, config inclusion, failed-job degradation, custom checks.
+Tests: 283/283, tsc 0.
+
 ## 2026-08-14 — Daemon verified end-to-end (issue #347) + 2 runtime bugs fixed
 
 **Status:** Done

--- a/tests/system.test.ts
+++ b/tests/system.test.ts
@@ -1,0 +1,179 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for issue #350: packages/system/ aggregates kernel processes/
+// services, workspace sessions, jobs, permissions and health into one
+// immutable SystemState snapshot.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Kernel } from "../packages/kernel/Kernel";
+import { JobScheduler } from "../packages/scheduler/JobScheduler";
+import { createJob } from "../packages/scheduler/Job";
+import { PermissionManager } from "../packages/security/PermissionManager";
+import { Capability } from "../packages/security/Capability";
+import { ConfigurationStore } from "../packages/system/ConfigurationStore";
+import { HealthMonitor } from "../packages/system/HealthMonitor";
+import { SystemManager } from "../packages/system/SystemManager";
+import { WorkspaceManager } from "../packages/workspace/WorkspaceManager";
+import { ProcessStatus } from "../packages/shared/types";
+
+let dirs: string[] = [];
+
+function makeRepoRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "arclux-sys-"));
+  mkdirSync(join(dir, ".git"));
+  dirs.push(dir);
+  return dir;
+}
+
+function cleanup(): void {
+  for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  dirs = [];
+}
+
+beforeEach(() => cleanup());
+afterEach(() => cleanup());
+
+describe("ConfigurationStore (issue #350)", () => {
+  it("falls back to defaults for declared keys", () => {
+    const store = new ConfigurationStore({ defaults: { maxWorkers: 4 } });
+    expect(store.get("maxWorkers")).toBe(4);
+    expect(store.get("unknown")).toBeUndefined();
+  });
+
+  it("set overrides the default; delete restores it", () => {
+    const store = new ConfigurationStore({ defaults: { maxWorkers: 4 } });
+    store.set("maxWorkers", 8);
+    expect(store.get("maxWorkers")).toBe(8);
+    expect(store.delete("maxWorkers")).toBe(true);
+    expect(store.get("maxWorkers")).toBe(4);
+  });
+
+  it("lists only explicitly-set entries", () => {
+    const store = new ConfigurationStore({ defaults: { a: 1 } });
+    store.set("b", 2);
+    expect(store.listKeys()).toEqual(["b"]);
+    expect(store.entries()).toEqual([["b", 2]]);
+  });
+});
+
+describe("HealthMonitor (issue #350)", () => {
+  it("overall is ok when all checks pass", () => {
+    const monitor = new HealthMonitor();
+    monitor.register("a", () => ({ ok: true }));
+    monitor.register("b", () => ({ ok: true, detail: "fine" }));
+
+    const health = monitor.check();
+    expect(health.overall).toBe("ok");
+    expect(health.components).toHaveLength(2);
+    expect(health.components[0]).toMatchObject({ name: "a", status: "ok" });
+  });
+
+  it("a failing check degrades overall", () => {
+    const monitor = new HealthMonitor();
+    monitor.register("a", () => ({ ok: true }));
+    monitor.register("b", () => ({ ok: false, detail: "2/5 failed" }));
+
+    expect(monitor.check().overall).toBe("degraded");
+  });
+
+  it("a throwing check marks the component down", () => {
+    const monitor = new HealthMonitor();
+    monitor.register("a", () => ({ ok: true }));
+    monitor.register("b", () => {
+      throw new Error("bridge unreachable");
+    });
+
+    const health = monitor.check();
+    expect(health.overall).toBe("down");
+    expect(health.components[1]).toMatchObject({ name: "b", status: "down", detail: "bridge unreachable" });
+  });
+});
+
+describe("SystemManager (issue #350)", () => {
+  it("aggregates processes, services, jobs, capabilities and health", async () => {
+    const kernel = new Kernel();
+    kernel.registerProcess({
+      id: "p1",
+      pid: null,
+      name: "demo",
+      command: process.execPath,
+      args: [],
+      cwd: ".",
+      status: ProcessStatus.ONLINE,
+      startedAt: Date.now(),
+    });
+    kernel.registerService({ name: "demo", processId: "p1", registeredAt: Date.now() });
+
+    const jobs = new JobScheduler({ maxActive: 1 });
+    jobs.schedule(createJob({ name: "ok", run: async () => {} }));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const permissions = new PermissionManager();
+    permissions.grant("p1", [Capability.EXEC]);
+
+    const manager = new SystemManager({ kernel, jobs, permissions });
+    const state = manager.snapshot();
+
+    expect(state.processes).toHaveLength(1);
+    expect(state.services).toHaveLength(1);
+    expect(state.jobs.length).toBeGreaterThanOrEqual(1);
+    expect(state.capabilities).toEqual([{ processId: "p1", permitted: ["exec"], effective: ["exec"] }]);
+    expect(state.health.overall).toBe("ok");
+  });
+
+  it("includes workspace snapshots when a WorkspaceManager is provided", () => {
+    const root = makeRepoRoot();
+    const workspaces = new WorkspaceManager();
+    workspaces.open(root);
+
+    const manager = new SystemManager({ kernel: new Kernel(), workspaces });
+    const state = manager.snapshot();
+
+    expect(state.workspaces).toHaveLength(1);
+    expect(state.workspaces[0].state.repositoryRoot).toBe(root);
+    expect(state.health.components.find((c) => c.name === "workspaces")?.detail).toContain("1 active");
+  });
+
+  it("includes configuration entries when a store is provided", () => {
+    const configuration = new ConfigurationStore({ defaults: { maxWorkers: 4 } });
+    configuration.set("theme", "dark");
+
+    const manager = new SystemManager({ kernel: new Kernel(), configuration });
+    expect(manager.snapshot().configuration).toEqual({ theme: "dark" });
+  });
+
+  it("job health check flags failed jobs as degraded", async () => {
+    const kernel = new Kernel();
+    const jobs = new JobScheduler({ maxActive: 1 });
+    jobs.schedule(
+      createJob({
+        name: "bad",
+        run: async () => {
+          throw new Error("boom");
+        },
+      })
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    const manager = new SystemManager({ kernel, jobs });
+    expect(manager.snapshot().health.overall).toBe("degraded");
+  });
+
+  it("custom health checks can be registered after construction", () => {
+    const manager = new SystemManager({ kernel: new Kernel() });
+    manager.registerHealthCheck("custom", () => ({ ok: false, detail: "warn" }));
+
+    expect(manager.snapshot().health.components.find((c) => c.name === "custom")).toMatchObject({
+      status: "degraded",
+    });
+  });
+});


### PR DESCRIPTION
Closes #350.

## What
`packages/system/` was 4 stub files ("not yet implemented"). Now the central state aggregator:

- **ConfigurationStore.ts** — in-memory key/value with typed defaults: `get` falls back to the default, `set` overrides, `delete` restores, `listKeys`/`entries` only cover explicit values.
- **HealthMonitor.ts** — component health checks (`register`/`unregister`/`check`); per-check try/catch so a throwing check marks that component `down` without taking the whole report down; overall `ok`/`degraded`/`down`.
- **SystemState.ts** — one immutable snapshot aggregating workspaces + processes + services + jobs + capabilities + configuration + health.
- **SystemManager.ts** — composes the already-existing pieces (Kernel, WorkspaceManager, JobScheduler, PermissionManager, ConfigurationStore) into `SystemState.snapshot()`; wires default health checks for kernel/workspaces/jobs (failed jobs → degraded).

## Supporting changes
`JobScheduler.list()` and `PermissionManager.list()` added (additive, no behavior change) so the aggregator can read their internal state.

## Wiring
`arclux system status` (formatted or `--json`) — verified running via tsx; aggregates a fresh Kernel + health in a one-shot CLI process.

## Validation
- +11 tests in `tests/system.test.ts`: config defaults/override/delete/list, health ok/degraded/down (incl. throwing check), full aggregation, workspace inclusion, config inclusion, failed-job degradation, custom checks.
- `npx vitest run`: **283/283 passed** (272 + 11).
- CLI typecheck clean (except pre-existing `analyze.ts`); CLI executed live.