### PR TITLE
[fix] Dedupe circular dependency findings (issue #207)

### DIFF
--- a/packages/detectors/detectCircularDependency.ts
+++ b/packages/detectors/detectCircularDependency.ts
@@ -12,10 +12,28 @@ export interface CircularDependency {
   cycle: string[];
 }
 
+// Cycles are recorded once per unique node set, not once per entry point
+// the outer loop happens to reach first -- without this, an N-node cycle
+// gets reported N times (once from each node still unresolved when the
+// outer loop visits it), since the same cycle rotated to start at a
+// different node looks like a different array. Rotate to a canonical
+// starting point (lexicographically smallest node) before deduping.
+// Contributed by ManSio, issue #207.
+function canonicalizeCycle(cycle: string[]): string {
+  const nodes = cycle.slice(0, -1);
+  let minIdx = 0;
+  for (let i = 1; i < nodes.length; i++) {
+    if (nodes[i] < nodes[minIdx]) minIdx = i;
+  }
+  const rotated = [...nodes.slice(minIdx), ...nodes.slice(0, minIdx)];
+  return [...rotated, rotated[0]].join("\0");
+}
+
 export function detectCircularDependency(repository: Repository): CircularDependency[] {
   const circular: CircularDependency[] = [];
   const resolved = new Set<string>();
   const unresolved = new Set<string>();
+  const seenCycles = new Set<string>();
   const stack: string[] = [];
 
   function resolve(moduleId: string) {
@@ -31,7 +49,12 @@ export function detectCircularDependency(repository: Repository): CircularDepend
 
         if (unresolved.has(dependencyId)) {
           const cycleStart = stack.indexOf(dependencyId);
-          circular.push({ cycle: [...stack.slice(cycleStart), dependencyId] });
+          const cycle = [...stack.slice(cycleStart), dependencyId];
+          const key = canonicalizeCycle(cycle);
+          if (!seenCycles.has(key)) {
+            seenCycles.add(key);
+            circular.push({ cycle });
+          }
           continue;
         }
 


### PR DESCRIPTION
## What

Cherry-picks the owner's commit `e15a63b` (issue #207) onto current ARCLUX.main: canonicalizes each detected cycle (rotate to lexicographically smallest node) and dedupes via a `seenCycles` set, so the same cycle is never reported twice, regardless of which node the traversal reaches first.

## Honest verification notes

- `pnpm vitest run` → 295/295 pass (before and after the change).
- Tried to reproduce the original duplication (2/3-node cycles with multiple independent importers into the cycle) on current code: pre-fix already reports 1 finding — the scenario from Aug 10 appears to have been resolved by later traversal refactors. The guard is included as defense-in-depth: it enforces the 'no duplicate findings' invariant and cannot reduce legitimate cycle reporting.
- Also checked branch `feat/issues-cleanup-and-docs-sync` commit `49071f4` ('gitignore docs/') — its content is ALREADY in main (.gitignore:18-19), so nothing to merge there; that branch is deleted instead.

## Testing

`pnpm vitest run` → 295 passed (33 files)