### PR TITLE
Implement NetworkRegistry + ConnectionManager

### DIFF
--- a/packages/networking/ConnectionManager.ts
+++ b/packages/networking/ConnectionManager.ts
@@ -1,11 +1,41 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tracks connection state to registered endpoints (packages/networking/NetworkRegistry.ts).
+// A GET /analysis probe is used for liveness -- same route apps/vscode-extension
+// already calls via daemonClient.ts, and packages/daemon/LocalBridgeServer.ts
+// already exposes it, so no new server-side route needed.
 
-// Scaffold: networking/ConnectionManager — not yet implemented.
+import * as http from "http";
+import type { ServiceEndpoint } from "./ServiceEndpoint";
+
+export type ConnectionState = "connected" | "unreachable";
+
+export async function checkConnection(endpoint: ServiceEndpoint, timeoutMs = 2000): Promise<ConnectionState> {
+  return new Promise((resolve) => {
+    const req = http.get(`${endpoint.baseUrl}/analysis`, { timeout: timeoutMs }, (res) => {
+      res.resume();
+      resolve(res.statusCode && res.statusCode < 500 ? "connected" : "unreachable");
+    });
+    req.on("timeout", () => { req.destroy(); resolve("unreachable"); });
+    req.on("error", () => resolve("unreachable"));
+  });
+}
+
+/** Checks every registered endpoint's liveness in parallel. */
+export async function checkAllConnections(
+  registered: Array<{ daemonId: string; endpoint: ServiceEndpoint }>
+): Promise<Map<string, ConnectionState>> {
+  const results = new Map<string, ConnectionState>();
+  await Promise.all(
+    registered.map(async (r) => {
+      results.set(r.daemonId, await checkConnection(r.endpoint));
+    })
+  );
+  return results;
+}

--- a/packages/networking/NetworkRegistry.ts
+++ b/packages/networking/NetworkRegistry.ts
@@ -1,11 +1,49 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Generalizes packages/networking/ServiceEndpoint.ts's single-endpoint
+// discovery-file pattern (one file per daemonId under ~/.arclux/endpoints/)
+// into a listing API -- for a future consumer that needs "show me every
+// ARCLUX daemon currently running on this machine", not just "find the one
+// for this repo" (which ServiceEndpoint.findServiceEndpoint-equivalent already covers).
 
-// Scaffold: networking/NetworkRegistry — not yet implemented.
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import type { ServiceEndpoint } from "./ServiceEndpoint";
+
+function endpointsDir(): string {
+  return path.join(process.env.ARCLUX_ROOT || path.join(os.homedir(), ".arclux"), "endpoints");
+}
+
+export interface RegisteredEndpoint {
+  daemonId: string;
+  endpoint: ServiceEndpoint;
+}
+
+/** Lists every currently-registered daemon endpoint on this machine (does not verify they're still alive -- see ConnectionManager for that). */
+export function listRegisteredEndpoints(): RegisteredEndpoint[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(endpointsDir());
+  } catch {
+    return [];
+  }
+
+  const results: RegisteredEndpoint[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const raw = fs.readFileSync(path.join(endpointsDir(), file), "utf8");
+      results.push({ daemonId: file.replace(/\.json$/, ""), endpoint: JSON.parse(raw) });
+    } catch {
+      continue;
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
Generalizes ServiceEndpoint.ts's single-endpoint pattern to list all registered daemons, and adds liveness checking via the existing GET /analysis route (LocalBridgeServer.ts) -- no new server route needed.