### PR TITLE
Implement packages/db/ (was 0%)

### DIFF
--- a/apps/cli/daemon.ts
+++ b/apps/cli/daemon.ts
@@ -18,6 +18,8 @@ import { ArcluxDaemon } from "../../packages/daemon/ArcluxDaemon";
 import { resolveWorkingRepositoryRoot } from "../../packages/environment/EnvironmentDetector";
 import { resolve } from "node:path";
 import { spawnDetached, stopDetached, getDaemonStatus } from "../../packages/daemon/DaemonProcess";
+import { saveRepo } from "../../packages/db/repositories/RepoStore";
+import { saveAnalysis } from "../../packages/db/repositories/AnalysisStore";
 import { fileURLToPath } from "node:url";
 
 export function registerDaemonCommand(program: Command): void {
@@ -70,6 +72,17 @@ export function registerDaemonCommand(program: Command): void {
 
       daemon.kernel.signalBus.on("daemon:analysis:updated", (data: any) => {
         p.log.info(`Re-analyzed: ${data.moduleCount} modules`);
+
+        // Persist each re-analysis to packages/db/ so history survives past
+        // this daemon process (see packages/db/repositories/AnalysisStore.ts).
+        // getAnalysis() here is cheap (cached, see watchRepository.ts) since
+        // this fires right after a real re-analysis already happened.
+        daemon.getAnalysis().then((result) => {
+          saveRepo(result.meta);
+          saveAnalysis(result.meta.id, result);
+        }).catch(() => {
+          // best-effort -- a failed save shouldn't crash the daemon
+        });
       });
 
       daemon.kernel.signalBus.on("daemon:diagnostics:updated", (data: any) => {

--- a/packages/db/client.ts
+++ b/packages/db/client.ts
@@ -5,4 +5,78 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Generic collection client: one JSON file per record, under
+// ~/.arclux/db/<collection>/<id>.json. Writes go through
+// packages/storage/RecoveryManager.ts's writeTransactional() -- same
+// crash-safety guarantee already verified for process records
+// (packages/storage/SnapshotManager.ts uses the same function).
 
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { writeTransactional } from "../storage/RecoveryManager";
+import { SCHEMA_VERSION, type CollectionName } from "./schema";
+
+function arcluxRoot(): string {
+  return process.env.ARCLUX_ROOT || path.join(os.homedir(), ".arclux");
+}
+
+function collectionDir(collection: CollectionName): string {
+  return path.join(arcluxRoot(), "db", collection);
+}
+
+function recordPath(collection: CollectionName, id: string): string {
+  return path.join(collectionDir(collection), `${id}.json`);
+}
+
+/** Writes (or overwrites) one record, journaled through RecoveryManager for crash safety. */
+export function putRecord<T extends { id: string }>(collection: CollectionName, record: T): void {
+  const withVersion = { ...record, __schemaVersion: SCHEMA_VERSION };
+  writeTransactional(recordPath(collection, record.id), JSON.stringify(withVersion, null, 2));
+}
+
+/** Reads one record by id, or null if it doesn't exist / is corrupt. */
+export function getRecord<T>(collection: CollectionName, id: string): T | null {
+  try {
+    const raw = fs.readFileSync(recordPath(collection, id), "utf8");
+    const parsed = JSON.parse(raw);
+    delete parsed.__schemaVersion;
+    return parsed as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Reads every record in a collection. Skips (does not throw on) individual corrupt files. */
+export function listRecords<T>(collection: CollectionName): T[] {
+  const dir = collectionDir(collection);
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+
+  const records: T[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const raw = fs.readFileSync(path.join(dir, file), "utf8");
+      const parsed = JSON.parse(raw);
+      delete parsed.__schemaVersion;
+      records.push(parsed as T);
+    } catch {
+      continue;
+    }
+  }
+  return records;
+}
+
+export function deleteRecord(collection: CollectionName, id: string): void {
+  try {
+    fs.unlinkSync(recordPath(collection, id));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+}

--- a/packages/db/repositories/AnalysisStore.ts
+++ b/packages/db/repositories/AnalysisStore.ts
@@ -5,4 +5,38 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Wraps packages/db/client.ts for the "analyses" collection. One record
+// per analyzeRepository() run -- a lightweight summary (counts + timestamp),
+// NOT the full DependencyGraph/Repository (those are large and already
+// re-derivable by re-running analysis; this store is for history/trend
+// queries like "how has moduleCount changed over time", not a graph cache).
 
+import { randomUUID } from "node:crypto";
+import { putRecord, getRecord, listRecords } from "../client";
+import type { AnalysisRecord } from "../schema";
+import type { AnalyzeRepositoryResult } from "../../engine/pipeline";
+
+export function saveAnalysis(repoId: string, result: AnalyzeRepositoryResult): AnalysisRecord {
+  const record: AnalysisRecord = {
+    id: randomUUID(),
+    repoId,
+    moduleCount: result.moduleCount,
+    nodeCount: result.graph.nodes.length,
+    edgeCount: result.graph.edges.length,
+    analyzedAt: result.meta.analyzedAt,
+  };
+  putRecord("analyses", record);
+  return record;
+}
+
+export function getAnalysis(id: string): AnalysisRecord | null {
+  return getRecord<AnalysisRecord>("analyses", id);
+}
+
+/** All analysis records for one repo, most recent first. */
+export function listAnalysesForRepo(repoId: string): AnalysisRecord[] {
+  return listRecords<AnalysisRecord>("analyses")
+    .filter((r) => r.repoId === repoId)
+    .sort((a, b) => b.analyzedAt.localeCompare(a.analyzedAt));
+}

--- a/packages/db/repositories/IssueStore.ts
+++ b/packages/db/repositories/IssueStore.ts
@@ -5,4 +5,47 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Wraps packages/db/client.ts for the "issues" collection. Persists
+// findings from packages/engine/contract.ts's runAllChecks() (10 detectors
+// + rule engine, aggregated into one Issue[] list) tied to an analysis run,
+// so past issues can be queried without re-running detectors.
 
+import { randomUUID } from "node:crypto";
+import { putRecord, listRecords, deleteRecord } from "../client";
+import type { IssueRecord } from "../schema";
+import type { Issue } from "../../engine/contract";
+
+export function saveIssues(repoId: string, analysisId: string, issues: Issue[]): IssueRecord[] {
+  const now = new Date().toISOString();
+  const records: IssueRecord[] = issues.map((issue) => ({
+    id: randomUUID(),
+    repoId,
+    analysisId,
+    source: issue.source,
+    checkId: issue.checkId,
+    severity: issue.severity,
+    message: issue.message,
+    createdAt: now,
+  }));
+
+  for (const record of records) {
+    putRecord("issues", record);
+  }
+  return records;
+}
+
+export function listIssuesForAnalysis(analysisId: string): IssueRecord[] {
+  return listRecords<IssueRecord>("issues").filter((r) => r.analysisId === analysisId);
+}
+
+export function listIssuesForRepo(repoId: string): IssueRecord[] {
+  return listRecords<IssueRecord>("issues").filter((r) => r.repoId === repoId);
+}
+
+/** Deletes every issue record belonging to one analysis run -- e.g. before re-saving a fresh set. */
+export function clearIssuesForAnalysis(analysisId: string): void {
+  for (const record of listIssuesForAnalysis(analysisId)) {
+    deleteRecord("issues", record.id);
+  }
+}

--- a/packages/db/repositories/RepoStore.ts
+++ b/packages/db/repositories/RepoStore.ts
@@ -5,4 +5,37 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Wraps packages/db/client.ts for the "repos" collection. Maps to/from
+// RepositoryMeta (packages/shared/types.ts) -- same shape AnalyzeRepositoryResult.meta
+// already produces, no new shape invented.
 
+import { putRecord, getRecord, listRecords, deleteRecord } from "../client";
+import type { RepoRecord } from "../schema";
+import type { RepositoryMeta } from "../../shared/types";
+
+export function saveRepo(meta: RepositoryMeta): void {
+  const record: RepoRecord = {
+    id: meta.id,
+    org: meta.org,
+    name: meta.name,
+    defaultBranch: meta.defaultBranch,
+    rootPath: meta.rootPath,
+    detectedFrameworks: meta.detectedFrameworks,
+    packageManager: meta.packageManager,
+    analyzedAt: meta.analyzedAt,
+  };
+  putRecord("repos", record);
+}
+
+export function getRepo(id: string): RepoRecord | null {
+  return getRecord<RepoRecord>("repos", id);
+}
+
+export function listRepos(): RepoRecord[] {
+  return listRecords<RepoRecord>("repos");
+}
+
+export function deleteRepo(id: string): void {
+  deleteRecord("repos", id);
+}

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -5,4 +5,51 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// packages/db/ was 0% (no database dependency installed -- confirmed via
+// package.json/node_modules, no sqlite/lowdb/knex/prisma/drizzle present,
+// and this session has no network access to `pnpm add` one). Rather than
+// write code against a library that isn't installed (unverifiable, same
+// mistake as the VS Code extension caveat), this uses a JSON-file-per-record
+// store through packages/storage/RecoveryManager.ts's writeTransactional()
+// (the write-ahead journal already built and verified this session) --
+// no new dependency, works today, crash-safe by construction.
+//
+// SCHEMA_VERSION exists so a future real SQL migration can detect "this
+// repo has old JSON-store data" and write a one-time importer, instead of
+// silently ignoring it.
 
+export const SCHEMA_VERSION = 1;
+
+export interface RepoRecord {
+  id: string;
+  org: string;
+  name: string;
+  defaultBranch: string;
+  rootPath: string;
+  detectedFrameworks: string[];
+  packageManager: "npm" | "pnpm" | "yarn" | "unknown";
+  analyzedAt: string;
+}
+
+export interface AnalysisRecord {
+  id: string;
+  repoId: string;
+  moduleCount: number;
+  nodeCount: number;
+  edgeCount: number;
+  analyzedAt: string;
+}
+
+export interface IssueRecord {
+  id: string;
+  repoId: string;
+  analysisId: string;
+  source: "detector" | "rule";
+  checkId: string;
+  severity: "error" | "warning";
+  message: string;
+  createdAt: string;
+}
+
+export type CollectionName = "repos" | "analyses" | "issues";


### PR DESCRIPTION
packages/db/* was 0%, no database dependency installed (confirmed: no sqlite/lowdb/knex/prisma/drizzle in package.json or node_modules, and this session has no network access to pnpm add one). Implemented as a JSON-file-per-record store instead, going through packages/storage/RecoveryManager.ts's writeTransactional() for the same crash-safety guarantee already verified for process records. schema.ts defines RepoRecord/AnalysisRecord/IssueRecord + SCHEMA_VERSION (so a future real SQL migration can detect old data). client.ts is a generic put/get/list/delete per collection. RepoStore/AnalysisStore/IssueStore wrap client.ts for each entity, mapping to/from existing shapes (RepositoryMeta, AnalyzeRepositoryResult, Issue) -- no new shapes invented.

Wired into apps/cli/daemon.ts: every daemon:analysis:updated event now saves the repo + analysis summary. Bug caught and fixed during this session: the save call was initially placed outside the event handler and before daemon.start(), so getAnalysis() threw silently (swallowed by .catch). Verified end-to-end (not just tsc --noEmit): ran the daemon, edited a file, confirmed real JSON files written to ~/.arclux/db/repos/ and ~/.arclux/db/analyses/.