### PR TITLE
Implement CacheProvider + memoryCache

### DIFF
--- a/packages/cache/CacheProvider.ts
+++ b/packages/cache/CacheProvider.ts
@@ -6,3 +6,26 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { fileCacheSize, clearFileCache } from "./fileCache";
+import { repositoryCacheSize, clearRepositoryCache } from "./repositoryCache";
+import { graphCacheSize, clearGraphCache } from "./graphCache";
+
+export interface CacheStats {
+  fileCacheSize: number;
+  repositoryCacheSize: number;
+  graphCacheSize: number;
+  totalEntries: number;
+}
+
+export function getCacheStats(): CacheStats {
+  const file = fileCacheSize();
+  const repository = repositoryCacheSize();
+  const graph = graphCacheSize();
+  return { fileCacheSize: file, repositoryCacheSize: repository, graphCacheSize: graph, totalEntries: file + repository + graph };
+}
+
+export function clearAllCaches(): void {
+  clearFileCache();
+  clearRepositoryCache();
+  clearGraphCache();
+}

--- a/packages/cache/memoryCache.ts
+++ b/packages/cache/memoryCache.ts
@@ -6,3 +6,41 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+interface CacheEntry<V> {
+  value: V;
+  expiresAt: number | null;
+}
+
+export class MemoryCache<K, V> {
+  private store = new Map<K, CacheEntry<V>>();
+
+  set(key: K, value: V, ttlMs?: number): void {
+    this.store.set(key, { value, expiresAt: ttlMs !== undefined ? Date.now() + ttlMs : null });
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.store.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt !== null && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  has(key: K): boolean {
+    return this.get(key) !== undefined;
+  }
+
+  delete(key: K): boolean {
+    return this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+
+  get size(): number {
+    return this.store.size;
+  }
+}


### PR DESCRIPTION
CacheProvider.ts: facade/stats layer over fileCache/repositoryCache/graphCache (all three already implemented and wired into buildIndex.ts/pipeline.ts). memoryCache.ts: generic TTL-based Map cache utility for future callers that don't need content-hash invalidation.