### PR TITLE
[feat] packages/language: language-intelligence layer (issue #348)

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -21,6 +21,7 @@ import { registerPsCommand } from "./commands/ps";
 import { registerWorkCommand } from "./commands/work";
 import { registerWorkspaceCommand } from "./workspace";
 import { registerSystemCommand } from "./commands/system";
+import { registerLanguageCommand } from "./language";
 
 const program = new Command();
 program.name("arclux").description("Repository intelligence CLI").version("0.1.0");
@@ -38,5 +39,6 @@ registerPsCommand(program);
 registerWorkCommand(program);
 registerWorkspaceCommand(program);
 registerSystemCommand(program);
+registerLanguageCommand(program);
 
 program.parse();

--- a/apps/cli/language.ts
+++ b/apps/cli/language.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// `arclux language <file>` — drives packages/language/ (issue #348):
+// parses a single file through the shared parser registry and prints the
+// symbol surface (exports/imports/calls/warnings). Follows the ps.ts
+// pattern of reading through a snapshot-like result.
+
+import type { Command } from "commander";
+import * as p from "@clack/prompts";
+import { readFileSync } from "node:fs";
+import { resolve, extname, relative, basename } from "node:path";
+import { LanguageService } from "../../packages/language/LanguageService";
+import type { FileInfo } from "../../packages/shared/types";
+
+export function registerLanguageCommand(program: Command): void {
+  program
+    .command("language")
+    .description("Parse a single file and print its exports/imports/calls (via packages/language)")
+    .argument("<file>", "path to the source file")
+    .option("--json", "output raw JSON instead of the formatted summary")
+    .action(async (fileArg: string, options: { json?: boolean }) => {
+      const filePath = resolve(fileArg);
+      try {
+        const content = readFileSync(filePath, "utf-8");
+        const fileInfo: FileInfo = {
+          absolutePath: filePath,
+          relativePath: relative(process.cwd(), filePath).replace(/\\/g, "/"),
+          language: "unknown",
+          extension: extname(filePath),
+          sizeBytes: Buffer.byteLength(content),
+          hash: "",
+        };
+        fileInfo.language = new LanguageService().language(fileInfo.extension);
+
+        const parsed = await new LanguageService().parseFile(fileInfo, content);
+
+        if (options.json) {
+          console.log(JSON.stringify(parsed, null, 2));
+          return;
+        }
+
+        p.log.success(`${basename(filePath)} (${fileInfo.language})`);
+        p.log.message(`Exports (${parsed.exports.length}): ${parsed.exports.map((e) => e.name).join(", ") || "—"}`);
+        p.log.message(`Imports (${parsed.imports.length}): ${parsed.imports.map((i) => i.source).join(", ") || "—"}`);
+        p.log.message(`Calls (${(parsed.calls ?? []).length}): ${(parsed.calls ?? []).map((c) => c.calleeName).join(", ") || "—"}`);
+        if (parsed.warnings.length > 0) {
+          p.log.warn(`Warnings (${parsed.warnings.length}):`);
+          for (const warning of parsed.warnings) p.log.message(`  ${warning}`);
+        }
+      } catch (err) {
+        p.log.error(err instanceof Error ? err.message : String(err));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -40,7 +40,7 @@ import type { Repository } from "../repository/Repository";
 // Register known parsers once, at module load. As more languages get parser
 // implementations (parseJs, parsePython, ...) they get registered here too.
 let parsersRegistered = false;
-function ensureParsersRegistered() {
+export function ensureParsersRegistered() {
   if (parsersRegistered) return;
   parserRegistry.register(parseTs);
   parserRegistry.register(parsePython);

--- a/packages/language/CompletionEngine.ts
+++ b/packages/language/CompletionEngine.ts
@@ -8,4 +8,62 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: language/CompletionEngine — not yet implemented.
+import type { Repository } from "../repository/Repository";
+import { SymbolEngine, type SymbolInfo } from "./SymbolEngine";
+
+// Repository-aware auto-completion (issue #348). Given a module and a
+// partial identifier, suggest exported symbols from the repository. Two
+// sources: (1) symbols exported by modules this file already imports, and
+// (2) every exported symbol whose name starts with the prefix. This is the
+// symbol-graph completion — identifier-position precision (is the cursor
+// really in an identifier position?) is the editor's job (packages/editor),
+// not this engine's.
+
+export interface CompletionItem {
+  name: string;
+  moduleId: string;
+  filePath: string;
+  line: number | null;
+  kind: SymbolInfo["kind"];
+  /** Whether the symbol comes from a module this file already imports. */
+  alreadyImported: boolean;
+}
+
+export class CompletionEngine {
+  private readonly symbols = new SymbolEngine();
+
+  constructor(private readonly repository: Repository) {}
+
+  /**
+   * Completion candidates for a prefix in a module.
+   * @param moduleId the module being edited (for the "already imported" boost)
+   * @param prefix   the partial identifier, e.g. "useSt"
+   */
+  complete(moduleId: string, prefix: string): CompletionItem[] {
+    const module = this.repository.getModule(moduleId);
+    const importedModuleIds = new Set(module?.imports ?? []);
+
+    const all = this.symbols.getSymbols(this.repository);
+    const matches = all.filter((symbol) => symbol.name.startsWith(prefix));
+
+    // Dedupe by name — a name exported by several modules is one suggestion
+    // (prefer the symbol from an already-imported module over other definitions).
+    const byName = new Map<string, { symbol: SymbolInfo; alreadyImported: boolean }>();
+    for (const symbol of matches) {
+      const alreadyImported = importedModuleIds.has(symbol.moduleId);
+      const existing = byName.get(symbol.name);
+      if (!existing || (alreadyImported && !existing.alreadyImported)) {
+        byName.set(symbol.name, { symbol, alreadyImported });
+      }
+    }
+
+    return [...byName.values()].map(({ symbol, alreadyImported }) => ({
+      name: symbol.name,
+      moduleId: symbol.moduleId,
+      filePath: symbol.filePath,
+      line: symbol.line,
+      kind: symbol.kind,
+      alreadyImported,
+    }));
+  }
+}

--- a/packages/language/DiffEngine.ts
+++ b/packages/language/DiffEngine.ts
@@ -8,4 +8,58 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: language/DiffEngine — not yet implemented.
+import type { ParsedFile } from "../shared/types";
+
+// Symbol-level diff of two versions of a file (issue #348): the first
+// stage of the semantic-diff pipeline (text → symbols → ...). Compares
+// exports, imports and call sites by identity (name/source/line-agnostic
+// where possible) and reports what was added/removed/kept. This is the
+// "what changed at the symbol level" answer that text diff alone can't
+// give (renamed export = remove+add, not a line edit).
+
+export interface SymbolDiffResult {
+  exportsAdded: string[];
+  exportsRemoved: string[];
+  exportsKept: string[];
+  importsAdded: string[];
+  importsRemoved: string[];
+  importsKept: string[];
+  /** Call sites present in both versions, keyed by callee name. */
+  callsKept: string[];
+  /** Rough change signal: 0 = no symbol-level change. */
+  changeCount: number;
+}
+
+export function diffSymbols(before: ParsedFile, after: ParsedFile): SymbolDiffResult {
+  const beforeExports = new Set(before.exports.map((e) => e.name));
+  const afterExports = new Set(after.exports.map((e) => e.name));
+  const exportsAdded = [...afterExports].filter((name) => !beforeExports.has(name)).sort();
+  const exportsRemoved = [...beforeExports].filter((name) => !afterExports.has(name)).sort();
+  const exportsKept = [...beforeExports].filter((name) => afterExports.has(name)).sort();
+
+  const beforeImports = new Set(before.imports.map((i) => i.source));
+  const afterImports = new Set(after.imports.map((i) => i.source));
+  const importsAdded = [...afterImports].filter((source) => !beforeImports.has(source)).sort();
+  const importsRemoved = [...beforeImports].filter((source) => !afterImports.has(source)).sort();
+  const importsKept = [...beforeImports].filter((source) => afterImports.has(source)).sort();
+
+  const beforeCalls = new Set((before.calls ?? []).map((c) => c.calleeName));
+  const afterCalls = new Set((after.calls ?? []).map((c) => c.calleeName));
+  const callsKept = [...beforeCalls].filter((name) => afterCalls.has(name)).sort();
+
+  return {
+    exportsAdded,
+    exportsRemoved,
+    exportsKept,
+    importsAdded,
+    importsRemoved,
+    importsKept,
+    callsKept,
+    changeCount: exportsAdded.length + exportsRemoved.length + importsAdded.length + importsRemoved.length,
+  };
+}
+
+/** True when the symbol surface (exports+imports) is unchanged. */
+export function hasSymbolChanges(diff: SymbolDiffResult): boolean {
+  return diff.changeCount > 0;
+}

--- a/packages/language/FormattingEngine.ts
+++ b/packages/language/FormattingEngine.ts
@@ -8,4 +8,66 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: language/FormattingEngine — not yet implemented.
+// Code formatting (issue #348). Honest scope: ARCLUX has NO full formatter
+// dependency (no prettier in package.json), and hand-rolling a language-
+// accurate formatter is out of scope for this package. What this engine
+// DOES provide is the normalization every format-on-save wants regardless
+// of language — line endings, trailing whitespace, final newline — plus a
+// per-line leading-whitespace normalization that preserves structure
+// (replaces tab runs with spaces at configurable width). Language-aware
+// pretty-printing belongs in a dedicated formatter dependency, not here.
+
+export interface FormattingOptions {
+  /** Spaces per tab level. Default 2. */
+  tabWidth?: number;
+  /** Use tabs instead of spaces for indentation. Default false. */
+  useTabs?: boolean;
+  /** Ensure the file ends with exactly one newline. Default true. */
+  ensureFinalNewline?: boolean;
+  /** Strip trailing whitespace on every line. Default true. */
+  stripTrailingWhitespace?: boolean;
+  /** Normalize CRLF → LF. Default true. */
+  normalizeLineEndings?: boolean;
+}
+
+export class FormattingEngine {
+  format(source: string, options: FormattingOptions = {}): string {
+    const tabWidth = options.tabWidth ?? 2;
+    const useTabs = options.useTabs ?? false;
+    const ensureFinalNewline = options.ensureFinalNewline ?? true;
+    const stripTrailing = options.stripTrailingWhitespace ?? true;
+    const normalizeEndings = options.normalizeLineEndings ?? true;
+
+    let text = source;
+    if (normalizeEndings) text = text.replace(/\r\n/g, "\n");
+
+    if (stripTrailing) {
+      text = text.replace(/[ \t]+$/gm, "");
+    }
+
+    // Normalize leading whitespace: expand tabs to tabWidth spaces, then
+    // (if useTabs) collapse back to tabs. This makes mixed-indentation
+    // files consistent without rewriting code.
+    const lines = text.split("\n").map((line) => {
+      const leading = line.match(/^[ \t]*/)?.[0] ?? "";
+      const rest = line.slice(leading.length);
+      const expanded = leading.replace(/\t/g, " ".repeat(tabWidth));
+      if (useTabs) {
+        const tabs = Math.floor(expanded.length / tabWidth);
+        const remainder = expanded.length % tabWidth;
+        return "\t".repeat(tabs) + " ".repeat(remainder) + rest;
+      }
+      return expanded + rest;
+    });
+    text = lines.join("\n");
+
+    if (ensureFinalNewline && text.length > 0 && !text.endsWith("\n")) {
+      text += "\n";
+    }
+    if (ensureFinalNewline) {
+      text = text.replace(/\n+$/, "\n");
+    }
+
+    return text;
+  }
+}

--- a/packages/language/LanguageService.ts
+++ b/packages/language/LanguageService.ts
@@ -8,4 +8,58 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: language/LanguageService — not yet implemented.
+import type { FileInfo, ParsedFile, SupportedLanguage } from "../shared/types";
+import type { Repository } from "../repository/Repository";
+import { SyntaxEngine } from "./SyntaxEngine";
+import { SymbolEngine, type SymbolInfo } from "./SymbolEngine";
+
+// The language-intelligence entry point (issue #348): combines the syntax
+// layer (per-file parsing via packages/parser/*) with the symbol layer
+// (whole-repository symbol resolution) behind one facade. Consumers
+// (editor context, semantic-diff pipeline) use this instead of reaching
+// into SyntaxEngine/SymbolEngine individually.
+
+export interface LanguageServiceOptions {
+  /** Repository to resolve symbols against. Optional for syntax-only use. */
+  repository?: Repository;
+}
+
+export class LanguageService {
+  readonly syntax = new SyntaxEngine();
+  readonly symbols = new SymbolEngine();
+  private readonly repository?: Repository;
+
+  constructor(options: LanguageServiceOptions = {}) {
+    this.repository = options.repository;
+  }
+
+  /** Parse a single file (throws UNSUPPORTED_LANGUAGE for unknown extensions). */
+  parseFile(file: FileInfo, content: string): Promise<ParsedFile> {
+    return this.syntax.parseFile(file, content);
+  }
+
+  /** Language for an extension (no parsing). */
+  language(extension: string): SupportedLanguage {
+    return this.syntax.language(extension);
+  }
+
+  /** All exported symbols in the repository (empty when no repository is set). */
+  getSymbols(): SymbolInfo[] {
+    return this.repository ? this.symbols.getSymbols(this.repository) : [];
+  }
+
+  /** Symbols with a given name (empty when no repository is set). */
+  findSymbol(name: string): SymbolInfo[] {
+    return this.repository ? this.symbols.findByName(this.repository, name) : [];
+  }
+
+  /** Symbols exported by one module (empty when no repository is set). */
+  symbolsForModule(moduleId: string): SymbolInfo[] {
+    return this.repository ? this.symbols.forModule(this.repository, moduleId) : [];
+  }
+
+  /** Consumers (importers + callers) of a module (empty when no repository is set). */
+  consumers(moduleId: string): string[] {
+    return this.repository ? this.symbols.consumers(this.repository, moduleId) : [];
+  }
+}

--- a/packages/language/SymbolEngine.ts
+++ b/packages/language/SymbolEngine.ts
@@ -8,4 +8,79 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: language/SymbolEngine — not yet implemented.
+import type { Repository } from "../repository/Repository";
+import type { ModuleInfo, RawExport } from "../shared/types";
+
+// Symbol-level resolution over an already-indexed Repository (issue #348).
+// Every export in every module is a symbol; for each one we report where it
+// is declared (module + line), which modules import that module, and which
+// modules call its exported functions (calledBy). Consumers can jump
+// symbol -> declaration -> importers/callers without re-indexing.
+
+export interface SymbolInfo {
+  name: string;
+  /** Module that declares this symbol. */
+  moduleId: string;
+  /** Module's file path. */
+  filePath: string;
+  /** Declaration line (1-indexed) from RawExport, or null for unknown. */
+  line: number | null;
+  /** Whether it's a default, named, or re-export. */
+  kind: RawExport["kind"];
+  /** For re-exports: the module being re-exported from, if internal. */
+  reExportSource?: string;
+  /** Module ids that import the declaring module. */
+  importedBy: string[];
+  /** Module ids that call this symbol's module exports (approximate, JS-family only). */
+  calledBy: string[];
+}
+
+export class SymbolEngine {
+  /** All exported symbols across the repository. */
+  getSymbols(repository: Repository): SymbolInfo[] {
+    const symbols: SymbolInfo[] = [];
+    for (const module of repository.getAllModules()) {
+      for (const exportItem of module.exports) {
+        symbols.push(this.describe(repository, module, exportItem));
+      }
+    }
+    return symbols;
+  }
+
+  /** All symbols with a given name (a name can be exported by many modules). */
+  findByName(repository: Repository, name: string): SymbolInfo[] {
+    return this.getSymbols(repository).filter((symbol) => symbol.name === name);
+  }
+
+  /** Symbols exported by one module. */
+  forModule(repository: Repository, moduleId: string): SymbolInfo[] {
+    const module = repository.getModule(moduleId);
+    if (!module) return [];
+    return module.exports.map((exportItem) => this.describe(repository, module, exportItem));
+  }
+
+  /** Consumers (importers + callers) of a module's exports. */
+  consumers(repository: Repository, moduleId: string): string[] {
+    const module = repository.getModule(moduleId);
+    if (!module) return [];
+    return [...new Set([...module.importedBy, ...module.calledBy])];
+  }
+
+  private describe(repository: Repository, module: ModuleInfo, exportItem: RawExport): SymbolInfo {
+    const reExportSource = exportItem.reExportSource
+      ? module.resolvedReExports[exportItem.name] ?? exportItem.reExportSource
+      : undefined;
+
+    const direct = [...module.importedBy];
+    return {
+      name: exportItem.name,
+      moduleId: module.id,
+      filePath: module.file.relativePath,
+      line: exportItem.line,
+      kind: exportItem.kind,
+      reExportSource,
+      importedBy: direct,
+      calledBy: [...module.calledBy],
+    };
+  }
+}

--- a/packages/language/SyntaxEngine.ts
+++ b/packages/language/SyntaxEngine.ts
@@ -8,4 +8,63 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-// Scaffold: language/SyntaxEngine — not yet implemented.
+import type { FileInfo, ParsedFile, RawCall, SupportedLanguage } from "../shared/types";
+import { detectLanguage } from "../parser/core/LanguageDetector";
+import { parserRegistry } from "../parser/core/ParserRegistry";
+import { ensureParsersRegistered } from "../engine/pipeline";
+import { ArcluxError } from "../shared/errors";
+
+// Syntax-level analysis of individual files (issue #348). Wraps the
+// existing packages/parser/* via the shared ParserRegistry — this layer
+// exists so editor/semantic-diff consumers can parse a single file on
+// demand without knowing which parser handles which extension, exactly as
+// engine/pipeline.ts does for whole-repo analysis.
+
+export interface SyntaxAnalysis {
+  language: SupportedLanguage;
+  imports: ParsedFile["imports"];
+  exports: ParsedFile["exports"];
+  calls: RawCall[];
+  warnings: string[];
+}
+
+export class SyntaxEngine {
+  /**
+   * Parses one file's content into the shared ParsedFile shape.
+   * Throws ArcluxError UNSUPPORTED_LANGUAGE when no parser is registered
+   * for the file's extension (caller should check `language` first).
+   */
+  async parseFile(file: FileInfo, content: string): Promise<ParsedFile> {
+    ensureParsersRegistered();
+    const parser = parserRegistry.getParserForExtension(file.extension);
+    if (!parser) {
+      throw new ArcluxError({
+        code: "UNSUPPORTED_LANGUAGE",
+        message: `No parser registered for extension "${file.extension}"`,
+      });
+    }
+    return parser.parse(file, content);
+  }
+
+  /** Cheap language detection from the file extension (no parsing). */
+  language(extension: string): SupportedLanguage {
+    return detectLanguage(extension);
+  }
+
+  /** Whether any registered parser handles this extension. */
+  supports(extension: string): boolean {
+    return parserRegistry.getParserForExtension(extension) !== undefined;
+  }
+
+  /** Convenience: parse and keep only the parts consumers usually need. */
+  async analyze(file: FileInfo, content: string): Promise<SyntaxAnalysis> {
+    const parsed = await this.parseFile(file, content);
+    return {
+      language: detectLanguage(file.extension),
+      imports: parsed.imports,
+      exports: parsed.exports,
+      calls: parsed.calls ?? [],
+      warnings: parsed.warnings,
+    };
+  }
+}

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -69,7 +69,7 @@ Full attribution is in `NOTICE` (root). Summary:
 
 | Source | License | Nature | Became |
 |---|---|---|---|
-| `sst/opencode` | MIT | pattern re-adapted | `theme/arclux.json`, `hooks/useFilteredList.ts` |
+| `sst/opencode` | MIT | pattern re-adapted | `theme/colors.ts`, `hooks/useFilteredList.ts` |
 | `pahen/madge` | MIT | algorithm re-implemented | `detectCircularDependency.ts` |
 | `git-truck` | MIT | UX pattern re-implemented | `GraphCanvas.tsx` |
 | `sverweij/dependency-cruiser` | MIT | concept re-implemented | `RuleEngine.ts` |
@@ -726,6 +726,40 @@ process.
 health ok/degraded/down (incl. throwing check), full aggregation, workspace
 inclusion, config inclusion, failed-job degradation, custom checks.
 Tests: 283/283, tsc 0.
+
+## 2026-08-14 — packages/language/ implemented (issue #348)
+
+**Status:** Done
+
+`packages/language/` was 6 stub files; now the language-intelligence layer
+wrapping packages/parser/* + the indexed Repository (issue #348):
+- `SyntaxEngine.ts` — per-file parsing via the shared ParserRegistry
+  (parseFile/analyze), language detection, UNSUPPORTED_LANGUAGE error.
+  `ensureParsersRegistered` is now exported from engine/pipeline.ts
+  (additive) so this layer can guarantee parsers are registered.
+- `SymbolEngine.ts` — symbol → declaration/importers/callers over a
+  Repository (getSymbols/findByName/forModule/consumers).
+- `LanguageService.ts` — entry facade: parseFile/language/getSymbols/
+  findSymbol/symbolsForModule/consumers (repository optional).
+- `CompletionEngine.ts` — prefix auto-completion over repository exports,
+  dedupe preferring symbols from already-imported modules.
+- `FormattingEngine.ts` — honest minimal normalization (CRLF→LF, trailing
+  whitespace, final newline, tab↔space by tabWidth) — no prettier
+  dependency exists, a full formatter is out of scope and documented.
+- `DiffEngine.ts` — symbol-level diff of two ParsedFile versions
+  (exports/imports added/removed/kept, calls kept, changeCount).
+
+IMPORTANT finding: blueprint (docs-site map-packages-platform.mdx) cites
+packages/engine/analyzeFile.ts / analyzeModule.ts / analyzeDependency.ts
+as "existing" — they are all EMPTY 8-line stubs. Rule 4 (check real
+shapes) applied: language/ wraps the real parserRegistry/Repository
+instead. Wired into the CLI: `arclux language <file>` (formatted or
+`--json`), verified running on real files.
++12 tests (tests/language.test.ts): parsing, language detection,
+unsupported-language error, symbol resolution (importers/callers),
+findSymbol multi-module, completion + imported-boost, formatting
+normalization (CRLF/tabs/trailing), symbol diff add/remove/no-change.
+Tests: 295/295, tsc 0.
 
 ## 2026-08-14 — Daemon verified end-to-end (issue #347) + 2 runtime bugs fixed
 

--- a/tests/language.test.ts
+++ b/tests/language.test.ts
@@ -1,0 +1,218 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for issue #348: packages/language/ wraps packages/parser/* (via the
+// shared ParserRegistry) and the indexed Repository — syntax parsing,
+// symbol resolution, completion, formatting normalization, symbol diff.
+
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildIndex } from "../packages/indexer/buildIndex";
+import { parserRegistry } from "../packages/parser/core/ParserRegistry";
+import { parseTs } from "../packages/parser/typescript/parseTs";
+import type { RepositoryMeta, FileInfo } from "../packages/shared/types";
+import { SyntaxEngine } from "../packages/language/SyntaxEngine";
+import { LanguageService } from "../packages/language/LanguageService";
+import { CompletionEngine } from "../packages/language/CompletionEngine";
+import { FormattingEngine } from "../packages/language/FormattingEngine";
+import { diffSymbols, hasSymbolChanges } from "../packages/language/DiffEngine";
+
+parserRegistry.register(parseTs);
+
+const META: RepositoryMeta = {
+  id: "local",
+  org: "local",
+  name: "fixture",
+  defaultBranch: "local",
+  rootPath: "",
+  detectedFrameworks: [],
+  packageManager: "npm",
+  analyzedAt: new Date(0).toISOString(),
+};
+
+const tracked: string[] = [];
+function makeRepoDir(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "arclux-lang-"));
+  tracked.push(dir);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(dir, rel);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of tracked) rmSync(dir, { recursive: true, force: true });
+});
+
+function fileInfo(relativePath: string, content: string): FileInfo {
+  const extension = relativePath.slice(relativePath.lastIndexOf("."));
+  return {
+    absolutePath: join("/virtual", relativePath),
+    relativePath,
+    language: "typescript",
+    extension,
+    sizeBytes: Buffer.byteLength(content),
+    hash: "",
+  };
+}
+
+describe("SyntaxEngine (issue #348)", () => {
+  it("parses a TS file into the shared ParsedFile shape", async () => {
+    const engine = new SyntaxEngine();
+    const parsed = await engine.parseFile(
+      fileInfo("src/a.ts", 'import { b } from "./b";\nexport const a = b;'),
+      'import { b } from "./b";\nexport const a = b;'
+    );
+
+    expect(parsed.exports.map((e) => e.name)).toContain("a");
+    expect(parsed.imports[0].source).toBe("./b");
+    expect(parsed.warnings).toEqual([]);
+  });
+
+  it("detects language from extension without parsing", () => {
+    const engine = new SyntaxEngine();
+    expect(engine.language(".ts")).toBe("typescript");
+    expect(engine.language(".py")).toBe("python");
+    expect(engine.language(".xyz")).toBe("unknown");
+  });
+
+  it("throws UNSUPPORTED_LANGUAGE for unknown extensions", async () => {
+    const engine = new SyntaxEngine();
+    await expect(
+      engine.parseFile(fileInfo("x.xyz", "hello"), "hello")
+    ).rejects.toThrow(/No parser registered/);
+  });
+});
+
+describe("SymbolEngine via LanguageService (issue #348)", () => {
+  it("resolves exports, importers and callers from an indexed repo", async () => {
+    const dir = makeRepoDir({
+      "src/a.ts": 'import { b } from "./b";\nexport const a = b;',
+      "src/b.ts": "export const b = 1;",
+    });
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+
+    const service = new LanguageService({ repository });
+    const symbols = service.getSymbols();
+    const names = symbols.map((s) => s.name);
+
+    expect(names).toContain("a");
+    expect(names).toContain("b");
+
+    const b = symbols.find((s) => s.name === "b")!;
+    expect(b.moduleId).toBe("src/b.ts");
+    expect(b.importedBy).toEqual(["src/a.ts"]);
+
+    const consumers = service.consumers("src/b.ts");
+    expect(consumers).toContain("src/a.ts");
+  });
+
+  it("findSymbol matches by name across modules", async () => {
+    const dir = makeRepoDir({
+      "src/a.ts": "export const shared = 1;",
+      "src/b.ts": "export const shared = 2;",
+    });
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+    const service = new LanguageService({ repository });
+
+    const matches = service.findSymbol("shared");
+    expect(matches).toHaveLength(2);
+    expect(matches.map((m) => m.moduleId).sort()).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+});
+
+describe("CompletionEngine (issue #348)", () => {
+  it("suggests repository symbols matching the prefix", async () => {
+    const dir = makeRepoDir({
+      "src/a.ts": 'import { useState } from "react";\nexport const a = useState;',
+      "src/b.ts": "export const useState = 1;",
+    });
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+    const completion = new CompletionEngine(repository);
+
+    const items = completion.complete("src/a.ts", "useSt");
+    expect(items.map((i) => i.name)).toContain("useState");
+  });
+
+  it("marks suggestions from already-imported modules", async () => {
+    const dir = makeRepoDir({
+      "src/a.ts": 'import { helper } from "./helper";\nexport const a = helper;',
+      "src/helper.ts": "export const helper = 1;\nexport const helper2 = 2;",
+    });
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+    const completion = new CompletionEngine(repository);
+
+    const items = completion.complete("src/a.ts", "helper");
+    const helper = items.find((i) => i.name === "helper");
+    expect(helper?.alreadyImported).toBe(true);
+  });
+});
+
+describe("FormattingEngine (issue #348)", () => {
+  it("normalizes CRLF, strips trailing whitespace, ensures final newline", () => {
+    const engine = new FormattingEngine();
+    const out = engine.format("a\r\nb  \r\nc\r\n");
+    expect(out).toBe("a\nb\nc\n");
+  });
+
+  it("expands tabs to spaces (default 2)", () => {
+    const engine = new FormattingEngine();
+    expect(engine.format("\tconst x = 1;\n")).toBe("  const x = 1;\n");
+  });
+
+  it("uses tabs when configured", () => {
+    const engine = new FormattingEngine();
+    expect(engine.format("    const x = 1;\n", { useTabs: true, tabWidth: 2 })).toBe("\t\tconst x = 1;\n");
+  });
+});
+
+describe("DiffEngine (issue #348)", () => {
+  it("reports added/removed exports and imports between versions", () => {
+    const before = {
+      file: fileInfo("src/a.ts", ""),
+      imports: [{ source: "./b", kind: "static" as const, namedImports: ["b"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+      exports: [{ name: "a", kind: "named" as const, line: 2 }],
+      warnings: [],
+    };
+    const after = {
+      file: fileInfo("src/a.ts", ""),
+      imports: [
+        { source: "./b", kind: "static" as const, namedImports: ["b"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        { source: "./c", kind: "static" as const, namedImports: [], hasDefaultImport: true, hasNamespaceImport: false, line: 2 },
+      ],
+      exports: [
+        { name: "a", kind: "named" as const, line: 2 },
+        { name: "c", kind: "named" as const, line: 3 },
+      ],
+      warnings: [],
+    };
+
+    const diff = diffSymbols(before, after);
+    expect(diff.exportsAdded).toEqual(["c"]);
+    expect(diff.importsAdded).toEqual(["./c"]);
+    expect(diff.exportsKept).toEqual(["a"]);
+    expect(diff.changeCount).toBe(2);
+    expect(hasSymbolChanges(diff)).toBe(true);
+  });
+
+  it("reports no changes for identical symbol surfaces", () => {
+    const version = {
+      file: fileInfo("src/a.ts", ""),
+      imports: [{ source: "./b", kind: "static" as const, namedImports: ["b"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+      exports: [{ name: "a", kind: "named" as const, line: 2 }],
+      warnings: [],
+    };
+    const diff = diffSymbols(version, version);
+    expect(diff.changeCount).toBe(0);
+    expect(hasSymbolChanges(diff)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #348. Six scaffold files under packages/language/ are now implemented (wrapping packages/parser/* + indexed Repository):

- SyntaxEngine: per-file parsing via shared ParserRegistry, UNSUPPORTED_LANGUAGE error; ensureParsersRegistered exported from engine/pipeline.ts (additive)
- SymbolEngine: symbol → declaration/importers/callers over a Repository
- LanguageService: entry facade (parseFile/language/getSymbols/findSymbol/symbolsForModule/consumers)
- CompletionEngine: prefix autocomplete over module exports, dedupe prioritizing already-imported modules
- FormattingEngine: honest minimal normalizer (CRLF→LF, trailing ws, final newline, tab↔spaces) — no prettier in deps
- DiffEngine: symbol-level diff (exports/imports added/removed/kept, changeCount)
- CLI: arclux language <file> (text/--json), run against real files
- Tests: tests/language.test.ts, 12 tests — total 295/295
- status-core.md: implementation entry + theme/arclux.json ref fix (KI-030)

Note: root tsc still reports pre-existing errors (apps/cli/analyze.ts, vscode-extension module, root @/ aliases — gotcha #51); apps/web tsc is clean.