### PR TITLE
[feat] Universal responsive UI (mobile-first)

### DIFF
--- a/apps/web/AGENT.md
+++ b/apps/web/AGENT.md
@@ -54,8 +54,8 @@ Detail lengkap: `apps/web/vendor-ui/README.md`.
 
 ## Theming
 
-Warna dan token graph sudah didefinisikan di `theme/arclux.json` dan
-`theme/graphColors.ts`, termasuk token khusus untuk 6 tipe node
+Warna dan token graph sudah didefinisikan di `theme/colors.ts`,
+`theme/theme.dark.ts` dan `theme/graphColors.ts`, termasuk token khusus untuk 6 tipe node
 (`file`, `folder`, `external-package`, `route`, `component`, `hook`) dan
 4 tipe edge. Jangan hardcode warna baru untuk elemen graph — tambahkan
 token di `graphColors.ts` dan referensikan dari sana.

--- a/apps/web/components/graph/GraphCanvas.tsx
+++ b/apps/web/components/graph/GraphCanvas.tsx
@@ -21,6 +21,7 @@ import {
 import { useGraphContext } from "./GraphProvider";
 import { GraphNode, type GraphNodePosition } from "./GraphNode";
 import { GraphEdge } from "./GraphEdge";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 interface SimNode extends SimulationNodeDatum {
   id: string;
@@ -28,6 +29,26 @@ interface SimNode extends SimulationNodeDatum {
 
 const DOUBLE_CLICK_DELAY_MS = 300;
 const ZOOM_TO_NODE_SCALE = 2;
+// Touch hit target for node dots (Apple HIG minimum). The invisible circle
+// is only rendered on coarse pointers; see GraphNode hitRadius prop.
+const NODE_HIT_RADIUS = 22;
+// World-space margin around the visible viewport kept in the render pass so
+// nodes/edges partially entering the frame don't pop out one frame early.
+const CULL_MARGIN = 100;
+
+interface PointerPoint {
+  x: number;
+  y: number;
+}
+
+interface PinchState {
+  startDistance: number;
+  startScale: number;
+  startMidX: number;
+  startMidY: number;
+  startTx: number;
+  startTy: number;
+}
 
 export function GraphCanvas() {
   const {
@@ -58,6 +79,16 @@ export function GraphCanvas() {
   // graph.edges (hundreds of SVG elements) on every pointermove. State is
   // only committed once, on pointerup, via setTransform.
   const liveTransform = useRef(transform);
+  // Active pointers (id -> position). Size 2 = pinch; the transition from
+  // 1 to 2 cancels the single-finger pan so the two gestures never fight.
+  const pointers = useRef(new Map<number, PointerPoint>());
+  // Snapshot taken when the second finger lands; updated scale/translation
+  // are derived from it on every move (zoom-to-midpoint, not viewport-center
+  // zoom — the content stays under the fingers).
+  const pinchStart = useRef<PinchState | null>(null);
+  // Coarse pointer (touch) devices get the larger node hit target; mouse
+  // keeps precise 6px targeting on dense graphs.
+  const isCoarsePointer = useMediaQuery("(pointer: coarse)");
 
   useEffect(() => {
     liveTransform.current = transform;
@@ -182,11 +213,53 @@ export function GraphCanvas() {
   }
 
   function handlePointerDown(e: React.PointerEvent) {
-    isPanning.current = true;
-    lastPointer.current = { x: e.clientX, y: e.clientY };
+    pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pointers.current.size === 2) {
+      // Second finger down: switch from pan to pinch, anchored at the
+      // current midpoint + scale so zoom keeps the content under the
+      // fingers (zoom-to-point) instead of around the viewport center.
+      const [p1, p2] = [...pointers.current.values()];
+      pinchStart.current = {
+        startDistance: Math.hypot(p2.x - p1.x, p2.y - p1.y),
+        startScale: liveTransform.current.scale,
+        startMidX: (p1.x + p2.x) / 2,
+        startMidY: (p1.y + p2.y) / 2,
+        startTx: liveTransform.current.x,
+        startTy: liveTransform.current.y,
+      };
+      isPanning.current = false;
+      return;
+    }
+
+    if (pointers.current.size === 1) {
+      isPanning.current = true;
+      lastPointer.current = { x: e.clientX, y: e.clientY };
+    }
   }
 
   function handlePointerMove(e: React.PointerEvent) {
+    if (!pointers.current.has(e.pointerId)) return;
+    pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    // Pinch: scale by the finger-distance ratio, translate so the midpoint
+    // stays pinned to where the fingers were when the pinch started.
+    if (pinchStart.current && pointers.current.size >= 2) {
+      const [p1, p2] = [...pointers.current.values()];
+      const distance = Math.hypot(p2.x - p1.x, p2.y - p1.y);
+      const midX = (p1.x + p2.x) / 2;
+      const midY = (p1.y + p2.y) / 2;
+      const scale = Math.min(3, Math.max(0.2, pinchStart.current.startScale * (distance / pinchStart.current.startDistance)));
+      const k = scale / pinchStart.current.startScale;
+      liveTransform.current = {
+        scale,
+        x: midX - k * (pinchStart.current.startMidX - pinchStart.current.startTx),
+        y: midY - k * (pinchStart.current.startMidY - pinchStart.current.startTy),
+      };
+      applyTransformToDOM(liveTransform.current);
+      return;
+    }
+
     if (!isPanning.current) return;
     const dx = e.clientX - lastPointer.current.x;
     const dy = e.clientY - lastPointer.current.y;
@@ -199,13 +272,18 @@ export function GraphCanvas() {
     applyTransformToDOM(liveTransform.current);
   }
 
-  function handlePointerUp() {
-    if (isPanning.current) {
-      // Commit the DOM-only value to React state exactly once, at the end
-      // of the drag, instead of on every pointermove.
-      setTransform(liveTransform.current);
+  function endPointer(e: React.PointerEvent) {
+    pointers.current.delete(e.pointerId);
+    // Lifting one finger out of a pinch falls back to one-finger pan.
+    if (pointers.current.size < 2) pinchStart.current = null;
+    if (pointers.current.size === 0) {
+      if (isPanning.current) {
+        // Commit the DOM-only value to React state exactly once, at the end
+        // of the drag, instead of on every pointermove.
+        setTransform(liveTransform.current);
+      }
+      isPanning.current = false;
     }
-    isPanning.current = false;
   }
 
   function handleWheel(e: React.WheelEvent) {
@@ -234,14 +312,27 @@ export function GraphCanvas() {
     );
   }
 
+  // Viewport culling: only render nodes/edges intersecting the visible
+  // world-space rectangle (plus CULL_MARGIN), so zoomed-in views of large
+  // graphs stop re-rendering hundreds of off-screen SVG elements. The
+  // selected/hovered node always renders regardless of visibility.
+  const margin = CULL_MARGIN / transform.scale;
+  const viewLeft = -transform.x / transform.scale - margin;
+  const viewTop = -transform.y / transform.scale - margin;
+  const viewRight = (dimensions.width - transform.x) / transform.scale + margin;
+  const viewBottom = (dimensions.height - transform.y) / transform.scale + margin;
+  const isInView = (pos: GraphNodePosition) =>
+    pos.x >= viewLeft && pos.x <= viewRight && pos.y >= viewTop && pos.y <= viewBottom;
+
   return (
     <div
       ref={containerRef}
-      className="relative h-full w-full overflow-hidden bg-black"
+      className="relative h-full w-full touch-none overflow-hidden bg-black"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerLeave={handlePointerUp}
+      onPointerUp={endPointer}
+      onPointerCancel={endPointer}
+      onPointerLeave={endPointer}
       onWheel={handleWheel}
     >
       <svg
@@ -282,6 +373,9 @@ export function GraphCanvas() {
               edge.target === selectedNodeId ||
               edge.source === hoveredNodeId ||
               edge.target === hoveredNodeId;
+            // Cull edges with BOTH endpoints off-screen (an edge touching a
+            // visible node must render, even if its other end is outside).
+            if (!isHighlighted && !isInView(sourcePos) && !isInView(targetPos)) return null;
             // Label only shows for the SELECTED node's edges, not hover —
             // hovering a high fan-in hub was popping dozens of overlapping
             // "imports" labels at once (see live dogfood screenshot).
@@ -302,17 +396,23 @@ export function GraphCanvas() {
           {graph.nodes.map((node) => {
             const pos = positions.get(node.id);
             if (!pos) return null;
+            const isSelected = node.id === selectedNodeId;
+            const isHovered = node.id === hoveredNodeId;
+            // Cull off-screen nodes (selected/hovered always stay mounted
+            // so interaction never drops them mid-gesture).
+            if (!isSelected && !isHovered && !isInView(pos)) return null;
             return (
               <GraphNode
                 key={node.id}
                 node={node}
                 position={pos}
-                isSelected={node.id === selectedNodeId}
-                isHovered={node.id === hoveredNodeId}
+                isSelected={isSelected}
+                isHovered={isHovered}
                 onClick={selectNode}
                 onHoverChange={setHoveredNodeId}
                 importCount={importCounts.get(node.id) ?? 0}
                 zoomScale={transform.scale}
+                hitRadius={isCoarsePointer ? NODE_HIT_RADIUS : undefined}
               />
             );
           })}

--- a/apps/web/components/graph/GraphEdge.tsx
+++ b/apps/web/components/graph/GraphEdge.tsx
@@ -8,6 +8,7 @@
 
 "use client";
 
+import { memo } from "react";
 import { getGraphEdgeColor } from "@/theme/graphColors";
 import type { GraphEdge as GraphEdgeData } from "@/packages/shared/types";
 import type { GraphNodePosition } from "./GraphNode";
@@ -59,7 +60,7 @@ function shortenToCircleBoundary(
  * as clean labeled cards with no overlap — that's the intended place to
  * see per-edge type info now, not the canvas itself.
  */
-export function GraphEdge({
+export function GraphEdgeComponent({
   edge,
   sourcePos,
   targetPos,
@@ -94,3 +95,11 @@ export function GraphEdge({
     />
   );
 }
+
+// Memoized for the same reason as GraphNode: GraphCanvas re-renders on every
+// pan/zoom frame (transform state), but an edge's own props (edge, sourcePos,
+// targetPos, isHighlighted) are stable across those frames — without memo,
+// hundreds of <line> elements re-render per pointermove for zero visual
+// change. Default shallow-compare is sufficient (all props are primitives or
+// stable references).
+export const GraphEdge = memo(GraphEdgeComponent);

--- a/apps/web/components/graph/GraphNode.tsx
+++ b/apps/web/components/graph/GraphNode.tsx
@@ -32,6 +32,11 @@ export interface GraphNodeProps {
    * only renders past MIN_ZOOM_FOR_HALO to avoid clutter when zoomed
    * out on dense graphs -- see progres/PROGRES-decisions.md. */
   zoomScale?: number;
+  /** Touch hit radius (px). Set on coarse-pointer devices so the visual
+   * 6px dot still meets the 44px tap target via an invisible larger
+   * circle. Undefined on fine pointers (mouse) — desktop keeps precise
+   * 6px targeting on dense graphs. */
+  hitRadius?: number;
 }
 
 const BASE_RADIUS = 6;
@@ -75,6 +80,7 @@ function GraphNodeComponent({
   onHoverChange,
   importCount = 0,
   zoomScale = 1,
+  hitRadius,
 }: GraphNodeProps) {
   const color = getGraphNodeColor(node.type, "dark");
   const radius = isSelected ? BASE_RADIUS + 3 : isHovered ? BASE_RADIUS + 1.5 : BASE_RADIUS;
@@ -119,6 +125,13 @@ function GraphNodeComponent({
           opacity={isSelected || isHovered ? 0.95 : 0.65}
           className="pointer-events-none"
         />
+      )}
+      {/* Invisible hit target. Must be LAST so it sits on top: SVG hits
+          register against the topmost shape, and the visible dot/icon/
+          label all keep pointer-events-none — so the whole hitRadius disk
+          becomes the tap target on touch devices. */}
+      {hitRadius !== undefined && hitRadius > radius && (
+        <circle r={hitRadius} fill="transparent" />
       )}
       {(() => {
         if (zoomScale < MIN_ZOOM_FOR_LABEL) return null;

--- a/apps/web/components/graph/GraphViewport.tsx
+++ b/apps/web/components/graph/GraphViewport.tsx
@@ -15,6 +15,7 @@ import { GraphSearch } from "./GraphSearch";
 import { GraphFocusView } from "./GraphFocusView";
 import { GraphContextMenu } from "./GraphContextMenu";
 import { Explorer } from "@/components/explorer/Explorer";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 export interface GraphViewportProps {
   repoUrl: string;
@@ -35,13 +36,24 @@ export interface GraphViewportProps {
  */
 function ExplorerPanel({ repoUrl, branch }: { repoUrl: string; branch?: string }) {
   const { graph, selectedNodeId, selectNode } = useGraphContext();
+  // md+ keeps the Explorer as a 380px flex sibling (canvas column narrows);
+  // below md a 380px sibling would leave the canvas ~0px wide on a phone,
+  // so it becomes a full-screen overlay instead. Safe to branch on the
+  // hook here: the panel only mounts after a client-side node selection.
+  const isMdUp = useMediaQuery("(min-width: 48rem)");
 
   if (!selectedNodeId) return null;
   const selected = graph?.nodes.find((n) => n.id === selectedNodeId);
   if (!selected || selected.type !== "file") return null;
 
   return (
-    <div className="h-full w-[380px] shrink-0">
+    <div
+      className={
+        isMdUp
+          ? "h-full w-[380px] shrink-0"
+          : "fixed inset-0 z-50 shadow-2xl"
+      }
+    >
       <Explorer
         repoUrl={repoUrl}
         moduleId={selectedNodeId}

--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -1,0 +1,70 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { LayoutDashboard, Network, Search, Activity, PanelsTopLeft } from "lucide-react"
+import { cn } from "@/lib/cn"
+
+interface BottomNavProps {
+  org: string
+  repo: string
+}
+
+const ITEMS = [
+  { label: "Overview", icon: LayoutDashboard, suffix: "" },
+  { label: "Graph", icon: Network, suffix: "/graph" },
+  { label: "Search", icon: Search, suffix: "/search" },
+  { label: "Activity", icon: Activity, suffix: "/activity" },
+  { label: "Workspace", icon: PanelsTopLeft, suffix: "/workspace" },
+]
+
+/**
+ * Mobile-only bottom navigation (< 768px, Tailwind `md:hidden`). Mirrors the
+ * desktop sidebar links minus Settings, which lives in the Navbar on mobile
+ * (one-off page — keeping the bottom bar to the 5 pages users actually
+ * switch between, GitHub-Mobile style). Rendered as a flex child of
+ * WorkspaceLayout (not `fixed`) so it never overlaps scrollable content or
+ * the graph canvas — it simply takes the bottom 4rem of the column. Safe
+ * area padding keeps it above the gesture/home bar on notched phones.
+ */
+export function BottomNav({ org, repo }: BottomNavProps) {
+  const pathname = usePathname()
+  const base = `/${org}/${repo}`
+
+  return (
+    <nav
+      aria-label="Primary"
+      className="bg-muted/50 select-none md:hidden"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      <div className="grid h-16 grid-cols-5">
+        {ITEMS.map(({ label, icon: Icon, suffix }) => {
+          const href = `${base}${suffix}`
+          const isActive = pathname === href
+          return (
+            <Link
+              key={href}
+              href={href}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "flex flex-col items-center justify-center gap-0.5 text-[11px] font-medium transition-transform active:scale-95",
+                isActive ? "text-primary" : "text-muted-foreground"
+              )}
+            >
+              <Icon className="h-5 w-5" />
+              {label}
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -9,21 +9,64 @@
 "use client"
 
 import Link from "next/link"
-import { Moon, Sun } from "lucide-react"
+import { Moon, Sun, PanelLeft, Settings } from "lucide-react"
 import { useTheme } from "@/hooks/useTheme"
 import { Button } from "@/components/ui/button"
 
-export function Navbar() {
+interface NavbarProps {
+  org: string
+  repo: string
+  /** Tablet: opens the sidebar overlay drawer. Desktop: toggles the inline collapse. */
+  onMenuClick?: () => void
+  /** Highlights the menu button while the overlay drawer is open. */
+  menuActive?: boolean
+}
+
+/**
+ * Top bar. No bottom border — the transition to the breadcrumbs strip below
+ * is a background-tone difference (breadcrumbs zone uses `bg-muted/40`),
+ * matching the borderless premium look. The menu button is hidden below
+ * `md` (mobile uses BottomNav), the Settings link is hidden above `md`
+ * (it lives in the sidebar there). Icon buttons grow to 44px on mobile for
+ * touch targets (Apple HIG), staying compact on desktop.
+ */
+export function Navbar({ org, repo, onMenuClick, menuActive = false }: NavbarProps) {
   const { theme, toggleTheme } = useTheme()
+  const settingsHref = `/${org}/${repo}/settings`
 
   return (
-    <header className="flex h-14 shrink-0 items-center justify-between border-b px-4">
-      <Link href="/" className="text-sm font-semibold tracking-tight">
-        Arclux
-      </Link>
+    <header className="flex h-14 shrink-0 items-center justify-between gap-2 bg-background px-4">
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onMenuClick}
+          aria-label="Toggle navigation"
+          aria-expanded={menuActive}
+          className="hidden size-11 md:flex md:size-8 active:scale-95"
+        >
+          <PanelLeft className="h-4 w-4" />
+        </Button>
+        <Link href="/" className="px-2 text-sm font-semibold tracking-tight">
+          Arclux
+        </Link>
+      </div>
 
-      <div className="flex items-center gap-2">
-        <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Toggle theme">
+      <div className="flex items-center gap-1">
+        <Link
+          href={settingsHref}
+          aria-label="Settings"
+          className="rounded-md p-2.5 text-muted-foreground transition-transform hover:text-foreground active:scale-95 md:hidden"
+        >
+          <Settings className="h-5 w-5" />
+        </Link>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={toggleTheme}
+          aria-label="Toggle theme"
+          className="size-11 md:size-8 active:scale-95"
+        >
           {theme === "dark" ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
         </Button>
       </div>

--- a/apps/web/components/layout/Sidebar.tsx
+++ b/apps/web/components/layout/Sidebar.tsx
@@ -10,15 +10,32 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, Network, Search, Settings, PanelsTopLeft, Activity } from "lucide-react"
+import { LayoutDashboard, Network, Search, Settings, PanelsTopLeft, Activity, X } from "lucide-react"
 import { cn } from "@/lib/cn"
 
 interface SidebarProps {
   org: string
   repo: string
+  /** Desktop inline mode: collapsed to a bare icon rail (w-16). */
+  collapsed?: boolean
+  /** Tablet overlay mode: rendered in a fixed drawer, shows a close button. */
+  overlay?: boolean
+  /** Called when the user asks to close the overlay drawer. */
+  onClose?: () => void
 }
 
-export function Sidebar({ org, repo }: SidebarProps) {
+/**
+ * Navigation sidebar, rendered by WorkspaceLayout in one of two modes:
+ * - Desktop (inline, `hidden lg:block` wrapper): `w-64`, collapsible to a
+ *   `w-16` icon rail. Width animates via `transition-all duration-300`.
+ * - Tablet (overlay): WorkspaceLayout wraps this in a `fixed` drawer with
+ *   a backdrop; `overlay` adds the close button. Not rendered on mobile —
+ *   BottomNav owns navigation there.
+ *
+ * Premium styling: no `border-r` — separation from the content column comes
+ * from the sidebar background token (`bg-sidebar`) plus a soft shadow.
+ */
+export function Sidebar({ org, repo, collapsed = false, overlay = false, onClose }: SidebarProps) {
   const pathname = usePathname()
   const base = `/${org}/${repo}`
 
@@ -32,7 +49,26 @@ export function Sidebar({ org, repo }: SidebarProps) {
   ]
 
   return (
-    <aside className="flex h-full w-56 shrink-0 flex-col gap-1 border-r bg-background p-3">
+    <aside
+      className={cn(
+        "flex h-full flex-col gap-1 overflow-hidden bg-sidebar p-3 text-sidebar-foreground transition-all duration-300 select-none",
+        collapsed ? "w-16" : "w-64",
+        overlay ? "shadow-2xl" : "shadow-lg"
+      )}
+    >
+      {overlay && (
+        <div className="mb-2 flex items-center justify-between px-2">
+          <span className="text-sm font-semibold">Navigation</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close navigation"
+            className="rounded-md p-2 transition-transform hover:bg-accent active:scale-95"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
       {links.map(({ label, href, icon: Icon }) => {
         const isActive = pathname === href
 
@@ -40,16 +76,18 @@ export function Sidebar({ org, repo }: SidebarProps) {
           <Link
             key={href}
             href={href}
+            title={collapsed ? label : undefined}
+            aria-current={isActive ? "page" : undefined}
             className={cn(
-              "flex items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium transition-colors",
+              "flex items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium transition-colors active:scale-[0.98]",
+              collapsed && "justify-center px-0",
               isActive
                 ? "bg-accent text-accent-foreground"
                 : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
             )}
-            aria-current={isActive ? "page" : undefined}
           >
-            <Icon className="h-4 w-4" />
-            {label}
+            <Icon className="h-4 w-4 shrink-0" />
+            {!collapsed && <span className="truncate">{label}</span>}
           </Link>
         )
       })}

--- a/apps/web/components/layout/WorkspaceLayout.tsx
+++ b/apps/web/components/layout/WorkspaceLayout.tsx
@@ -6,9 +6,15 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+"use client"
+
+import { useState } from "react"
 import { Navbar } from "@/components/layout/Navbar"
 import { Sidebar } from "@/components/layout/Sidebar"
+import { BottomNav } from "@/components/layout/BottomNav"
 import { Breadcrumbs, type BreadcrumbItem } from "@/components/layout/Breadcrumbs"
+import { useBreakpoint } from "@/hooks/useBreakpoint"
+import { cn } from "@/lib/cn"
 
 interface WorkspaceLayoutProps {
   org: string
@@ -17,19 +23,77 @@ interface WorkspaceLayoutProps {
   children: React.ReactNode
 }
 
+/**
+ * Shared app shell for every /[org]/[repo]/* page, responsive across three
+ * breakpoints (Tailwind `md` = 768px, `lg` = 1024px):
+ * - Desktop (lg+): inline Sidebar, collapsible to an icon rail via the
+ *   Navbar menu button.
+ * - Tablet (md–lg): Sidebar becomes a fixed overlay drawer opened by the
+ *   same menu button; hidden by default.
+ * - Mobile (<md): no sidebar at all — BottomNav takes over navigation;
+ *   Settings moves into the Navbar.
+ *
+ * Visibility is driven by Tailwind responsive classes (hydration-safe); the
+ * useBreakpoint hook only decides which action the menu button performs.
+ * BottomNav is a flex child (not `fixed`) so it never overlaps content.
+ * Borderless premium styling: sidebar uses the `bg-sidebar` token + shadow,
+ * the breadcrumbs strip uses `bg-muted/40` — no `border-*` anywhere.
+ */
 export function WorkspaceLayout({ org, repo, breadcrumbs, children }: WorkspaceLayoutProps) {
+  const { isDesktop } = useBreakpoint()
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+
+  function handleMenuClick() {
+    if (isDesktop) {
+      setSidebarCollapsed((c) => !c)
+    } else {
+      setSidebarOpen((o) => !o)
+    }
+  }
+
   return (
-    <div className="flex h-screen flex-col">
-      <Navbar />
+    <div className="flex h-screen flex-col bg-background text-foreground">
+      <Navbar
+        org={org}
+        repo={repo}
+        onMenuClick={handleMenuClick}
+        menuActive={sidebarOpen}
+      />
+
       <div className="flex flex-1 overflow-hidden">
-        <Sidebar org={org} repo={repo} />
-        <div className="flex flex-1 flex-col overflow-hidden">
-          <div className="border-b px-6 py-3">
+        {/* Desktop: inline collapsible sidebar. Hidden below lg (CSS). */}
+        <div className="hidden lg:block">
+          <Sidebar org={org} repo={repo} collapsed={sidebarCollapsed} />
+        </div>
+
+        {/* Tablet: overlay drawer. Always mounted so resize to desktop hides
+            it via CSS instead of unmounting mid-gesture. */}
+        <div
+          className={cn(
+            "fixed inset-0 z-50 lg:hidden",
+            sidebarOpen ? "" : "pointer-events-none invisible"
+          )}
+        >
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => setSidebarOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute inset-y-0 left-0">
+            <Sidebar org={org} repo={repo} overlay onClose={() => setSidebarOpen(false)} />
+          </div>
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <div className="bg-muted/40 px-6 py-3">
             <Breadcrumbs items={breadcrumbs} />
           </div>
           <div className="flex-1 overflow-auto">{children}</div>
         </div>
       </div>
+
+      <BottomNav org={org} repo={repo} />
     </div>
   )
 }

--- a/apps/web/components/search/GlobalSearch.tsx
+++ b/apps/web/components/search/GlobalSearch.tsx
@@ -113,13 +113,13 @@ export function GlobalSearch({ repoUrl, branch, onSelect }: GlobalSearchProps) {
       )}
 
       {results.length > 0 && (
-        <div className="mt-2 rounded-md border">
+        <div className="mt-2 rounded-lg bg-card shadow-lg">
           {results.slice(0, 20).map((r) => (
             <button
               key={r.moduleId}
               type="button"
               onClick={() => onSelect?.(r.moduleId)}
-              className="block w-full cursor-pointer px-3 py-2 text-left text-sm hover:bg-muted"
+              className="block w-full cursor-pointer px-3 py-2.5 text-left text-sm transition-transform hover:bg-muted active:scale-[0.99]"
             >
               <div className="font-medium">{r.filePath.split("/").pop()}</div>
               <div className="text-xs text-muted-foreground">{r.filePath}</div>

--- a/apps/web/hooks/useBreakpoint.ts
+++ b/apps/web/hooks/useBreakpoint.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useMediaQuery } from "@/hooks/useMediaQuery"
+
+export interface BreakpointState {
+  /** < 768px — Tailwind `md` and below. Bottom nav instead of the sidebar. */
+  isMobile: boolean
+  /** 768–1024px — `md` up to `lg`. Sidebar becomes an overlay drawer. */
+  isTablet: boolean
+  /** ≥ 1024px — `lg` and up. Inline collapsible sidebar. */
+  isDesktop: boolean
+}
+
+/**
+ * Breakpoint state matching Tailwind's default `md` (48rem) and `lg`
+ * (64rem) prefixes — see node_modules/tailwindcss/theme.css. Built on the
+ * project's existing useMediaQuery wrapper (issue #147: prefer a re-export
+ * over a reimplementation). Layout visibility itself is driven by Tailwind
+ * responsive classes (hydration-safe); this hook only feeds interactive
+ * behavior (which gesture a button performs, which variant to render).
+ */
+export function useBreakpoint(): BreakpointState {
+  const isDesktop = useMediaQuery("(min-width: 64rem)")
+  const isTabletUp = useMediaQuery("(min-width: 48rem)")
+  return {
+    isDesktop,
+    isTablet: isTabletUp && !isDesktop,
+    isMobile: !isTabletUp,
+  }
+}

--- a/apps/web/hooks/useTheme.ts
+++ b/apps/web/hooks/useTheme.ts
@@ -9,7 +9,7 @@
 // Fix: default was "light", and this hook was never actually called from
 // app/layout.tsx (see the fix there) so it had zero effect on first paint
 // regardless. Default flipped to "dark" to match ARCLUX's dark-first
-// design (theme/arclux.json) and the inline init script layout.tsx now
+// design (theme/theme.dark.ts) and the inline init script layout.tsx now
 // runs before hydration — this hook's job is now just keeping state in
 // sync for the toggle button, not doing the initial theme decision alone.
 
@@ -22,7 +22,7 @@ type Theme = "light" | "dark"
 export function useTheme() {
   // layout.tsx's inline init script applies the theme class before hydration,
   // so reading it in the lazy initializer gives the true initial theme
-  // (dark-first, matches theme/arclux.json) without a sync-setState effect.
+  // (dark-first, matches theme/theme.dark.ts) without a sync-setState effect.
   const [theme, setTheme] = useState<Theme>(() =>
     typeof document !== "undefined" && document.documentElement.classList.contains("dark") ? "dark" : "light"
   )

--- a/docs-site/progres/progres-bugs.mdx
+++ b/docs-site/progres/progres-bugs.mdx
@@ -142,7 +142,7 @@ the first place.
 ## 2026-08-05 — Update — dark theme default fix + GraphMenu consolidation
 
 **Dark theme bug found via dogfooding**: landing page and graph viewer
-rendered light/white despite theme/arclux.json being dark-first by
+rendered light/white despite theme/theme.dark.ts being dark-first by
 design. Root cause: hooks/useTheme.ts existed and worked, but NOTHING in
 the app tree ever called it — app/layout.tsx never applied the "dark"
 class to &lt;html> at all. Fixed:

--- a/docs-site/progres/progres-status-core.mdx
+++ b/docs-site/progres/progres-status-core.mdx
@@ -76,7 +76,7 @@ Full attribution is in `NOTICE` (root). Summary:
 
 | Source | License | Nature | Became |
 |---|---|---|---|
-| `sst/opencode` | MIT | pattern re-adapted | `theme/arclux.json`, `hooks/useFilteredList.ts` |
+| `sst/opencode` | MIT | pattern re-adapted | `theme/colors.ts`, `hooks/useFilteredList.ts` |
 | `pahen/madge` | MIT | algorithm re-implemented | `detectCircularDependency.ts` |
 | `git-truck` | MIT | UX pattern re-implemented | `GraphCanvas.tsx` |
 | `sverweij/dependency-cruiser` | MIT | concept re-implemented | `RuleEngine.ts` |

--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -135,7 +135,7 @@ the first place.
 ## 2026-08-05 — Update — dark theme default fix + GraphMenu consolidation
 
 **Dark theme bug found via dogfooding**: landing page and graph viewer
-rendered light/white despite theme/arclux.json being dark-first by
+rendered light/white despite theme/theme.dark.ts being dark-first by
 design. Root cause: hooks/useTheme.ts existed and worked, but NOTHING in
 the app tree ever called it — app/layout.tsx never applied the "dark"
 class to <html> at all. Fixed:

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -570,3 +570,66 @@ verified in a real browser (standard gap).
   latest = the #336 merge), 6 contributors (top: GSF-001, 307);
   /activity page 200, no errors. tsc 0, eslint 0, vitest 208/208. Not
   visually verified in a real browser (standard gap).
+
+## 2026-08-14 — Universal Responsive UI (mobile-first, Termux-friendly)
+
+**Status:** Done (tsc 0, eslint 0, vitest 295/295, dev-server live: 6/6
+pages HTTP 200, SSR HTML contains all new chrome). Visual pass on an
+actual phone still pending (Mikatoshi).
+
+- `hooks/useBreakpoint.ts` (new): { isMobile, isTablet, isDesktop }
+  over the existing useMediaQuery wrapper (issue #147: re-export, not
+  reimplementation). Breakpoints match Tailwind defaults (md=48rem,
+  lg=64rem). Visibility itself is Tailwind-class driven (hydration-safe);
+  the hook only feeds interactive behavior.
+- `components/layout/BottomNav.tsx` (new): mobile-only (<md) 5-tab bar
+  (Overview/Graph/Search/Activity/Workspace) as a flex child of the
+  layout (not `fixed` — never overlaps content or the graph canvas),
+  safe-area padding for notched phones, active tab highlight, 44px+
+  targets.
+- `Sidebar.tsx`: desktop `w-64` collapsible to a `w-16` icon rail
+  (`transition-all duration-300`); tablet overlay mode (`overlay` +
+  onClose); mobile hidden (BottomNav owns nav). Premium: `bg-sidebar`
+  token + shadow, no `border-r`.
+- `Navbar.tsx`: org/repo props; menu button (tablet opens overlay,
+  desktop collapses sidebar — decided via useBreakpoint); Settings link
+  visible only <md (it lives in the sidebar on larger screens); icon
+  buttons `size-11 md:size-8` (44px touch target on mobile); no
+  `border-b`.
+- `WorkspaceLayout.tsx`: now "use client" with sidebar collapse state +
+  overlay drawer (always mounted, CSS-hidden on lg+ so resizing to
+  desktop mid-gesture is safe). Breadcrumbs strip uses `bg-muted/40`
+  instead of `border-b`.
+- `GraphCanvas.tsx`: native pinch-to-zoom (two-pointer distance ratio,
+  zoom-to-midpoint), single-finger pan fallback after lifting one
+  finger, `touch-none` on the canvas container (no browser scroll
+  hijack), viewport culling for nodes AND edges (selected/hovered always
+  render; CULL_MARGIN=100 world units), coarse-pointer hit radius
+  (44px) via `(pointer: coarse)` media query.
+- `GraphNode.tsx`: optional invisible hit-area circle (22px radius) for
+  coarse pointers — visual 6px dot still meets the 44px tap target;
+  rendered last so it sits on top (other shapes are pointer-events-none).
+- `GraphEdge.tsx`: memoized (props stable across pan/zoom frames — same
+  reasoning as GraphNode memo).
+- `GraphViewport.tsx` ExplorerPanel: <md becomes a full-screen overlay
+  (a 380px flex sibling would leave the canvas ~0px on a phone); md+
+  keeps the 380px sibling. Branches on useMediaQuery — safe because the
+  panel only mounts after a client-side node selection.
+- `GlobalSearch.tsx`: results list `border` → `bg-card shadow-lg`,
+  taller tap targets.
+- No new npm dependencies (pinch is native Pointer Events; verified
+  @use-gesture/react v10.3.1 is 2 years stale with unconfirmed React 19
+  compat).
+- Doc contradiction fixed (§4.9): `theme/arclux.json` referenced in 7
+  places but never existed — all updated to theme/colors.ts +
+  theme/theme.dark.ts (KI-030).
+- Pre-existing build blocker found (not touched, out of scope):
+  app/api/diagnostics/route.ts scaffold has no exports → `next build`
+  fails its type-check on the generated route type (KI-029).
+
+Verified: `cd apps/web && npx tsc --noEmit` 0; `pnpm --filter web lint`
+0; `pnpm test` 295/295; `pnpm --filter web build` compiles but fails
+final type-check on KI-029 only; dev-server: /test/test + graph/search/
+workspace/activity/settings all HTTP 200, SSR HTML contains
+Toggle-navigation / aria-label=Primary / bg-sidebar markers, no
+console errors. Not visually verified on a real phone (standard gap).


### PR DESCRIPTION
Mobile-first responsive overhaul for Termux/Android dev:

- useBreakpoint over existing useMediaQuery (issue #147)
- BottomNav (mobile <md): 5 tabs, safe-area, 44px targets
- Collapsible desktop sidebar (w-64 -> w-16 rail) + tablet overlay drawer
- Native pinch-to-zoom + viewport culling on the graph (no new deps)
- 44px touch hit-areas, borderless premium styling via theme tokens
- Doc fix: theme/arclux.json -> colors.ts/theme.dark.ts (KI-030)

Validated: tsc 0, eslint 0, vitest 295/295, dev-server 6/6 pages HTTP 200.