### PR TITLE
test: fix tests/impact.test.ts — real graph fixtures instead of stale-signature calls

### DIFF
--- a/tests/impact.test.ts
+++ b/tests/impact.test.ts
@@ -1,55 +1,205 @@
-import { describe, it, expect, beforeAll } from "vitest";
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Impact analysis tests against a REAL Repository populated with
+// ModuleInfo fixtures (same makeModule/makeRepository convention as
+// tests/graph.test.ts). Fixes issue #424: the previous version called
+// the impact functions with the stale (moduleId, graph) signature on an
+// empty Repository — all 6 tests crashed with
+// "repository.getModule is not a function" and never exercised the
+// actual impact mechanics.
+//
+// Fixture topology:
+//   chain:   entry.ts -> service.ts -> repository.ts
+//   circular: a.ts -> b.ts -> c.ts -> a.ts
+//   fan-out:  a.ts -> { b.ts, c.ts }
+
+import { describe, it, expect } from "vitest";
 import { Repository } from "../packages/repository/Repository";
 import { calculateAffectedFiles } from "../packages/impact/calculateAffectedFiles";
 import { buildImpactTree } from "../packages/impact/buildImpactTree";
 import { traceConsumers } from "../packages/impact/traceConsumers";
 import { traceDependencies } from "../packages/impact/traceDependencies";
+import type { ModuleInfo, RepositoryMeta, FileInfo } from "../packages/shared/types";
 
-describe("Impact Analysis", () => {
-  let repo: Repository;
+function makeFile(relativePath: string): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "typescript",
+    extension: ".ts",
+    sizeBytes: 100,
+    hash: "fake-hash",
+  };
+}
 
