### PR TITLE
Fix 404: register how-to-use in Docusaurus sidebar

### DIFF
--- a/docs-site/sidebars.js
+++ b/docs-site/sidebars.js
@@ -2,6 +2,7 @@
 const sidebars = {
   docsSidebar: [
     'intro',
+    'how-to-use',
     'architecture',
     'stack',
     'gotchas',


### PR DESCRIPTION
docs.json (Mintlify) was edited to add how-to-use, but the actual deployed site is built via Docusaurus (docusaurus build, confirmed in .github/workflows -- docs.json appears to be a leftover from an earlier Mintlify setup, no longer wired into deployment). Registered how-to-use in sidebars.js's docsSidebar array, matching the pattern of intro/architecture/stack/gotchas/roadmap.