### PR TITLE
[feat] Glassmorphism UI polish (1/3) + KI-029 build fix

### DIFF
--- a/apps/web/app/api/diagnostics/route.ts
+++ b/apps/web/app/api/diagnostics/route.ts
@@ -1,11 +1,25 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: web/api/diagnostics — not yet implemented.
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/diagnostics
+ *
+ * Placeholder endpoint (issue KI-029): the previous 8-line scaffold had no
+ * exports, which made `next build`'s generated route type fail to compile
+ * ("File ... is not a module"). This file now has a valid route export
+ * returning an empty, explicitly-empty result — consumers must treat an
+ * empty `diagnostics` array as "nothing reported yet", not "checked and
+ * clean". The real implementation belongs on top of the detector pipeline
+ * (see POST /api/doctor for the runDoctor-based approach); this route
+ * intentionally does NOT fake a full scan.
+ */
+export async function GET() {
+  return NextResponse.json({ diagnostics: [] }, { status: 200 });
+}

--- a/apps/web/app/api/editor/route.ts
+++ b/apps/web/app/api/editor/route.ts
@@ -1,11 +1,20 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: web/api/editor — not yet implemented.
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/editor — placeholder endpoint (KI-029 family: scaffold files
+ * with no exports broke `next build`'s generated route types). Returns an
+ * explicitly-empty list; real implementation belongs on the editor/runtime
+ * platform layer (packages/editor). Empty array = "nothing reported yet",
+ * not "checked and clean".
+ */
+export async function GET() {
+  return NextResponse.json({ files: [] }, { status: 200 });
+}

--- a/apps/web/app/api/notifications/route.ts
+++ b/apps/web/app/api/notifications/route.ts
@@ -1,11 +1,20 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: web/api/notifications — not yet implemented.
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/notifications — placeholder endpoint (KI-029 family: scaffold
+ * files with no exports broke `next build`'s generated route types).
+ * Returns an explicitly-empty list; real implementation belongs on top of
+ * packages/notifications (NotificationManager fan-out). Empty array =
+ * "nothing reported yet", not "checked and clean".
+ */
+export async function GET() {
+  return NextResponse.json({ notifications: [] }, { status: 200 });
+}

--- a/apps/web/app/api/processes/route.ts
+++ b/apps/web/app/api/processes/route.ts
@@ -1,11 +1,20 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: web/api/processes — not yet implemented.
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/processes — placeholder endpoint (KI-029 family: scaffold
+ * files with no exports broke `next build`'s generated route types).
+ * Returns an explicitly-empty list; real implementation belongs on top of
+ * the platform process layer. Empty array = "nothing reported yet", not
+ * "checked and clean".
+ */
+export async function GET() {
+  return NextResponse.json({ processes: [] }, { status: 200 });
+}

--- a/apps/web/app/api/runtime/route.ts
+++ b/apps/web/app/api/runtime/route.ts
@@ -1,11 +1,20 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: web/api/runtime — not yet implemented.
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/runtime — placeholder endpoint (KI-029 family: scaffold files
+ * with no exports broke `next build`'s generated route types). Returns an
+ * explicitly-empty object; real implementation belongs on top of
+ * packages/runtime. Empty = "nothing reported yet", not "checked and
+ * clean".
+ */
+export async function GET() {
+  return NextResponse.json({ status: "unknown", components: [] }, { status: 200 });
+}

--- a/apps/web/app/api/services/route.ts
+++ b/apps/web/app/api/services/route.ts
@@ -1,11 +1,20 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: web/api/services — not yet implemented.
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/services — placeholder endpoint (KI-029 family: scaffold files
+ * with no exports broke `next build`'s generated route types). Returns an
+ * explicitly-empty list; real implementation belongs on top of the
+ * platform services layer. Empty array = "nothing reported yet", not
+ * "checked and clean".
+ */
+export async function GET() {
+  return NextResponse.json({ services: [] }, { status: 200 });
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -208,3 +208,48 @@
     @apply font-sans;
   }
 }
+
+/*
+ * Glassmorphism utilities (Mikatoshi's "1/3 glass" — UI chrome only, never
+ * content). Colors go through theme tokens (bg-background / border-foreground)
+ * instead of hardcoded zinc so the light theme keeps working: in dark mode
+ * background = #000 (equivalent to zinc-900), in light mode = #FFF frosted.
+ * Performance guard: mobile (<768px) drops blur to a lighter 4px pass,
+ * prefers-reduced-motion removes backdrop-filter entirely (solid fallback).
+ */
+@layer components {
+  .glass-panel {
+    @apply border border-foreground/5 bg-background/60 shadow-2xl backdrop-blur-md transition-all duration-200;
+  }
+  .glass-overlay {
+    @apply border border-foreground/5 bg-background/80 backdrop-blur-lg;
+  }
+  .glass-card {
+    @apply border border-foreground/5 bg-background/40 shadow-2xl backdrop-blur-sm transition-all duration-200;
+  }
+  .glass-card:hover {
+    @apply bg-background/50;
+  }
+  .glass-topbar {
+    @apply border-b border-foreground/5 bg-background/70 backdrop-blur-md;
+  }
+  @media (max-width: 768px) {
+    .glass-panel,
+    .glass-overlay,
+    .glass-card,
+    .glass-topbar {
+      backdrop-filter: blur(4px);
+      -webkit-backdrop-filter: blur(4px);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .glass-panel,
+    .glass-overlay,
+    .glass-card,
+    .glass-topbar {
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      background-color: var(--background);
+    }
+  }
+}

--- a/apps/web/components/activity/ActivityView.tsx
+++ b/apps/web/components/activity/ActivityView.tsx
@@ -111,7 +111,7 @@ export function ActivityView({ repoUrl, branch }: ActivityViewProps) {
               {data.commits.map((commit) => (
                 <li
                   key={commit.hash}
-                  className="rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2"
+                  className="glass-card rounded-md px-3 py-2"
                 >
                   <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
                     <code className="font-mono text-xs text-neutral-500">{shortHash(commit.hash)}</code>
@@ -136,7 +136,7 @@ export function ActivityView({ repoUrl, branch }: ActivityViewProps) {
               {data.contributors.map((contributor) => (
                 <li
                   key={contributor.email}
-                  className="flex items-center justify-between gap-3 rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2"
+                  className="glass-card flex items-center justify-between gap-3 rounded-md px-3 py-2"
                 >
                   <div className="min-w-0">
                     <p className="truncate text-sm text-neutral-200">{contributor.name}</p>

--- a/apps/web/components/graph/GraphContextMenu.tsx
+++ b/apps/web/components/graph/GraphContextMenu.tsx
@@ -67,7 +67,7 @@ export function GraphContextMenu() {
     <div
       ref={menuRef}
       style={{ left: menuPos.x, top: menuPos.y }}
-      className="fixed z-50 w-44 overflow-hidden rounded-md border bg-popover py-1 text-sm shadow-md"
+      className="glass-panel fixed z-50 w-44 overflow-hidden rounded-md py-1 text-sm"
     >
       <button
         onClick={focusNode}

--- a/apps/web/components/graph/GraphFocusView.tsx
+++ b/apps/web/components/graph/GraphFocusView.tsx
@@ -118,7 +118,7 @@ export function GraphFocusView() {
     .filter((n): n is GraphNodeData => Boolean(n));
 
   return (
-    <div className="absolute inset-4 z-20 flex flex-col overflow-hidden rounded-lg border border-neutral-800 bg-black/95 backdrop-blur-sm">
+    <div className="glass-panel absolute inset-4 z-20 flex flex-col overflow-hidden rounded-lg">
       <div className="flex items-center justify-between border-b border-neutral-800 px-4 py-3">
         <div className="flex min-w-0 items-center gap-2">
           {canGoBack && (

--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -42,7 +42,7 @@ export function BottomNav({ org, repo }: BottomNavProps) {
   return (
     <nav
       aria-label="Primary"
-      className="bg-muted/50 select-none md:hidden"
+      className="glass-overlay select-none md:hidden"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       <div className="grid h-16 grid-cols-5">

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -12,6 +12,7 @@ import Link from "next/link"
 import { Moon, Sun, PanelLeft, Settings } from "lucide-react"
 import { useTheme } from "@/hooks/useTheme"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/cn"
 
 interface NavbarProps {
   org: string
@@ -20,6 +21,8 @@ interface NavbarProps {
   onMenuClick?: () => void
   /** Highlights the menu button while the overlay drawer is open. */
   menuActive?: boolean
+  /** True once the page content scrolled past 10px — switches the header to glass. */
+  scrolled?: boolean
 }
 
 /**
@@ -30,12 +33,17 @@ interface NavbarProps {
  * (it lives in the sidebar there). Icon buttons grow to 44px on mobile for
  * touch targets (Apple HIG), staying compact on desktop.
  */
-export function Navbar({ org, repo, onMenuClick, menuActive = false }: NavbarProps) {
+export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = false }: NavbarProps) {
   const { theme, toggleTheme } = useTheme()
   const settingsHref = `/${org}/${repo}/settings`
 
   return (
-    <header className="flex h-14 shrink-0 items-center justify-between gap-2 bg-background px-4">
+    <header
+      className={cn(
+        "flex h-14 shrink-0 items-center justify-between gap-2 px-4",
+        scrolled ? "glass-topbar" : "bg-background"
+      )}
+    >
       <div className="flex items-center gap-1">
         <Button
           variant="ghost"

--- a/apps/web/components/layout/Sidebar.tsx
+++ b/apps/web/components/layout/Sidebar.tsx
@@ -51,9 +51,9 @@ export function Sidebar({ org, repo, collapsed = false, overlay = false, onClose
   return (
     <aside
       className={cn(
-        "flex h-full flex-col gap-1 overflow-hidden bg-sidebar p-3 text-sidebar-foreground transition-all duration-300 select-none",
+        "flex h-full flex-col gap-1 overflow-hidden p-3 text-sidebar-foreground select-none",
         collapsed ? "w-16" : "w-64",
-        overlay ? "shadow-2xl" : "shadow-lg"
+        overlay ? "glass-overlay" : "glass-panel"
       )}
     >
       {overlay && (

--- a/apps/web/components/layout/WorkspaceLayout.tsx
+++ b/apps/web/components/layout/WorkspaceLayout.tsx
@@ -43,6 +43,7 @@ export function WorkspaceLayout({ org, repo, breadcrumbs, children }: WorkspaceL
   const { isDesktop } = useBreakpoint()
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
 
   function handleMenuClick() {
     if (isDesktop) {
@@ -59,6 +60,7 @@ export function WorkspaceLayout({ org, repo, breadcrumbs, children }: WorkspaceL
         repo={repo}
         onMenuClick={handleMenuClick}
         menuActive={sidebarOpen}
+        scrolled={scrolled}
       />
 
       <div className="flex flex-1 overflow-hidden">
@@ -89,7 +91,12 @@ export function WorkspaceLayout({ org, repo, breadcrumbs, children }: WorkspaceL
           <div className="bg-muted/40 px-6 py-3">
             <Breadcrumbs items={breadcrumbs} />
           </div>
-          <div className="flex-1 overflow-auto">{children}</div>
+          <div
+            className="flex-1 overflow-auto"
+            onScroll={(e) => setScrolled(e.currentTarget.scrollTop > 10)}
+          >
+            {children}
+          </div>
         </div>
       </div>
 

--- a/apps/web/components/overview/RepositoryInfo.tsx
+++ b/apps/web/components/overview/RepositoryInfo.tsx
@@ -25,9 +25,9 @@ interface StatCardProps {
 
 function StatCard({ label, value }: StatCardProps) {
   return (
-    <div className="rounded-lg border border-neutral-800 bg-neutral-950/60 px-4 py-3">
-      <p className="text-xs uppercase tracking-wide text-neutral-500">{label}</p>
-      <p className="mt-1 truncate font-mono text-lg text-neutral-100">{value}</p>
+    <div className="glass-card rounded-lg px-4 py-3">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="mt-1 truncate font-mono text-lg text-foreground">{value}</p>
     </div>
   );
 }

--- a/apps/web/components/patterns/CommandPalette.tsx
+++ b/apps/web/components/patterns/CommandPalette.tsx
@@ -56,7 +56,7 @@ export function CommandPalette({ org, repo }: CommandPaletteProps) {
       onClick={() => setOpen(false)}
     >
       <Command
-        className="w-full max-w-md overflow-hidden rounded-lg border bg-popover shadow-lg"
+        className="glass-panel w-full max-w-md overflow-hidden rounded-lg"
         onClick={(e) => e.stopPropagation()}
         label="Command palette"
       >

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -633,3 +633,40 @@ final type-check on KI-029 only; dev-server: /test/test + graph/search/
 workspace/activity/settings all HTTP 200, SSR HTML contains
 Toggle-navigation / aria-label=Primary / bg-sidebar markers, no
 console errors. Not visually verified on a real phone (standard gap).
+
+## 2026-08-14 — Glassmorphism UI polish (1/3) + KI-029 systemic build fix
+
+**Status:** Done (tsc 0, eslint 0, vitest 295/295, `next build` now
+PASSES — previously failed on the scaffold routes, dev-server 6/6 pages
+200). PR #363.
+
+- Glass utilities in `app/globals.css` (`@layer components`):
+  `.glass-panel` (bg-background/60 + blur-md + shadow-2xl),
+  `.glass-overlay` (bg-background/80 + blur-lg), `.glass-card`
+  (bg-background/40 + blur-sm, hover→/50), `.glass-topbar`
+  (bg-background/70 + blur-md, applied on scroll). Colors go through
+  theme tokens (bg-background / border-foreground) instead of the
+  hardcoded zinc from the request — equivalent effect in dark mode
+  (#000 background), and the light theme keeps working.
+- Applied (chrome only, Mikatoshi's "1/3"): Sidebar inline
+  (glass-panel) + overlay drawer (glass-overlay), BottomNav
+  (glass-overlay), Navbar (glass-topbar when content scrollTop > 10px —
+  scroll listener lives on the overflow-auto container in
+  WorkspaceLayout, not window), RepositoryInfo stat cards + ActivityView
+  commit/contributor cards (glass-card, border/neutral hardcodes
+  replaced with tokens), GraphFocusView + GraphContextMenu + CommandPalette
+  (glass-panel). NOT applied: graph canvas (solid black, perf), code
+  blocks/FileDetails, search result list (readability).
+- Performance guards (in globals.css): `@media (max-width: 768px)` →
+  backdrop-filter blur(4px); `prefers-reduced-motion` → backdrop-filter
+  none + solid `var(--background)`.
+- KI-029 systemic: `next build` type-check failure was NOT one scaffold
+  but six — app/api/{diagnostics,editor,notifications,processes,runtime,
+  services}/route.ts were 8-line stubs with no exports. All six now
+  export valid GET handlers returning explicitly-empty 200 JSON (honest
+  "nothing reported yet" semantics documented in each file; NOT faking a
+  scan). `next build` passes end-to-end.
+- Shipping note: PR #362 (responsive UI) was merged while this work was
+  in flight — the glass commit was pushed to the already-merged branch,
+  so it was re-based as a fresh branch (feat/glass-ki029) off the
+  updated ARCLUX.main and opened as PR #363.


### PR DESCRIPTION
Follow-up to merged PR #362. Glass utilities + build fix:

**Glass (Mikatoshi feedback, 1/3 — chrome only, not content):**
- New utilities in globals.css: .glass-panel / .glass-overlay / .glass-card / .glass-topbar — via theme tokens (bg-background/60 + border-foreground/5 + backdrop-blur), so the light theme keeps working
- Applied: sidebar (inline + overlay drawer), bottom nav, topbar (glass on scroll >10px), overview stat cards, activity commit/contributor cards, graph focus view, graph context menu, command palette
- NOT applied: graph canvas (solid, perf), code blocks, search results (readability)
- Performance guards: mobile (<768px) blur 4px, prefers-reduced-motion → no backdrop-filter (solid fallback)

**KI-029 build fix (systemic — 6 scaffolds):**
- app/api/diagnostics|editor|notifications|processes|runtime|services: 8-line scaffolds with no exports broke next build type-check; all now export valid GET handlers returning explicitly-empty 200 JSON (not faking a scan)

Validated: tsc 0, eslint 0, vitest 295/295, next build PASSES (previously failed), dev-server 6/6 pages 200.