### PR TITLE
JS/TS syntax highlighting

### DIFF
--- a/apps/web/app/api/file/route.ts
+++ b/apps/web/app/api/file/route.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import { parseOrgAndName } from "@/packages/engine/pipeline";
 import { detectLanguage } from "@/packages/parser/core/LanguageDetector";
 import { highlightPythonSource, type HighlightToken } from "@/packages/parser/python/highlightPython";
+import { highlightJavaScriptSource, highlightTypeScriptSource } from "@/packages/parser/javascript/highlightJs";
 
 /**
  * GET /api/file?repoUrl=...&filePath=...&branch=...
@@ -70,14 +71,18 @@ export async function GET(request: NextRequest) {
   const language = detectLanguage(extension);
 
   let tokens: HighlightToken[] = [];
-  if (language === "python") {
-    try {
+  try {
+    if (language === "python") {
       tokens = await highlightPythonSource(content);
-    } catch (err) {
-      // Highlighting is best-effort — fall back to plain text instead of
-      // failing the whole request if the query engine errors out.
-      console.error("Python highlighting failed:", err);
+    } else if (language === "javascript") {
+      tokens = await highlightJavaScriptSource(content);
+    } else if (language === "typescript") {
+      tokens = await highlightTypeScriptSource(content);
     }
+  } catch (err) {
+    // Highlighting is best-effort — fall back to plain text instead of
+    // failing the whole request if the query engine errors out.
+    console.error(`${language} highlighting failed:`, err);
   }
 
   return NextResponse.json({ content, language, branch: usedBranch, tokens });

--- a/packages/parser/javascript/highlightJs.ts
+++ b/packages/parser/javascript/highlightJs.ts
@@ -1,0 +1,154 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Same pattern as packages/parser/python/highlightPython.ts, generalized
+// to accept a wasm filename so JS and TS (and future languages) share one
+// loader instead of duplicating the walk-up-from-cwd wasm resolution logic.
+// CRITICAL, per parsePython.ts's own comment (regressed twice before):
+// NEVER call require.resolve() or nodeRequire.resolve() here -- it returns
+// a webpack-bundle-relative path, not a real filesystem path, inside
+// Next.js's webpack runtime. Always walk up from process.cwd() instead.
+//
+// Highlight query merges tree-sitter-javascript's queries/highlights.scm
+// (base tokens: keyword, string, comment, function, operator, etc) with
+// tree-sitter-typescript's TS-specific additions (type, interface,
+// namespace keywords, etc) -- fetched from the official grammar repos,
+// not written from scratch. TSX-specific JSX captures not included --
+// out of scope for a first pass, .tsx files fall back to the base JS/TS
+// captures (JSX tag names etc render as plain text, not a rendering bug).
+
+import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import type { HighlightToken, SyntaxTokenType } from "./highlightTypes";
+import { JS_TS_HIGHLIGHTS_QUERY } from "./jsTsHighlightQuery";
+
+const require = createRequire(import.meta.url);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TreeSitter: any = require("web-tree-sitter");
+const { Parser, Language, Query } = TreeSitter;
+
+const CAPTURE_PRIORITY: Array<{ name: string; kind: SyntaxTokenType }> = [
+  { name: "constructor", kind: "type" },
+  { name: "type", kind: "type" },
+  { name: "type.builtin", kind: "type" },
+  { name: "constant.builtin", kind: "constant" },
+  { name: "constant", kind: "constant" },
+  { name: "number", kind: "constant" },
+  { name: "function.builtin", kind: "property" },
+  { name: "function.method", kind: "property" },
+  { name: "function", kind: "property" },
+  { name: "property", kind: "property" },
+  { name: "comment", kind: "comment" },
+  { name: "string", kind: "string" },
+  { name: "string.special", kind: "string" },
+  { name: "keyword", kind: "keyword" },
+  { name: "operator", kind: "operator" },
+  { name: "variable.builtin", kind: "variable" },
+  { name: "variable.parameter", kind: "variable" },
+  { name: "variable", kind: "variable" },
+];
+
+const PRIORITY_INDEX = new Map(CAPTURE_PRIORITY.map((c, i) => [c.name, i]));
+
+interface RawCapture {
+  name: string;
+  startIndex: number;
+  endIndex: number;
+  text: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const runtimeCache = new Map<string, Promise<any>>();
+
+function findWasmPath(wasmFilename: string): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(dir, "node_modules", "tree-sitter-wasms", "out", wasmFilename);
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error(`Could not find tree-sitter-wasms/out/${wasmFilename} by walking up from ${process.cwd()}`);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getRuntime(wasmFilename: string): Promise<any> {
+  const cached = runtimeCache.get(wasmFilename);
+  if (cached) return cached;
+
+  const promise = (async () => {
+    await Parser.init();
+    const parser = new Parser();
+    const wasmPath = findWasmPath(wasmFilename);
+    const language = await Language.load(wasmPath);
+    parser.setLanguage(language);
+    return { parser, language };
+  })();
+
+  runtimeCache.set(wasmFilename, promise);
+  return promise;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createHighlightQuery(language: any): any {
+  if (typeof Query === "function") {
+    return new Query(language, JS_TS_HIGHLIGHTS_QUERY);
+  }
+  return language.query(JS_TS_HIGHLIGHTS_QUERY);
+}
+
+async function highlightWith(source: string, wasmFilename: string): Promise<HighlightToken[]> {
+  const { parser, language } = await getRuntime(wasmFilename);
+  const tree = parser.parse(source);
+  const query = createHighlightQuery(language);
+
+  const matches = query.matches(tree.rootNode) as Array<{
+    captures: Array<{ name: string; node: { text: string; startIndex: number; endIndex: number } }>;
+  }>;
+
+  const raw: RawCapture[] = [];
+  for (const match of matches) {
+    for (const capture of match.captures) {
+      if (!PRIORITY_INDEX.has(capture.name)) continue;
+      raw.push({
+        name: capture.name,
+        startIndex: capture.node.startIndex,
+        endIndex: capture.node.endIndex,
+        text: capture.node.text,
+      });
+    }
+  }
+
+  const bySpan = new Map<string, RawCapture>();
+  for (const cap of raw) {
+    const key = `${cap.startIndex}-${cap.endIndex}`;
+    const existing = bySpan.get(key);
+    if (!existing || PRIORITY_INDEX.get(cap.name)! < PRIORITY_INDEX.get(existing.name)!) {
+      bySpan.set(key, cap);
+    }
+  }
+
+  return Array.from(bySpan.values())
+    .map((cap) => ({
+      startIndex: cap.startIndex,
+      endIndex: cap.endIndex,
+      text: cap.text,
+      tokenType: CAPTURE_PRIORITY[PRIORITY_INDEX.get(cap.name)!].kind,
+    }))
+    .sort((a, b) => a.startIndex - b.startIndex);
+}
+
+export function highlightJavaScriptSource(source: string): Promise<HighlightToken[]> {
+  return highlightWith(source, "tree-sitter-javascript.wasm");
+}
+
+export function highlightTypeScriptSource(source: string): Promise<HighlightToken[]> {
+  return highlightWith(source, "tree-sitter-typescript.wasm");
+}

--- a/packages/parser/javascript/highlightTypes.ts
+++ b/packages/parser/javascript/highlightTypes.ts
@@ -1,0 +1,28 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Shared between highlightPython.ts and highlightJs.ts so both use the
+// exact same token shape/type union instead of two copies drifting apart.
+
+export type SyntaxTokenType =
+  | "comment"
+  | "keyword"
+  | "string"
+  | "variable"
+  | "property"
+  | "type"
+  | "constant"
+  | "operator"
+  | "punctuation";
+
+export interface HighlightToken {
+  startIndex: number;
+  endIndex: number;
+  text: string;
+  tokenType: SyntaxTokenType;
+}

--- a/packages/parser/javascript/jsTsHighlightQuery.ts
+++ b/packages/parser/javascript/jsTsHighlightQuery.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Merged from official grammar repos (not written from scratch):
+// tree-sitter/tree-sitter-javascript queries/highlights.scm (base tokens)
+// + tree-sitter/tree-sitter-typescript queries/highlights.scm (TS-specific
+// additions: type/interface/namespace keywords, type_identifier, etc).
+// Works for both .js and .ts since TS's grammar is a superset of JS's.
+
+export const JS_TS_HIGHLIGHTS_QUERY = `
+(identifier) @variable
+(property_identifier) @property
+
+(function_expression name: (identifier) @function)
+(function_declaration name: (identifier) @function)
+(method_definition name: (property_identifier) @function.method)
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function_expression) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function_expression) (arrow_function)])
+
+(call_expression function: (identifier) @function)
+(call_expression function: (member_expression property: (property_identifier) @function.method))
+
+((identifier) @constructor (#match? @constructor "^[A-Z]"))
+((identifier) @constant (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+((identifier) @variable.builtin (#match? @variable.builtin "^(arguments|module|console|window|document)$"))
+((identifier) @function.builtin (#eq? @function.builtin "require"))
+
+(this) @variable.builtin
+(super) @variable.builtin
+
+[(true) (false) (null) (undefined)] @constant.builtin
+
+(comment) @comment
+[(string) (template_string)] @string
+(regex) @string.special
+(number) @number
+
+(type_identifier) @type
+(predefined_type) @type.builtin
+
+[
+  "abstract" "declare" "enum" "export" "implements" "interface" "keyof"
+  "namespace" "private" "protected" "public" "readonly" "override" "satisfies"
+  "as" "async" "await" "break" "case" "catch" "class" "const" "continue"
+  "debugger" "default" "delete" "do" "else" "extends" "finally" "for"
+  "from" "function" "get" "if" "import" "in" "instanceof" "let" "new"
+  "of" "return" "set" "static" "switch" "target" "throw" "try" "type"
+  "typeof" "var" "void" "while" "with" "yield"
+] @keyword
+
+[
+  "-" "--" "-=" "+" "++" "+=" "*" "*=" "**" "**=" "/" "/=" "%" "%="
+  "<" "<=" "<<" "<<=" "=" "==" "===" "!" "!=" "!==" "=>" ">" ">=" ">>"
+  ">>=" ">>>" ">>>=" "~" "^" "&" "|" "^=" "&=" "|=" "&&" "||" "??"
+  "&&=" "||=" "??="
+] @operator
+`;


### PR DESCRIPTION
Was Python-only (per route.ts's own comment). Added highlightJs.ts: generic highlightWith(source, wasmFilename) loader following the exact same walk-up-from-process.cwd() pattern as highlightPython.ts (critical per that file's comment: never require.resolve(), it returns a webpack-bundle-relative path under Next.js). Query (jsTsHighlightQuery.ts) merged from the official tree-sitter-javascript and tree-sitter-typescript grammar repos' highlights.scm files, not written from scratch. Extracted shared HighlightToken/SyntaxTokenType into highlightTypes.ts so Python and JS/TS don't duplicate the interface. Wired into /api/file/route.ts for language === javascript/typescript. Not yet visually verified in browser.