### PR TITLE
Inline diagnostic gutter markers

### DIFF
--- a/apps/web/components/explorer/Explorer.tsx
+++ b/apps/web/components/explorer/Explorer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { FileDetails } from "./FileDetails";
+import { useState, useEffect } from "react";
+import { FileDetails, type DiagnosticMarker } from "./FileDetails";
 import { DependencyList } from "./DependencyList";
 import { ImpactSummary } from "./ImpactSummary";
 
@@ -40,6 +40,43 @@ export interface ExplorerProps {
  */
 export function Explorer({ repoUrl, moduleId, branch, onClose }: ExplorerProps) {
   const [activeTab, setActiveTab] = useState<ExplorerTab>("file");
+  const [fileDiagnostics, setFileDiagnostics] = useState<DiagnosticMarker[]>([]);
+
+  // Fetches once per repoUrl/branch (not per file switch) -- POST /api/diagnostics
+  // does a full clone+index per call (same cost as /api/analyze, /api/doctor),
+  // so re-fetching on every file open inside the same repo would be wasteful.
+  // Findings are filtered by moduleId client-side per render instead.
+  const [allDiagnostics, setAllDiagnostics] = useState<any[]>([]);
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/diagnostics", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repoUrl, branch }),
+    })
+      .then((res) => res.json())
+      .then((json) => {
+        if (!cancelled) setAllDiagnostics(json.events ?? []);
+      })
+      .catch(() => {
+        // best-effort -- FileDetails still works without diagnostics, just no gutter markers
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repoUrl, branch]);
+
+  useEffect(() => {
+    const filtered: DiagnosticMarker[] = allDiagnostics
+      .filter((e: any) => e.filePath === moduleId)
+      .map((e: any) => ({
+        line: e.line,
+        severity: e.severity,
+        message: e.message,
+        checkId: e.checkId,
+      }));
+    setFileDiagnostics(filtered);
+  }, [allDiagnostics, moduleId]);
 
   return (
     <div className="flex h-full flex-col bg-background">
@@ -74,7 +111,7 @@ export function Explorer({ repoUrl, moduleId, branch, onClose }: ExplorerProps) 
       </div>
 
       <div className="flex-1 overflow-auto">
-        {activeTab === "file" && <FileDetails repoUrl={repoUrl} filePath={moduleId} branch={branch} />}
+        {activeTab === "file" && <FileDetails repoUrl={repoUrl} filePath={moduleId} branch={branch} diagnostics={fileDiagnostics} />}
         {activeTab === "dependencies" && (
           <DependencyList repoUrl={repoUrl} moduleId={moduleId} branch={branch} />
         )}

--- a/apps/web/components/explorer/FileDetails.tsx
+++ b/apps/web/components/explorer/FileDetails.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
+import { useEffect } from "react";
 import { LoadingState } from "@/components/patterns/LoadingState";
 import { ErrorState } from "@/components/patterns/ErrorState";
 
@@ -18,10 +19,15 @@ interface FileResponse {
   tokens: HighlightToken[];
 }
 
-// Mirrors theme/theme.dark.ts `syntax` tokens. Duplicated here rather than
-// imported because that file exports color values meant for CSS variable
-// wiring, not a ready-to-use token-name -> hex map — keeping this local
-// avoids coupling this client component to globals.css wiring specifics.
+/** One diagnostic finding pinned to a specific line in this file. Shape matches DiagnosticEvent (packages/diagnostics/DiagnosticEvent.ts) as returned by POST /api/diagnostics, filtered by the caller to this file's filePath. */
+export interface DiagnosticMarker {
+  line: number;
+  severity: "error" | "warning";
+  message: string;
+  checkId: string;
+  suggestion?: string;
+}
+
 const TOKEN_COLORS: Record<string, string> = {
   comment: "#878787",
   keyword: "#F75590",
@@ -34,22 +40,24 @@ const TOKEN_COLORS: Record<string, string> = {
   punctuation: "#EDEDED",
 };
 
+const SEVERITY_COLOR: Record<DiagnosticMarker["severity"], string> = {
+  error: "#F75590",
+  warning: "#F2A700",
+};
+
 export interface FileDetailsProps {
   repoUrl: string;
   filePath: string;
   branch?: string;
+  /** Diagnostic findings for THIS file only -- caller (Explorer.tsx) fetches /api/diagnostics once and filters by filePath, so this component doesn't re-fetch the (expensive, full-repo) diagnostics call per file open. */
+  diagnostics?: DiagnosticMarker[];
 }
 
-/**
- * STATUS: not yet wired up to any page (components/explorer/Explorer.tsx is
- * still empty) — this is a standalone building block for now. Also not yet
- * visually verified in a browser; see highlightPython.ts and
- * apps/web/app/api/file/route.ts for what's still unconfirmed.
- */
-export function FileDetails({ repoUrl, filePath, branch }: FileDetailsProps) {
+export function FileDetails({ repoUrl, filePath, branch, diagnostics = [] }: FileDetailsProps) {
   const [data, setData] = useState<FileResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [expandedLine, setExpandedLine] = useState<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -83,50 +91,123 @@ export function FileDetails({ repoUrl, filePath, branch }: FileDetailsProps) {
   if (error) return <ErrorState title="Couldn't load file" message={error} />;
   if (!data) return null;
 
+  const markersByLine = new Map<number, DiagnosticMarker[]>();
+  for (const marker of diagnostics) {
+    const list = markersByLine.get(marker.line) ?? [];
+    list.push(marker);
+    markersByLine.set(marker.line, list);
+  }
+
   return (
     <div className="h-full overflow-auto bg-black">
-      <div className="border-b px-4 py-2 font-mono text-xs text-muted-foreground">
-        {filePath}
+      <div className="flex items-center justify-between bg-neutral-900/40 px-4 py-2 font-mono text-xs text-muted-foreground">
+        <span>{filePath}</span>
+        {diagnostics.length > 0 && (
+          <span style={{ color: SEVERITY_COLOR.error }}>{diagnostics.length} finding(s)</span>
+        )}
       </div>
-      <pre className="p-4 text-sm leading-relaxed">
-        <code>{renderTokens(data.content, data.tokens)}</code>
-      </pre>
+      <div className="text-sm leading-relaxed">
+        {renderLines(data.content, data.tokens, markersByLine, expandedLine, setExpandedLine)}
+      </div>
     </div>
   );
 }
 
 /**
- * Renders source with highlighted spans, filling gaps between tokens as
- * plain unstyled text. Assumes token.startIndex/endIndex line up with JS
- * string indices — that's how the reference examples for web-tree-sitter
- * use them when the parser is fed a JS string directly, but it hasn't been
- * visually confirmed in-browser for this project yet. If colors land on
- * the wrong characters, check that assumption first.
+ * Renders source split by line, one row per line: a gutter (line number +
+ * colored bar if a diagnostic exists on that line) and the syntax-highlighted
+ * content. Clicking a marked line expands a message row below it showing
+ * the diagnostic message + fix suggestion, matching how an editor's Problems
+ * panel works but inline instead of in a separate list.
+ *
+ * Token offsets from /api/file are global string indices (see the original
+ * comment this replaces) -- converted here to per-line by tracking each
+ * line's start offset. Tokens are assumed not to span multiple lines
+ * (true for keyword/string/comment/etc token types the highlighter emits).
  */
-function renderTokens(source: string, tokens: HighlightToken[]): ReactNode {
-  if (tokens.length === 0) {
-    return source;
+function renderLines(
+  source: string,
+  tokens: HighlightToken[],
+  markersByLine: Map<number, DiagnosticMarker[]>,
+  expandedLine: number | null,
+  setExpandedLine: (line: number | null) => void
+): ReactNode {
+  const lines = source.split("\n");
+  const lineStarts: number[] = [];
+  let offset = 0;
+  for (const line of lines) {
+    lineStarts.push(offset);
+    offset += line.length + 1;
   }
+
+  const tokensByLineIndex: HighlightToken[][] = lines.map(() => []);
+  for (const token of tokens) {
+    let lineIdx = 0;
+    for (let i = 0; i < lineStarts.length; i++) {
+      if (lineStarts[i] <= token.startIndex) lineIdx = i;
+      else break;
+    }
+    tokensByLineIndex[lineIdx]?.push(token);
+  }
+
+  return lines.map((lineText, idx) => {
+    const lineNumber = idx + 1;
+    const lineStart = lineStarts[idx];
+    const lineMarkers = markersByLine.get(lineNumber) ?? [];
+    const hasError = lineMarkers.some((m) => m.severity === "error");
+    const barColor = lineMarkers.length > 0 ? SEVERITY_COLOR[hasError ? "error" : "warning"] : "transparent";
+    const isExpanded = expandedLine === lineNumber;
+
+    return (
+      <div key={lineNumber}>
+        <button
+          type="button"
+          onClick={() => lineMarkers.length > 0 && setExpandedLine(isExpanded ? null : lineNumber)}
+          className={`flex w-full items-start gap-3 px-2 text-left font-mono ${
+            lineMarkers.length > 0 ? "cursor-pointer hover:bg-neutral-900/60" : "cursor-default"
+          } ${isExpanded ? "bg-neutral-900/60" : ""}`}
+        >
+          <span style={{ backgroundColor: barColor }} className="mt-0.5 h-full w-0.5 shrink-0 self-stretch" />
+          <span className="w-8 shrink-0 select-none text-right text-neutral-600">{lineNumber}</span>
+          <span className="flex-1 whitespace-pre">
+            {renderLineTokens(lineText, lineStart, tokensByLineIndex[idx] ?? [])}
+          </span>
+        </button>
+        {isExpanded &&
+          lineMarkers.map((marker) => (
+            <div
+              key={marker.checkId}
+              className="ml-[52px] mr-2 mb-1 rounded bg-neutral-900/80 px-3 py-2 text-xs"
+              style={{ borderLeft: `2px solid ${SEVERITY_COLOR[marker.severity]}` }}
+            >
+              <p style={{ color: SEVERITY_COLOR[marker.severity] }}>{marker.message}</p>
+              {marker.suggestion && <p className="mt-1 text-neutral-400">Fix: {marker.suggestion}</p>}
+            </div>
+          ))}
+      </div>
+    );
+  });
+}
+
+function renderLineTokens(lineText: string, lineStart: number, lineTokens: HighlightToken[]): ReactNode {
+  if (lineTokens.length === 0) return lineText;
 
   const nodes: ReactNode[] = [];
   let cursor = 0;
 
-  for (const token of tokens) {
-    if (token.startIndex > cursor) {
-      nodes.push(source.slice(cursor, token.startIndex));
-    }
+  for (const token of lineTokens) {
+    const relStart = Math.max(0, token.startIndex - lineStart);
+    const relEnd = Math.min(lineText.length, token.endIndex - lineStart);
+    if (relStart > cursor) nodes.push(lineText.slice(cursor, relStart));
     const color = TOKEN_COLORS[token.tokenType];
     nodes.push(
       <span key={`${token.startIndex}-${token.endIndex}`} style={{ color }}>
-        {source.slice(token.startIndex, token.endIndex)}
+        {lineText.slice(relStart, relEnd)}
       </span>
     );
-    cursor = token.endIndex;
+    cursor = relEnd;
   }
 
-  if (cursor < source.length) {
-    nodes.push(source.slice(cursor));
-  }
-
+  if (cursor < lineText.length) nodes.push(lineText.slice(cursor));
   return nodes;
 }


### PR DESCRIPTION
Replaces flat token-highlighted <pre> in FileDetails.tsx with a per-line render: each line gets a gutter (colored bar for error/warning + line number), clicking a marked line expands the diagnostic message and fix suggestion inline -- editor-style, instead of only showing which FILES are affected via the separate Impact tab. Explorer.tsx fetches POST /api/diagnostics once per repoUrl/branch (not per file switch, since the endpoint does a full clone+index per call) and filters events to the currently open file's path.