### PR TITLE
Merge navbar + breadcrumb into single row

### DIFF
--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ import { Moon, Sun, PanelLeft, Settings } from "lucide-react"
 import { useTheme } from "@/hooks/useTheme"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/cn"
+import { Breadcrumbs, type BreadcrumbItem } from "@/components/layout/Breadcrumbs"
 
 interface NavbarProps {
   org: string
@@ -23,6 +24,8 @@ interface NavbarProps {
   menuActive?: boolean
   /** True once the page content scrolled past 10px — switches the header to glass. */
   scrolled?: boolean
+  /** Rendered inline next to the logo, replacing the old separate breadcrumb strip. */
+  breadcrumbs?: BreadcrumbItem[]
 }
 
 /**
@@ -33,7 +36,7 @@ interface NavbarProps {
  * (it lives in the sidebar there). Icon buttons grow to 44px on mobile for
  * touch targets (Apple HIG), staying compact on desktop.
  */
-export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = false }: NavbarProps) {
+export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = false, breadcrumbs }: NavbarProps) {
   const { theme, toggleTheme } = useTheme()
   const settingsHref = `/${org}/${repo}/settings`
 
@@ -55,9 +58,15 @@ export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = 
         >
           <PanelLeft className="h-4 w-4" />
         </Button>
-        <Link href="/" className="px-2 text-sm font-semibold tracking-tight">
+        <Link href="/" className="px-2 text-sm font-semibold tracking-tight shrink-0">
           Arclux
         </Link>
+        {breadcrumbs && breadcrumbs.length > 0 && (
+          <>
+            <span className="text-muted-foreground/40">/</span>
+            <Breadcrumbs items={breadcrumbs} className="min-w-0" />
+          </>
+        )}
       </div>
 
       <div className="flex items-center gap-1">

--- a/apps/web/components/layout/WorkspaceLayout.tsx
+++ b/apps/web/components/layout/WorkspaceLayout.tsx
@@ -12,7 +12,7 @@ import { useState } from "react"
 import { Navbar } from "@/components/layout/Navbar"
 import { Sidebar } from "@/components/layout/Sidebar"
 import { BottomNav } from "@/components/layout/BottomNav"
-import { Breadcrumbs, type BreadcrumbItem } from "@/components/layout/Breadcrumbs"
+import type { BreadcrumbItem } from "@/components/layout/Breadcrumbs"
 import { useBreakpoint } from "@/hooks/useBreakpoint"
 import { cn } from "@/lib/cn"
 
@@ -61,6 +61,7 @@ export function WorkspaceLayout({ org, repo, breadcrumbs, children }: WorkspaceL
         onMenuClick={handleMenuClick}
         menuActive={sidebarOpen}
         scrolled={scrolled}
+        breadcrumbs={breadcrumbs}
       />
 
       <div className="flex flex-1 overflow-hidden">
@@ -88,9 +89,6 @@ export function WorkspaceLayout({ org, repo, breadcrumbs, children }: WorkspaceL
         </div>
 
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <div className="bg-muted/40 px-6 py-3">
-            <Breadcrumbs items={breadcrumbs} />
-          </div>
           <div
             className="flex-1 overflow-auto"
             onScroll={(e) => setScrolled(e.currentTarget.scrollTop > 10)}


### PR DESCRIPTION
Header previously rendered as two stacked bars (Navbar h-14 + a separate breadcrumb strip below with its own bg-muted/40 px-6 py-3). Merged breadcrumbs into Navbar itself, rendered inline next to the logo, so there's one header row instead of two. WorkspaceLayout now passes breadcrumbs through to Navbar instead of rendering its own strip.