### PR TITLE
Fix QUICKSTART branch refs, add how-to-use guide

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,8 +4,8 @@ Read this first. Full details live in TOOLING.md, scripts/README.md, and CONTRIB
 
 ## Standard workflow
 
-git checkout main
-git pull origin main
+git checkout ARCLUX.main
+git pull origin ARCLUX.main
 git checkout -b type/short-description
 
 git add file
@@ -15,12 +15,12 @@ git push origin type/short-description
 
 gh pr create --repo GSF-001/ARCLUX --title "title" --body "description"
 
-git diff main..type/short-description --stat
+git diff ARCLUX.main..type/short-description --stat
 
 gh pr merge NUMBER --repo GSF-001/ARCLUX --merge --delete-branch
 
-git checkout main
-git pull origin main
+git checkout ARCLUX.main
+git pull origin ARCLUX.main
 
 Branch types: feat, fix, docs, chore, test, split, update
 main is protected — direct push will be rejected, always go through a PR.

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -15,7 +15,8 @@
         "pages": [
           "overview",
           "quickstart",
-          "usage"
+          "usage",
+          "how-to-use"
         ]
       },
       {


### PR DESCRIPTION
QUICKSTART.md still referenced 'main' instead of 'ARCLUX.main' (the actively-used branch per progres/gotchas.md), which would send new contributors down the same confusing path this session hit repeatedly. Fixed. Also added docs-site/docs/how-to-use.md: a real usage guide covering all 4 ways to use ARCLUX now (CLI commands, daemon with --detach/--status/--stop + HTTP/SSE bridge, web dashboard with the new gutter markers + collapsible tree, VS Code extension) -- the existing usage.md is auto-generated from QUICKSTART.md and only lists bare commands, this is a proper walkthrough. Registered in docs.json's Getting Started group.