### PR TITLE
README: accurate stub file status

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ What is solid right now:
 What is not there yet:
 - General-purpose source parsers for Rust, C#, C++, PHP, Ruby (dependency-manifest parsing exists for all of these; PHP has route-file parsing — `packages/parser/php/parsePhpRoutes.ts` — but the general `.php` source parser is deliberately deferred, see `progres/decisions.md`)
 - True per-file incremental re-analysis (`packages/incremental` + `packages/watcher` are built and verified standalone; `watchRepository` wraps the pipeline in a coarse change-level cache, but `buildIndex` still does a full rebuild — see `progres/decisions.md`)
+- Persistence layer: `packages/db/*` (schema, client, RepoStore/AnalysisStore/IssueStore) is 0% -- no database wired in yet, everything is in-memory per-run
+- Cache layer: `packages/cache/*` (CacheProvider, memoryCache) is 0% -- see `progres/decisions.md` for a documented design conflict blocking this
+- Several `packages/engine/analyze*.ts` files (analyzeFile, analyzeModule, analyzeImpact, analyzeConvention, analyzeArchitecture, analyzeDependency) and `generateSummary.ts`/`generateReport.ts` are stubs -- the actual analysis entry point is `packages/engine/pipeline.ts`'s `analyzeRepository()`, which is what's real and tested; these per-concern files are an unimplemented finer-grained API surface, not a broken core
+- `packages/ui/*` (graphLayout, graphTheme, graphAnimation, graphIcons) is 0% -- current graph rendering lives directly in `apps/web/components/graph/*` instead
+- `packages/watcher/watchGit.ts` and `packages/indexer/updateIndex.ts`/`watchIndex.ts`/`indexSchema.ts` are stubs -- live file-watching exists via `packages/daemon/` (see the Daemon section above), which wraps `watchRepository`/`watchFilesystem` directly rather than these
+
+Run `find packages -name "*.ts" -not -path "*/node_modules/*" | while read f; do [ "$(wc -l < "$f")" -le 9 ] && echo "$f"; done` to see the current, exact stub list yourself -- this list can drift as work continues.
 
 ## What it does
 


### PR DESCRIPTION
README's 'not there yet' list was outdated -- didn't mention db/ and cache/ (both 0%, confirmed via file line-count scan), engine/analyze*.ts stubs (real entry point is pipeline.ts), ui/* (0%), or watcher/watchGit.ts. Added a reproducible scan command so this list doesn't go stale silently again.