-  beforeAll(() => {
-    repo = new Repository({
-      id: "test-repo",
-      org: "test",
-      name: "repo",
-      rootPath: "/test",
-      defaultBranch: "main",
-      detectedFrameworks: [],
-      packageManager: undefined,
-      analyzedAt: new Date().toISOString(),
-    });
+function makeModule(
+  relativePath: string,
+  overrides: Partial<ModuleInfo> = {}
+): ModuleInfo {
+  return {
+    id: relativePath,
+    file: makeFile(relativePath),
+    exports: [],
+    resolvedReExports: {},
+    importedBy: [],
+    imports: [],
+    resolvedImports: [],
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+    ...overrides,
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "impact-test",
+    org: "test-org",
+    name: "impact-test",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+/** entry.ts -> service.ts -> repository.ts (one consumer chain) */
+function chainRepository(): Repository {
+  return makeRepository([
+    makeModule("entry.ts", { imports: ["service.ts"] }),
+    makeModule("service.ts", {
+      imports: ["repository.ts"],
+      importedBy: ["entry.ts"],
+    }),
+    makeModule("repository.ts", { importedBy: ["service.ts"] }),
+  ]);
+}
+
+/** a.ts -> b.ts -> c.ts -> a.ts (import cycle back to the start) */
+function circularRepository(): Repository {
+  return makeRepository([
+    makeModule("a.ts", { imports: ["b.ts"], importedBy: ["c.ts"] }),
+    makeModule("b.ts", { imports: ["c.ts"], importedBy: ["a.ts"] }),
+    makeModule("c.ts", { imports: ["a.ts"], importedBy: ["b.ts"] }),
+  ]);
+}
+
+/** a.ts -> b.ts and a.ts -> c.ts (one importer, two dependencies) */
+function fanOutRepository(): Repository {
+  return makeRepository([
+    makeModule("a.ts", { imports: ["b.ts", "c.ts"] }),
+    makeModule("b.ts", { importedBy: ["a.ts"] }),
+    makeModule("c.ts", { importedBy: ["a.ts"] }),
+  ]);
+}
+
+describe("Impact Analysis — traceConsumers", () => {
+  it("returns direct and transitive consumers along the chain", () => {
+    const trace = traceConsumers(chainRepository(), "repository.ts");
+    expect(trace.notFound).toBe(false);
+    expect(trace.direct).toEqual(["service.ts"]);
+    // BFS order: service (direct) first, then entry.
+    expect(trace.transitive).toEqual(["service.ts", "entry.ts"]);
   });
 
-  it("calculateAffectedFiles should return Set<string>", () => {
-    const affected = calculateAffectedFiles("test.ts", repo.graph);
-    expect(affected instanceof Set).toBe(true);
+  it("returns notFound for a module that does not exist", () => {
+    const trace = traceConsumers(chainRepository(), "ghost.ts");
+    expect(trace).toEqual({ direct: [], transitive: [], notFound: true });
   });
 
-  it("calculateAffectedFiles should handle non-existent module gracefully", () => {
-    const affected = calculateAffectedFiles("nonexistent.ts", repo.graph);
-    expect(affected instanceof Set).toBe(true);
+  it("terminates on circular import chains", () => {
+    const trace = traceConsumers(circularRepository(), "a.ts");
+    // c.ts imports a.ts; b.ts imports c.ts; a.ts imports b.ts (visited).
+    expect(trace.direct).toEqual(["c.ts"]);
+    expect(trace.transitive).toEqual(["c.ts", "b.ts"]);
+  });
+});
+
+describe("Impact Analysis — traceDependencies", () => {
+  it("returns direct and transitive dependencies along the chain", () => {
+    const trace = traceDependencies(chainRepository(), "entry.ts");
+    expect(trace.notFound).toBe(false);
+    expect(trace.direct).toEqual(["service.ts"]);
+    expect(trace.transitive).toEqual(["service.ts", "repository.ts"]);
   });
 
-  it("buildImpactTree should return tree structure", () => {
-    const tree = buildImpactTree("test.ts", repo.graph);
-    expect(tree).toHaveProperty("moduleId");
-    expect(tree).toHaveProperty("affected");
+  it("returns all fan-out targets for one importer", () => {
+    const trace = traceDependencies(fanOutRepository(), "a.ts");
+    expect(trace.direct).toEqual(["b.ts", "c.ts"]);
+    expect(trace.transitive).toEqual(["b.ts", "c.ts"]);
   });
 
-  it("traceConsumers should return array of consumers", () => {
-    const consumers = traceConsumers("test.ts", repo.graph);
-    expect(Array.isArray(consumers)).toBe(true);
+  it("returns notFound for a module that does not exist", () => {
+    const trace = traceDependencies(chainRepository(), "ghost.ts");
+    expect(trace).toEqual({ direct: [], transitive: [], notFound: true });
+  });
+});
+
+describe("Impact Analysis — calculateAffectedFiles", () => {
+  it("reports consumers of the changed module with correct distances", () => {
+    // Change repository.ts -> service.ts (distance 1) and entry.ts (distance 2).
+    const impact = calculateAffectedFiles(chainRepository(), "repository.ts");
+    expect(impact.notFound).toBe(false);
+    expect(impact.changedModuleId).toBe("repository.ts");
+    expect(impact.totalAffected).toBe(2);
+    expect(impact.affectedFiles).toEqual([
+      { moduleId: "service.ts", filePath: "service.ts", distance: 1 },
+      { moduleId: "entry.ts", filePath: "entry.ts", distance: 2 },
+    ]);
   });
 
-  it("traceDependencies should return array of dependencies", () => {
-    const deps = traceDependencies("test.ts", repo.graph);
-    expect(Array.isArray(deps)).toBe(true);
+  it("reports the single direct consumer in a fan-out", () => {
+    const impact = calculateAffectedFiles(fanOutRepository(), "b.ts");
+    expect(impact.notFound).toBe(false);
+    expect(impact.totalAffected).toBe(1);
+    expect(impact.affectedFiles).toEqual([
+      { moduleId: "a.ts", filePath: "a.ts", distance: 1 },
+    ]);
   });
 
-  it("buildImpactTree should guard against circular dependencies", () => {
-    expect(() => {
-      buildImpactTree("circular.ts", repo.graph);
-    }).not.toThrow();
+  it("returns empty result with notFound for a missing module", () => {
+    const impact = calculateAffectedFiles(chainRepository(), "ghost.ts");
+    expect(impact.notFound).toBe(true);
+    expect(impact.totalAffected).toBe(0);
+    expect(impact.affectedFiles).toEqual([]);
+  });
+});
+
+describe("Impact Analysis — buildImpactTree", () => {
+  it("builds a nested tree of consumers", () => {
+    const tree = buildImpactTree(chainRepository(), "repository.ts");
+    expect(tree).not.toBeNull();
+    expect(tree!.moduleId).toBe("repository.ts");
+    expect(tree!.children.map((n) => n.moduleId)).toEqual(["service.ts"]);
+    const service = tree!.children[0];
+    expect(service.children.map((n) => n.moduleId)).toEqual(["entry.ts"]);
+  });
+
+  it("does not recurse forever on circular import chains", () => {
+    const tree = buildImpactTree(circularRepository(), "a.ts");
+    expect(tree).not.toBeNull();
+    expect(tree!.moduleId).toBe("a.ts");
+    // The tree walks UP consumers: a.ts is imported by c.ts, c.ts by b.ts,
+    // and b.ts's consumer a.ts is an ancestor — the cycle must be cut there.
+    expect(tree!.children.map((n) => n.moduleId)).toEqual(["c.ts"]);
+    const c = tree!.children[0];
+    expect(c.children.map((n) => n.moduleId)).toEqual(["b.ts"]);
+    expect(c.children[0].children).toEqual([]);
+  });
+
+  it("returns null for a module that does not exist", () => {
+    expect(buildImpactTree(chainRepository(), "ghost.ts")).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #424

## Problem

`tests/impact.test.ts` failed 6/6 (`repository.getModule is not a function`) because it called the impact functions with the stale `(moduleId, graph)` signature while the current API is `(repository, moduleId)`. The Repository was also empty and has no `graph` property. CI (`pnpm run test`) was red on ARCLUX.main.

## Fix

Rewrote the test file using the makeModule/makeRepository convention from tests/graph.test.ts and asserts real impact mechanics:

- **chain** (entry.ts -> service.ts -> repository.ts): change repository -> expect service (dist 1) and entry (dist 2) affected; traceConsumers/traceDependencies direct+transitive
- **circular** (a -> b -> c -> a): cycle guard — no infinite loop, cycle cut in buildImpactTree
- **fan-out** (a -> {b, c}): all targets returned
- **nonexistent module**: notFound behavior across all four functions

Local: 12/12 tests pass. Full suite 331/331 + typecheck + lint green.

Refs: progres/bugs.md 2026-08-15 entry (status was Not Started; logged diagnosis there was inaccurate — real cause is the stale signature).