### PR TITLE
[fix] CLI analyze.ts undefined result + docs-site blueprint stub refs

### DIFF
--- a/apps/cli/analyze.ts
+++ b/apps/cli/analyze.ts
@@ -62,7 +62,7 @@ export function registerAnalyzeCommand(program: Command): void {
         p.log.info(`Package manager: ${meta.packageManager}`);
         p.log.success(`${repository.moduleCount} modules indexed`);
         p.log.info(
-          `Scan: ${result.scanSummary.filesScanned} files, ${result.scanSummary.filesParsed} parsed, ${result.scanSummary.filesSkippedNoParser} skipped (no parser)`
+          `Scan: ${scanSummary.filesScanned} files, ${scanSummary.filesParsed} parsed, ${scanSummary.filesSkippedNoParser} skipped (no parser)`
         );
         p.log.success(`${graph.nodes.length} nodes, ${graph.edges.length} edges in dependency graph`);
 

--- a/docs-site/map/map-packages-engine.mdx
+++ b/docs-site/map/map-packages-engine.mdx
@@ -13,10 +13,10 @@ _Tidak ada package.json (bukan package standar Node)._
 
 - `analyzeArchitecture.ts`
 - `analyzeConvention.ts`
-- `analyzeDependency.ts`
-- `analyzeFile.ts`
-- `analyzeImpact.ts`
-- `analyzeModule.ts`
+- `analyzeDependency.ts` _(EMPTY 8-line stub, jangan dipakai)_
+- `analyzeFile.ts` _(EMPTY 8-line stub, jangan dipakai — per-file parsing ada di packages/language/SyntaxEngine.ts)_
+- `analyzeImpact.ts` _(EMPTY 8-line stub, jangan dipakai — impact ada di packages/impact/*)_
+- `analyzeModule.ts` _(EMPTY 8-line stub, jangan dipakai — symbols ada di packages/language/SymbolEngine.ts)_
 - `contract.ts`
 - `detectRepositoryMeta.ts`
 - `generateReport.ts`

--- a/docs-site/map/map-packages-platform.mdx
+++ b/docs-site/map/map-packages-platform.mdx
@@ -200,12 +200,12 @@ ke file+line.
 | Tahap | File platform (baru) | Konsumsi dari (existing) |
 |---|---|---|
 | Editor menangkap keystroke | packages/editor/EditContext.ts, CodeNavigator.ts | — |
-| Incremental analysis | packages/language/LanguageService.ts | packages/engine/analyzeFile.ts (existing) |
+| Incremental analysis | packages/language/LanguageService.ts | packages/parser/* (ParserRegistry, existing) |
 | Error detection | packages/diagnostics/DiagnosticEngine.ts | packages/detectors/* (existing) |
-| Symbol resolution | packages/language/SymbolEngine.ts | packages/engine/analyzeModule.ts (existing) |
-| Dependency resolution | packages/language/SyntaxEngine.ts | packages/engine/analyzeDependency.ts (existing) |
+| Symbol resolution | packages/language/SymbolEngine.ts | packages/repository/Repository (existing) |
+| Dependency resolution | packages/language/SyntaxEngine.ts | packages/parser/* (ParserRegistry, existing) |
 | Diagnostics aggregation | packages/diagnostics/DiagnosticEngine.ts, ErrorLocation.ts | — |
-| Impact engine | packages/editor/ImpactNavigator.ts | packages/engine/analyzeImpact.ts (existing) |
+| Impact engine | packages/editor/ImpactNavigator.ts | packages/impact/* (existing, cek map-packages-impact.mdx) |
 | Affected files/lines/symbols | packages/diagnostics/FixSuggestion.ts | packages/impact/* (existing, cek map-packages-impact.mdx) |
 | Notification | packages/notifications/NotificationManager.ts | — |
 | Navigasi ke file+line | packages/editor/CodeNavigator.ts | — |
@@ -218,14 +218,19 @@ Impact Diff → Architectural Diff.
 | Tahap | File platform (baru) | Konsumsi dari (existing) |
 |---|---|---|
 | Text Diff | packages/semantic-diff/SemanticDiff.ts (entry) | packages/diff/gitDiff.ts (existing) |
-| Symbol Diff | packages/semantic-diff/SymbolDiff.ts | packages/engine/analyzeModule.ts (existing) |
+| Symbol Diff | packages/semantic-diff/SymbolDiff.ts | packages/language/SymbolEngine.ts (existing, issue #348) |
 | AST Diff | packages/semantic-diff/AstDiff.ts | packages/parser/* (existing, cek map-packages-parser.mdx) |
 | Dependency Diff | packages/semantic-diff/DependencyDiff.ts | packages/diff/architecturalDiff.ts (existing) |
-| Impact Diff | packages/semantic-diff/DependencyDiff.ts (lanjutan) | packages/engine/analyzeImpact.ts (existing) |
+| Impact Diff | packages/semantic-diff/DependencyDiff.ts (lanjutan) | packages/impact/* (existing) |
 | Architectural Diff | packages/semantic-diff/SemanticDiff.ts (final stage) | packages/diff/architecturalDiff.ts (existing) |
 | Render output | packages/semantic-diff/DiffRenderer.ts | — |
 
-**Catatan penting:** semantic-diff TIDAK bikin parser/graph engine kedua.
+**Catatan penting:** `packages/engine/analyzeFile.ts`, `analyzeModule.ts`,
+`analyzeDependency.ts`, `analyzeImpact.ts` — semua EMPTY 8-line stubs
+(hanya license header), JANGAN dianggap existing. Real sources yang sudah
+implemented: packages/language/* (issue #348, per-file parsing via
+ParserRegistry, symbols via Repository), packages/impact/*, packages/parser/*.
+semantic-diff TIDAK bikin parser/graph engine kedua.
 Semua tahap di atas WAJIB memanggil fungsi existing di packages/engine
 dan packages/diff, bukan reimplementasi. Kalau nemu diri lu nulis AST
 walking baru di sini, itu tanda salah arah — harusnya panggil


### PR DESCRIPTION
Two follow-up fixes:

1. **apps/cli/analyze.ts:65** — pre-existing TS2304: code used `result.scanSummary` but the destructured variable is `scanSummary` (from `analyzeRepository(...)`). `arclux analyze` would have thrown at runtime. Fixed; root tsc errors for analyze.ts now 0.

2. **docs-site blueprint** — map-packages-platform.mdx Blueprint Integration tables cited `packages/engine/analyzeFile`, `analyzeModule`, `analyzeDependency`, `analyzeImpact` as "(existing)" — all four are EMPTY 8-line stubs (license header only, verified). Rewired the tables to real sources: `packages/parser/*` (ParserRegistry), `packages/repository/Repository`, `packages/language/*` (SymbolEngine — implemented in #348), `packages/impact/*`. Added a warning note so future sessions don't treat the stubs as usable. map-packages-engine.mdx file list marks the stubs with pointers to real implementations.

Validated: vitest 295/295.
