### PR TITLE
[docs] Add SKILL.md for AI agent auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dependency graph, impact analysis, and structural convention checking for your c
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions for contributing code
 - [`PROGRES.md`](PROGRES.md) (+ [`progres/`](progres/)) — up-to-date project status: what works, what's a stub, decisions, known bugs/gotchas
 - [`ARCHITECTURE_MAP.md`](ARCHITECTURE_MAP.md) — boundary map for the codebase, read before adding new capabilities
+- [`SKILL.md`](SKILL.md) — auto-discovered by AI coding agents (Claude Code, Cursor, etc); teaches them to use the `arclux` CLI instead of guessing at codebase structure
 - [`CONTEXT.md`](CONTEXT.md) — project brief at a glance: stack, architecture, current state.
 - [`progres/roadmap.md`](progres/roadmap.md) — long-term direction, phased
 

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -16,7 +16,8 @@
           "overview",
           "quickstart",
           "usage",
-          "how-to-use"
+          "how-to-use",
+          "skill"
         ]
       },
       {

--- a/docs-site/skill.mdx
+++ b/docs-site/skill.mdx
@@ -1,0 +1,22 @@
+---
+title: "AI Agent Skill"
+description: "SKILL.md reference for AI coding agents working in this repo"
+---
+
+ARCLUX ships a `SKILL.md` file at the repo root, following the convention used by AI coding agent skill managers (Claude Code, Cursor, and similar tools that auto-discover `SKILL.md`). Any agent working in this repository picks it up automatically -- no manual prompting needed.
+
+<Card title="View SKILL.md on GitHub" icon="github" href="https://github.com/GSF-001/ARCLUX/blob/ARCLUX.main/SKILL.md">
+  Full source, always up to date with the repo
+</Card>
+
+## What it covers
+
+- Which `arclux` command to run for common situations (before editing, after editing, before opening a PR)
+- Environment gotchas specific to this repo (Termux/Webpack, large-repo memory flags, the Python WASM path regression)
+- Boundaries the agent should respect (don't hand-edit progres files, don't add intelligence layers inside core packages)
+
+## Example
+
+```bash
+npx tsx apps/cli/index.ts impact packages/engine/pipeline.ts
+```

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -694,3 +694,9 @@ Added a chevron toggle button (only visible once a file is selected) between the
 **Status:** In Progress
 
 Added packages/parser/javascript/highlightJs.ts using the same walk-up-from-cwd wasm loading pattern as highlightPython.ts, with query merged from official tree-sitter-javascript + tree-sitter-typescript highlights.scm files. Wired into /api/file/route.ts. Still Go/Java/other languages -- tree-sitter-wasms has grammars for go.wasm, java.wasm, etc (confirmed present), but each needs its own highlights.scm sourced from that language's official tree-sitter grammar repo before highlighting can be added -- same process as this PR, just not done yet for those languages. Not yet visually verified in browser for JS/TS either. See PR #395.
+
+## 2026-08-15 — Add docs page for SKILL.md
+
+**Status:** Done
+
+docs-site/skill.mdx added under Getting Started: points to SKILL.md on GitHub, summarizes what it covers, one example command. Registered in docs.json nav.


### PR DESCRIPTION
Adds SKILL.md at repo root, wires docs-site/skill.mdx into nav, links from README.