### PR TITLE
[fix] Resolve monorepo tsconfig path aliases (issue #372)

### DIFF
--- a/packages/graph/resolveAliases.ts
+++ b/packages/graph/resolveAliases.ts
@@ -6,7 +6,7 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { posix } from "node:path";
 
 /**
@@ -32,37 +32,70 @@ const CONFIG_FILENAMES = ["tsconfig.json", "jsconfig.json"];
  * `compilerOptions.paths` + `baseUrl`. Used so resolvePath.ts can turn "@/lib/api"
  * into a candidate internal module path instead of misreading it as an npm package.
  *
- * Returns an empty rule set (never throws) if no config file exists or it's
+ * Reads the repo-root config AND each config in apps/* (e.g. apps/web/tsconfig.json,
+ * the pnpm workspace members). In a monorepo, apps/web/tsconfig.json typically has
+ * its own "@/*" pointing at apps/web/ (different base than the root's "@/*" pointing
+ * at repo root) — without the nested configs, every "@/..." import inside apps/web
+ * resolves against the WRONG base, falls through to "external package", and
+ * produces mass false-positive unusedExports/orphanFiles findings (issue #372).
+ * Rules from all configs are merged (targets rebased to be repo-root-relative);
+ * resolvePath already tries every candidate rule, so extra bases are harmless —
+ * a wrong-base candidate simply won't exist in knownFiles and gets skipped.
+ *
+ * Returns an empty rule set (never throws) if no config file exists or all are
  * malformed — a missing/broken tsconfig should never crash indexing, imports
  * will just fall back to being treated as external, same as before this existed.
  */
 export function loadAliasConfig(repoRoot: string): AliasConfig {
-  for (const filename of CONFIG_FILENAMES) {
-    const configPath = posix.join(repoRoot, filename);
-    if (!existsSync(configPath)) continue;
+  const rules: AliasRule[] = [];
+  const seen = new Set<string>();
 
-    try {
-      const raw = readFileSync(configPath, "utf-8");
-      const json = JSON.parse(stripJsonComments(raw)) as {
-        compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
-      };
+  // Root config first, then one level of apps/* (mirrors pnpm-workspace.yaml).
+  const configRelDirs = [""];
+  try {
+    const appsDir = posix.join(repoRoot, "apps");
+    for (const entry of readdirSync(appsDir, { withFileTypes: true })) {
+      if (entry.isDirectory()) configRelDirs.push(posix.join("apps", entry.name));
+    }
+  } catch {
+    // No apps/ directory (single-package repo) — the root config is enough.
+  }
 
-      const rules = buildRules(json.compilerOptions?.paths, json.compilerOptions?.baseUrl);
-      if (rules.length > 0) {
-        return { rules };
+  for (const relDir of configRelDirs) {
+    for (const filename of CONFIG_FILENAMES) {
+      const configPath = posix.join(repoRoot, relDir, filename);
+      if (!existsSync(configPath)) continue;
+
+      try {
+        const raw = readFileSync(configPath, "utf-8");
+        const json = JSON.parse(stripJsonComments(raw)) as {
+          compilerOptions?: { baseUrl?: string; paths?: Record<string, string[]> };
+        };
+
+        for (const rule of buildRules(json.compilerOptions?.paths, json.compilerOptions?.baseUrl, relDir)) {
+          const key = `${rule.prefix}\u0000${rule.targets.join("\u0000")}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          rules.push(rule);
+        }
+      } catch {
+        // Malformed config — try the next candidate filename, or fall through to empty.
+        continue;
       }
-    } catch {
-      // Malformed tsconfig — try the next candidate filename, or fall through to empty.
-      continue;
     }
   }
 
-  return { rules: [] };
+  // Longest prefix wins first, so a specific alias like "@/packages/*" is tried
+  // before a catch-all like "@/*" when both could technically match.
+  rules.sort((a, b) => b.prefix.length - a.prefix.length);
+
+  return { rules };
 }
 
 function buildRules(
   paths: Record<string, string[]> | undefined,
-  baseUrl: string | undefined
+  baseUrl: string | undefined,
+  configRelDir = ""
 ): AliasRule[] {
   if (!paths) return [];
 
@@ -78,14 +111,16 @@ function buildRules(
       if (baseUrl) {
         base = posix.join(baseUrl, base);
       }
+      // Targets are relative to the config file's own directory (apps/web's
+      // "./*" means apps/web/, not repo root). For the root config this is a
+      // no-op ("" joins to the same path) — behavior is unchanged for it.
+      base = posix.join(configRelDir, base);
       return base.endsWith("/") ? base : `${base}/`;
     });
 
     rules.push({ prefix, targets: normalizedTargets });
   }
 
-  // Longest prefix wins first, so a specific alias like "@/packages/*" is tried
-  // before a catch-all like "@/*" when both could technically match.
   rules.sort((a, b) => b.prefix.length - a.prefix.length);
 
   return rules;
@@ -114,13 +149,64 @@ export function resolveAlias(importSource: string, config: AliasConfig): string[
 }
 
 /**
- * tsconfig.json commonly has // comments and trailing commas, neither of which
- * are valid JSON. Strips just enough of that to make JSON.parse succeed —
- * not a full JSONC parser, but sufficient for standard tsconfig files.
+ * tsconfig.json commonly has line comments (double slash), block comments
+ * (slash-star ... star-slash) and trailing commas, none of which are valid
+ * JSON. Strips just enough of that to make JSON.parse succeed. Implemented as
+ * a small string-aware state machine: the naive regex approach breaks on real
+ * Next.js configs, where path patterns like "@/" and double-star include
+ * globs contain the literal sequences slash-star and star-slash INSIDE quoted
+ * strings — a block-comment regex then eats everything between them,
+ * corrupting the JSON and making loadAliasConfig return empty rules (issue #372).
  */
 function stripJsonComments(input: string): string {
-  return input
-    .replace(/\/\*[\s\S]*?\*\//g, "") // block comments
-    .replace(/(^|[^:])\/\/.*$/gm, "$1") // line comments (careful not to eat "://")
-    .replace(/,(\s*[}\]])/g, "$1"); // trailing commas
+  let out = "";
+  let inString = false;
+  let i = 0;
+  while (i < input.length) {
+    const c = input[i];
+
+    if (inString) {
+      out += c;
+      if (c === "\\" && i + 1 < input.length) {
+        out += input[i + 1];
+        i += 2;
+        continue;
+      }
+      if (c === '"') inString = false;
+      i++;
+      continue;
+    }
+
+    if (c === '"') {
+      inString = true;
+      out += c;
+      i++;
+      continue;
+    }
+
+    if (c === "/" && input[i + 1] === "/") {
+      while (i < input.length && input[i] !== "\n") i++;
+      continue;
+    }
+
+    if (c === "/" && input[i + 1] === "*") {
+      i += 2;
+      while (i < input.length && !(input[i] === "*" && input[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+
+    if (c === ",") {
+      let j = i + 1;
+      while (j < input.length && /\s/.test(input[j])) j++;
+      if (input[j] === "}" || input[j] === "]") {
+        i++; // trailing comma — drop it, keep following whitespace
+        continue;
+      }
+    }
+
+    out += c;
+    i++;
+  }
+  return out;
 }

--- a/tests/alias-resolution.test.ts
+++ b/tests/alias-resolution.test.ts
@@ -1,0 +1,165 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Coverage for issue #372: monorepo tsconfig path-alias resolution.
+// loadAliasConfig used to read only the repo-root tsconfig, so apps/web's
+// own "@/*" (pointing at apps/web/) was ignored and every "@/..." import
+// inside apps/web resolved against the root's base → false-positive
+// unusedExports/orphanFiles. These tests pin the merged-rules behavior.
+
+import { describe, it, expect, afterAll } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { loadAliasConfig } from "../packages/graph/resolveAliases";
+import { resolvePath } from "../packages/graph/resolvePath";
+
+const tempDirs: string[] = [];
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeRepoDir(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "arclux-alias-"));
+  tempDirs.push(dir);
+  for (const [relPath, content] of Object.entries(files)) {
+    const full = join(dir, relPath);
+    mkdirSync(dirname(full), { recursive: true });
+    writeFileSync(full, content, "utf-8");
+  }
+  return dir;
+}
+
+const ROOT_TSCONFIG = JSON.stringify({ compilerOptions: { paths: { "@/*": ["./*"] } } });
+
+const WEB_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    paths: { "@/*": ["./*"], "@/packages/*": ["../../packages/*"] },
+  },
+});
+
+// Real Next.js-style config: include globs like "**/*.ts" contain the literal
+// "*/" sequence, which the old regex-based comment stripper misread as the end
+// of a block comment opened by "/*" in "@/*" — corrupting the JSON and making
+// loadAliasConfig return empty rules (issue #372 root cause).
+const NEXTJS_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    jsx: "preserve",
+    moduleResolution: "bundler",
+    paths: { "@/*": ["./*"] },
+  },
+  include: ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  exclude: ["node_modules"],
+});
+
+describe("loadAliasConfig — monorepo tsconfig merge (issue #372)", () => {
+  it("reads only the root config when there is no apps/ directory (unchanged behavior)", () => {
+    const root = makeRepoDir({ "tsconfig.json": ROOT_TSCONFIG });
+    const config = loadAliasConfig(root);
+    expect(config.rules).toHaveLength(1);
+    expect(config.rules[0].prefix).toBe("@/");
+    expect(config.rules[0].targets).toEqual(["./"]);
+  });
+
+  it("merges apps/web/tsconfig.json rules with config-dir-relative bases", () => {
+    const root = makeRepoDir({
+      "tsconfig.json": ROOT_TSCONFIG,
+      "apps/web/tsconfig.json": WEB_TSCONFIG,
+    });
+    const config = loadAliasConfig(root);
+    const targetsFor = (prefix: string) =>
+      config.rules.filter((r) => r.prefix === prefix).flatMap((r) => r.targets);
+    // "@/*" from both configs: root's "./" AND apps/web's "apps/web/"
+    expect(new Set(targetsFor("@/"))).toEqual(new Set(["./", "apps/web/"]));
+    // "@/packages/*" from apps/web, rebased from apps/web → repo-root packages/
+    expect(targetsFor("@/packages/")).toEqual(["packages/"]);
+  });
+
+  it("keeps longest-prefix-first ordering in the merged rule list", () => {
+    const root = makeRepoDir({
+      "tsconfig.json": ROOT_TSCONFIG,
+      "apps/web/tsconfig.json": WEB_TSCONFIG,
+    });
+    expect(loadAliasConfig(root).rules[0].prefix).toBe("@/packages/");
+  });
+
+  it("ignores a malformed nested config and still returns the root rules", () => {
+    const root = makeRepoDir({
+      "tsconfig.json": ROOT_TSCONFIG,
+      "apps/web/tsconfig.json": "{ this is not json !!!",
+    });
+    expect(loadAliasConfig(root).rules.some((r) => r.prefix === "@/")).toBe(true);
+  });
+
+  it("dedupes identical rules from tsconfig.json + jsconfig.json in the same dir", () => {
+    const root = makeRepoDir({
+      "tsconfig.json": ROOT_TSCONFIG,
+      "jsconfig.json": ROOT_TSCONFIG, // same paths, same dir → identical after rebase
+      "apps/web/tsconfig.json": WEB_TSCONFIG,
+    });
+    const config = loadAliasConfig(root);
+    // "@/" rules: one from root (tsconfig+jsconfig deduped) + one from apps/web
+    expect(config.rules.filter((r) => r.prefix === "@/")).toHaveLength(2);
+  });
+
+  it("returns empty rules for a repo with no tsconfig at all", () => {
+    const root = makeRepoDir({});
+    expect(loadAliasConfig(root).rules).toEqual([]);
+  });
+
+  it("parses a realistic Next.js config without corrupting @/* paths or include globs (issue #372 root cause)", () => {
+    const root = makeRepoDir({ "tsconfig.json": NEXTJS_TSCONFIG });
+    const config = loadAliasConfig(root);
+    expect(config.rules).toHaveLength(1);
+    expect(config.rules[0].prefix).toBe("@/");
+    expect(config.rules[0].targets).toEqual(["./"]);
+  });
+
+  it("strips real comments and trailing commas but not /* inside strings", () => {
+    const withComments = `{
+      // a line comment
+      /* a block comment */
+      "compilerOptions": {
+        "paths": { "@/*": ["./*"] },
+      },
+      "include": ["**/*.ts"],
+    }`;
+    const root = makeRepoDir({ "tsconfig.json": withComments });
+    const config = loadAliasConfig(root);
+    expect(config.rules).toHaveLength(1);
+    expect(config.rules[0].prefix).toBe("@/");
+    expect(config.rules[0].targets).toEqual(["./"]);
+  });
+});
+
+describe("resolvePath with merged monorepo aliases (issue #372 false positives)", () => {
+  it("resolves '@/...' imported inside apps/web to apps/web/, not repo root", () => {
+    const root = makeRepoDir({
+      "tsconfig.json": ROOT_TSCONFIG,
+      "apps/web/tsconfig.json": WEB_TSCONFIG,
+      "apps/web/components/layout/Navbar.ts": "export const Navbar = () => null;",
+      "apps/web/pages/index.ts": "import Navbar from '@/components/layout/Navbar';",
+    });
+    const config = loadAliasConfig(root);
+    const knownFiles = new Set(["apps/web/components/layout/Navbar.ts", "apps/web/pages/index.ts"]);
+    const resolution = resolvePath("apps/web/pages/index.ts", "@/components/layout/Navbar", knownFiles, config);
+    expect(resolution).toEqual({ type: "internal", moduleId: "apps/web/components/layout/Navbar.ts" });
+  });
+
+  it("resolves '@/packages/*' imported from apps/web to repo-root packages/", () => {
+    const root = makeRepoDir({
+      "tsconfig.json": ROOT_TSCONFIG,
+      "apps/web/tsconfig.json": WEB_TSCONFIG,
+      "packages/graph/buildDependencyGraph.ts": "export const x = 1;",
+    });
+    const config = loadAliasConfig(root);
+    const knownFiles = new Set(["packages/graph/buildDependencyGraph.ts"]);
+    const resolution = resolvePath("apps/web/lib/x.ts", "@/packages/graph/buildDependencyGraph", knownFiles, config);
+    expect(resolution).toEqual({ type: "internal", moduleId: "packages/graph/buildDependencyGraph.ts" });
+  });
+});


### PR DESCRIPTION
## Root cause (corrected diagnosis)

Issue #372's framing ('loadAliasConfig only reads root tsconfig') was partially wrong. The REAL blocker was deeper:

`stripJsonComments` (regex-based) treated the literal `/*` inside `"@/*": ["./*"]` path patterns as a block-comment opener and matched it lazily to the first `*/` — which in a real Next.js config is inside include globs like `"**/*.ts"`. That corrupted the JSON, `JSON.parse` always threw, and `loadAliasConfig` returned **empty rules**. Every `@/...` import then fell through to 'external package' → mass false-positive unusedExports/orphanFiles (incl. the issue's example apps/web/components/layout/Navbar.tsx).

This also explains the earlier failed fix attempt ('loadOneConfig() returned [] even when tsconfig parsed correctly'): the config was parseable, but the strip step silently destroyed it.

## Changes (packages/graph/resolveAliases.ts)

1. **stripJsonComments** → string-aware state machine: strips // and /* */ comments and trailing commas ONLY outside quoted strings. The sequences inside `"@/*"` / `"**/*.ts"` are left untouched.
2. **loadAliasConfig** → also scans apps/*/tsconfig.json (pnpm workspace members from pnpm-workspace.yaml), merging rules with targets rebased to be repo-root-relative (config-dir aware), deduped, longest-prefix-first. resolvePath already tries every candidate rule, so merging is safe — a wrong-base candidate just never exists in knownFiles.

## Verification

- New tests: tests/alias-resolution.test.ts (10 tests) — incl. a realistic Next.js config (paths + include globs) that fails with the old stripper, and the exact monorepo scenario from the issue.
- `pnpm vitest run` → **305/305** (was 295).
- `pnpm run typecheck` → clean.
- Dogfood on ARCLUX itself (before → after):
  - graph edges: 751 → **965** (+214 — alias imports now resolve)
  - unusedExports: 482 → **417**; orphanFiles: 304 → **247**
  - Navbar.tsx: 'never imported' → **importedBy=1**
  - Remaining apps/web orphans are legitimately dead code (GraphLegend/GraphToolbar explicitly superseded by GraphMenu in their own file comments).

Closes #372.