### PR TITLE
Add Mintlify how-to-use.mdx (fixes 404 on mintlify.app)

### DIFF
--- a/docs-site/how-to-use.mdx
+++ b/docs-site/how-to-use.mdx
@@ -1,0 +1,70 @@
+---
+title: "How to Use ARCLUX"
+description: "CLI, daemon, web dashboard, and VS Code extension"
+---
+
+Everything ARCLUX can do today, from a one-off CLI check to always-on background analysis with editor integration.
+
+## 1. One-off CLI commands
+
+Point any command at a local repo path (defaults to .):
+
+```bash
+npx tsx apps/cli/index.ts analyze [path]
+npx tsx apps/cli/index.ts graph [path]
+npx tsx apps/cli/index.ts impact <file> [path]
+npx tsx apps/cli/index.ts doctor [path]
+npx tsx apps/cli/index.ts diagnose [path]
+npx tsx apps/cli/index.ts diff <from> <to> [path]
+npx tsx apps/cli/index.ts verify [path]
+npx tsx apps/cli/index.ts config [path]
+```
+
+diagnose output includes clickable file paths (OSC 8 hyperlinks) in terminals that support it (Termux, iTerm2, VS Code integrated terminal) -- tap/click to open the file directly.
+
+## 2. Always-on daemon
+
+Instead of re-running commands by hand, start ARCLUX as a background process that watches your repo and re-analyzes on every save:
+
+```bash
+npx tsx apps/cli/index.ts daemon --detach
+npx tsx apps/cli/index.ts daemon --status
+npx tsx apps/cli/index.ts daemon --stop
+```
+
+Run without --detach to see live output in the foreground instead.
+
+The daemon exposes a local HTTP+SSE bridge so any editor or terminal can connect:
+
+```bash
+curl http://127.0.0.1:PORT/analysis
+curl http://127.0.0.1:PORT/events
+```
+
+Find the port from ~/.arclux/endpoints/DAEMON_ID.json, written automatically when the daemon starts.
+
+## 3. Web dashboard
+
+```bash
+cd apps/web
+pnpm run dev
+```
+
+Open localhost:3000/ORG/REPO for a given GitHub URL. From the Overview page:
+- Click any file in the Project structure tree to open it
+- The File tab shows syntax-highlighted source (Python, JavaScript, TypeScript today) with inline diagnostic gutter markers -- a colored bar on any line with a finding, click it to expand the message + fix suggestion
+- Dependencies and Impact tabs show what a file needs and what breaks if you change it
+- Click the collapse chevron to give the file panel full width
+
+The Graph page renders the full dependency graph; selecting a node opens a focus panel showing what it needs and what it affects.
+
+## 4. VS Code extension
+
+Connects to a running daemon and surfaces diagnostics in VS Code's Problems panel + a status bar module count.
+
+```bash
+cd apps/vscode-extension
+pnpm install && pnpm build
+```
+
+Then load it via VS Code's Extension Development Host. Requires a daemon already running for the workspace folder.


### PR DESCRIPTION
Discovered two parallel doc sites exist: arclux-os.mintlify.site (Docusaurus, built via docusaurus build, deployed to GitHub Pages, nav in sidebars.js) and arclux-os.mintlify.app (actual Mintlify hosting, reads root-level docs-site/*.mdx files, nav in docs.json). docs.json already had 'how-to-use' registered from an earlier edit, but docs-site/how-to-use.mdx was never created -- only the Docusaurus version (docs-site/docs/how-to-use.md) existed. This adds the missing Mintlify-format file.