### PR TITLE
test: pipeline tests — deterministic fixture + portable temp path (ThreatCrush finding)

### DIFF
--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -376,6 +376,6 @@ Contributor commit added apps/cli/commands/{edit,logs,open,verify}.ts using expo
 
 ## 2026-08-15 — CI failing: tests/impact.test.ts all 6 tests fail, repository.getModule is not a function
 
-**Status:** Not Started
+**Status:** Fixed (PR #426, closes issue #424)
 
-Test file uses a mock/plain object for repository that doesn't implement Repository class methods (getModule, etc). Needs fixing test setup to use real Repository instance or a proper mock with getModule. Not yet fixed.
+Original diagnosis ("mock/plain object doesn't implement getModule") was inaccurate. Root cause: impact functions were refactored from `(moduleId, graph)` to `(repository, moduleId)` and the test file still used the old signature on an empty Repository (which also has no `graph` property — graph is built separately by buildDependencyGraph). Fix: rewrote tests/impact.test.ts with real ModuleInfo fixtures (makeModule/makeRepository convention from tests/graph.test.ts) covering chain (entry->service->repository), circular (a->b->c->a, cycle guard), fan-out (a->{b,c}) and notFound behavior — 12 tests, all green. Related: tests/pipeline.test.ts fixed in PR #427 (issue #425): `/tmp/test` ThreatCrush finding was a false positive (path never touched — throws before I/O), replaced with portable os.tmpdir() path; weak `moduleCount >= 0` assertions replaced with deterministic fixture (tests/fixtures/pipeline-basic/, entry->service->repository) asserting exact moduleCount/edges/scanSummary (~1.8s -> ~22ms).

--- a/tests/fixtures/pipeline-basic/entry.ts
+++ b/tests/fixtures/pipeline-basic/entry.ts
@@ -1,0 +1,7 @@
+// Fixture for tests/pipeline.test.ts — deterministic import chain:
+// entry.ts -> service.ts -> repository.ts
+import { getService } from "./service";
+
+export function main(): string {
+  return getService();
+}

--- a/tests/fixtures/pipeline-basic/repository.ts
+++ b/tests/fixtures/pipeline-basic/repository.ts
@@ -1,0 +1,5 @@
+// Fixture for tests/pipeline.test.ts — deterministic import chain:
+// entry.ts -> service.ts -> repository.ts (sink node, imports nothing)
+export function getRepository(): string {
+  return "data";
+}

--- a/tests/fixtures/pipeline-basic/service.ts
+++ b/tests/fixtures/pipeline-basic/service.ts
@@ -1,0 +1,7 @@
+// Fixture for tests/pipeline.test.ts — deterministic import chain:
+// entry.ts -> service.ts -> repository.ts
+import { getRepository } from "./repository";
+
+export function getService(): string {
+  return getRepository();
+}

--- a/tests/impact.test.ts
+++ b/tests/impact.test.ts
@@ -1,55 +1,205 @@
-import { describe, it, expect, beforeAll } from "vitest";
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Impact analysis tests against a REAL Repository populated with
+// ModuleInfo fixtures (same makeModule/makeRepository convention as
+// tests/graph.test.ts). Fixes issue #424: the previous version called
+// the impact functions with the stale (moduleId, graph) signature on an
+// empty Repository — all 6 tests crashed with
+// "repository.getModule is not a function" and never exercised the
+// actual impact mechanics.
+//
+// Fixture topology:
+//   chain:   entry.ts -> service.ts -> repository.ts
+//   circular: a.ts -> b.ts -> c.ts -> a.ts
+//   fan-out:  a.ts -> { b.ts, c.ts }
+
+import { describe, it, expect } from "vitest";
 import { Repository } from "../packages/repository/Repository";
 import { calculateAffectedFiles } from "../packages/impact/calculateAffectedFiles";
 import { buildImpactTree } from "../packages/impact/buildImpactTree";
 import { traceConsumers } from "../packages/impact/traceConsumers";
 import { traceDependencies } from "../packages/impact/traceDependencies";
+import type { ModuleInfo, RepositoryMeta, FileInfo } from "../packages/shared/types";
 
-describe("Impact Analysis", () => {
-  let repo: Repository;
+function makeFile(relativePath: string): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "typescript",
+    extension: ".ts",
+    sizeBytes: 100,
+    hash: "fake-hash",
+  };
+}
 
-  beforeAll(() => {
-    repo = new Repository({
-      id: "test-repo",
-      org: "test",
-      name: "repo",
-      rootPath: "/test",
-      defaultBranch: "main",
-      detectedFrameworks: [],
-      packageManager: undefined,
-      analyzedAt: new Date().toISOString(),
-    });
+function makeModule(
+  relativePath: string,
+  overrides: Partial<ModuleInfo> = {}
+): ModuleInfo {
+  return {
+    id: relativePath,
+    file: makeFile(relativePath),
+    exports: [],
+    resolvedReExports: {},
+    importedBy: [],
+    imports: [],
+    resolvedImports: [],
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+    ...overrides,
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "impact-test",
+    org: "test-org",
+    name: "impact-test",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+/** entry.ts -> service.ts -> repository.ts (one consumer chain) */
+function chainRepository(): Repository {
+  return makeRepository([
+    makeModule("entry.ts", { imports: ["service.ts"] }),
+    makeModule("service.ts", {
+      imports: ["repository.ts"],
+      importedBy: ["entry.ts"],
+    }),
+    makeModule("repository.ts", { importedBy: ["service.ts"] }),
+  ]);
+}
+
+/** a.ts -> b.ts -> c.ts -> a.ts (import cycle back to the start) */
+function circularRepository(): Repository {
+  return makeRepository([
+    makeModule("a.ts", { imports: ["b.ts"], importedBy: ["c.ts"] }),
+    makeModule("b.ts", { imports: ["c.ts"], importedBy: ["a.ts"] }),
+    makeModule("c.ts", { imports: ["a.ts"], importedBy: ["b.ts"] }),
+  ]);
+}
+
+/** a.ts -> b.ts and a.ts -> c.ts (one importer, two dependencies) */
+function fanOutRepository(): Repository {
+  return makeRepository([
+    makeModule("a.ts", { imports: ["b.ts", "c.ts"] }),
+    makeModule("b.ts", { importedBy: ["a.ts"] }),
+    makeModule("c.ts", { importedBy: ["a.ts"] }),
+  ]);
+}
+
+describe("Impact Analysis — traceConsumers", () => {
+  it("returns direct and transitive consumers along the chain", () => {
+    const trace = traceConsumers(chainRepository(), "repository.ts");
+    expect(trace.notFound).toBe(false);
+    expect(trace.direct).toEqual(["service.ts"]);
+    // BFS order: service (direct) first, then entry.
+    expect(trace.transitive).toEqual(["service.ts", "entry.ts"]);
   });
 
-  it("calculateAffectedFiles should return Set<string>", () => {
-    const affected = calculateAffectedFiles("test.ts", repo.graph);
-    expect(affected instanceof Set).toBe(true);
+  it("returns notFound for a module that does not exist", () => {
+    const trace = traceConsumers(chainRepository(), "ghost.ts");
+    expect(trace).toEqual({ direct: [], transitive: [], notFound: true });
   });
 
-  it("calculateAffectedFiles should handle non-existent module gracefully", () => {
-    const affected = calculateAffectedFiles("nonexistent.ts", repo.graph);
-    expect(affected instanceof Set).toBe(true);
+  it("terminates on circular import chains", () => {
+    const trace = traceConsumers(circularRepository(), "a.ts");
+    // c.ts imports a.ts; b.ts imports c.ts; a.ts imports b.ts (visited).
+    expect(trace.direct).toEqual(["c.ts"]);
+    expect(trace.transitive).toEqual(["c.ts", "b.ts"]);
+  });
+});
+
+describe("Impact Analysis — traceDependencies", () => {
+  it("returns direct and transitive dependencies along the chain", () => {
+    const trace = traceDependencies(chainRepository(), "entry.ts");
+    expect(trace.notFound).toBe(false);
+    expect(trace.direct).toEqual(["service.ts"]);
+    expect(trace.transitive).toEqual(["service.ts", "repository.ts"]);
   });
 
-  it("buildImpactTree should return tree structure", () => {
-    const tree = buildImpactTree("test.ts", repo.graph);
-    expect(tree).toHaveProperty("moduleId");
-    expect(tree).toHaveProperty("affected");
+  it("returns all fan-out targets for one importer", () => {
+    const trace = traceDependencies(fanOutRepository(), "a.ts");
+    expect(trace.direct).toEqual(["b.ts", "c.ts"]);
+    expect(trace.transitive).toEqual(["b.ts", "c.ts"]);
   });
 
-  it("traceConsumers should return array of consumers", () => {
-    const consumers = traceConsumers("test.ts", repo.graph);
-    expect(Array.isArray(consumers)).toBe(true);
+  it("returns notFound for a module that does not exist", () => {
+    const trace = traceDependencies(chainRepository(), "ghost.ts");
+    expect(trace).toEqual({ direct: [], transitive: [], notFound: true });
+  });
+});
+
+describe("Impact Analysis — calculateAffectedFiles", () => {
+  it("reports consumers of the changed module with correct distances", () => {
+    // Change repository.ts -> service.ts (distance 1) and entry.ts (distance 2).
+    const impact = calculateAffectedFiles(chainRepository(), "repository.ts");
+    expect(impact.notFound).toBe(false);
+    expect(impact.changedModuleId).toBe("repository.ts");
+    expect(impact.totalAffected).toBe(2);
+    expect(impact.affectedFiles).toEqual([
+      { moduleId: "service.ts", filePath: "service.ts", distance: 1 },
+      { moduleId: "entry.ts", filePath: "entry.ts", distance: 2 },
+    ]);
   });
 
-  it("traceDependencies should return array of dependencies", () => {
-    const deps = traceDependencies("test.ts", repo.graph);
-    expect(Array.isArray(deps)).toBe(true);
+  it("reports the single direct consumer in a fan-out", () => {
+    const impact = calculateAffectedFiles(fanOutRepository(), "b.ts");
+    expect(impact.notFound).toBe(false);
+    expect(impact.totalAffected).toBe(1);
+    expect(impact.affectedFiles).toEqual([
+      { moduleId: "a.ts", filePath: "a.ts", distance: 1 },
+    ]);
   });
 
-  it("buildImpactTree should guard against circular dependencies", () => {
-    expect(() => {
-      buildImpactTree("circular.ts", repo.graph);
-    }).not.toThrow();
+  it("returns empty result with notFound for a missing module", () => {
+    const impact = calculateAffectedFiles(chainRepository(), "ghost.ts");
+    expect(impact.notFound).toBe(true);
+    expect(impact.totalAffected).toBe(0);
+    expect(impact.affectedFiles).toEqual([]);
+  });
+});
+
+describe("Impact Analysis — buildImpactTree", () => {
+  it("builds a nested tree of consumers", () => {
+    const tree = buildImpactTree(chainRepository(), "repository.ts");
+    expect(tree).not.toBeNull();
+    expect(tree!.moduleId).toBe("repository.ts");
+    expect(tree!.children.map((n) => n.moduleId)).toEqual(["service.ts"]);
+    const service = tree!.children[0];
+    expect(service.children.map((n) => n.moduleId)).toEqual(["entry.ts"]);
+  });
+
+  it("does not recurse forever on circular import chains", () => {
+    const tree = buildImpactTree(circularRepository(), "a.ts");
+    expect(tree).not.toBeNull();
+    expect(tree!.moduleId).toBe("a.ts");
+    // The tree walks UP consumers: a.ts is imported by c.ts, c.ts by b.ts,
+    // and b.ts's consumer a.ts is an ancestor — the cycle must be cut there.
+    expect(tree!.children.map((n) => n.moduleId)).toEqual(["c.ts"]);
+    const c = tree!.children[0];
+    expect(c.children.map((n) => n.moduleId)).toEqual(["b.ts"]);
+    expect(c.children[0].children).toEqual([]);
+  });
+
+  it("returns null for a module that does not exist", () => {
+    expect(buildImpactTree(chainRepository(), "ghost.ts")).toBeNull();
   });
 });

--- a/tests/pipeline.test.ts
+++ b/tests/pipeline.test.ts
@@ -1,77 +1,87 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import path from "path";
-import { analyzeRepository } from "../packages/engine/pipeline";
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Pipeline tests against a SMALL deterministic fixture
+// (tests/fixtures/pipeline-basic: entry.ts -> service.ts -> repository.ts)
+// instead of the whole repo. Fixes issue #425:
+//   - the previous hardcoded temp fixture path (ThreatCrush MEDIUM
+//     insecure-temp-file finding) is replaced with a portable os.tmpdir()
+//     path that is never created — analyzeRepository throws on the
+//     both-args case BEFORE any filesystem access.
+//   - `moduleCount >= 0` + shape-only assertions replaced with concrete
+//     facts: exact module count, scan accounting, dependency edges.
 
-describe("Pipeline: analyzeRepository", () => {
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import os from "node:os";
+import { analyzeRepository, type AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "pipeline-basic");
+
+describe("Pipeline: analyzeRepository — argument validation", () => {
   it("should throw when both repoUrl and localPath are provided", async () => {
-    try {
-      await analyzeRepository({
+    // The path is never created or touched: analyzeRepository validates the
+    // options and throws before any clone/scan I/O. os.tmpdir() is used (not
+    // a hardcoded temp path) so the intent is portable and ThreatCrush-clean.
+    const unusedLocalPath = path.join(os.tmpdir(), "arclux-test-never-created");
+    await expect(
+      analyzeRepository({
         repoUrl: "https://github.com/test/repo",
-        localPath: "/tmp/test",
-      });
-      expect.fail("Should have thrown");
-    } catch (err) {
-      expect(err).toBeDefined();
-    }
+        localPath: unusedLocalPath,
+      })
+    ).rejects.toThrow("provide either repoUrl or localPath");
   });
 
   it("should throw when neither repoUrl nor localPath are provided", async () => {
-    try {
-      await analyzeRepository({});
-      expect.fail("Should have thrown");
-    } catch (err) {
-      expect(err).toBeDefined();
+    await expect(analyzeRepository({})).rejects.toThrow("repoUrl or localPath is required");
+  });
+});
+
+describe("Pipeline: analyzeRepository — deterministic fixture", () => {
+  let result: AnalyzeRepositoryResult;
+
+  beforeAll(async () => {
+    result = await analyzeRepository({ localPath: FIXTURE_PATH });
+  }, 30_000);
+
+  it("indexes exactly the 3 fixture modules", () => {
+    expect(result.moduleCount).toBe(3);
+    const ids = result.repository.getAllModules().map((m) => m.id).sort();
+    expect(ids).toEqual(["entry.ts", "repository.ts", "service.ts"]);
+  });
+
+  it("records accurate scan accounting", () => {
+    expect(result.scanSummary.filesScanned).toBe(3);
+    expect(result.scanSummary.filesParsed).toBe(3);
+    expect(result.scanSummary.filesSkippedNoParser).toBe(0);
+    expect(result.scanSummary.skippedByExtension).toEqual({});
+  });
+
+  it("builds the expected dependency edges (entry -> service -> repository)", () => {
+    const edges = result.graph.edges.map((e) => `${e.source}->${e.target}`).sort();
+    expect(edges).toEqual(["entry.ts->service.ts", "service.ts->repository.ts"]);
+    // Every edge target is a node that exists in the graph.
+    const nodeIds = new Set(result.graph.nodes.map((n) => n.id));
+    for (const edge of result.graph.edges) {
+      expect(nodeIds.has(edge.source)).toBe(true);
+      expect(nodeIds.has(edge.target)).toBe(true);
     }
   });
 
-  it("should return AnalyzeRepositoryResult structure", async () => {
-    const result = await analyzeRepository({
-      localPath: ".",
-    });
+  it("exposes repository meta derived from the fixture path", () => {
+    expect(result.meta.rootPath).toBe(path.resolve(FIXTURE_PATH));
+    expect(result.meta.name).toBe("pipeline-basic");
+  });
 
-    expect(result).toHaveProperty("meta");
-    expect(result).toHaveProperty("moduleCount");
+  it("returns the AnalyzeRepositoryResult shape with an empty dependency list (no manifests)", () => {
     expect(result).toHaveProperty("graph");
-    expect(result).toHaveProperty("scanSummary");
     expect(result).toHaveProperty("repository");
-    expect(result).toHaveProperty("dependencies");
-  }, 30000);
-
-  it("should have valid scanSummary structure", async () => {
-    const result = await analyzeRepository({
-      localPath: ".",
-    });
-
-    expect(result.scanSummary).toHaveProperty("filesScanned");
-    expect(result.scanSummary).toHaveProperty("filesParsed");
-    expect(result.scanSummary).toHaveProperty("filesSkippedNoParser");
-    expect(typeof result.scanSummary.filesScanned).toBe("number");
-  });
-
-  it("should have valid meta structure", async () => {
-    const result = await analyzeRepository({
-      localPath: ".",
-    });
-
-    expect(result.meta).toHaveProperty("org");
-    expect(result.meta).toHaveProperty("name");
-    expect(result.meta).toHaveProperty("rootPath");
-    expect(result.meta).toHaveProperty("analyzedAt");
-  });
-
-  it("should have non-negative moduleCount", async () => {
-    const result = await analyzeRepository({
-      localPath: ".",
-    });
-
-    expect(result.moduleCount).toBeGreaterThanOrEqual(0);
-  });
-
-  it("should have dependencies array", async () => {
-    const result = await analyzeRepository({
-      localPath: ".",
-    });
-
     expect(Array.isArray(result.dependencies)).toBe(true);
+    expect(result.dependencies).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #425

## Finding 1 — ThreatCrush MEDIUM insecure-temp-file (tests/pipeline.test.ts:10)

`/tmp/test` was flagged. Verified: it is a **false positive** — `analyzeRepository` throws on the both-args case (packages/engine/pipeline.ts:143) before any filesystem access, so the path is never created. Replaced it with a portable `path.join(os.tmpdir(), ...)` path with a comment documenting why it is never touched.

## Finding 2 — assertions proved nothing

Old tests ran `analyzeRepository({ localPath: "." })` (the whole repo, ~1.8s for 5 scans) and asserted `moduleCount >= 0` + shape checks.

New: deterministic fixture `tests/fixtures/pipeline-basic/` (entry.ts -> service.ts -> repository.ts) asserting concrete facts:

- exact moduleCount === 3 and module ids
- scanSummary: filesScanned === 3, filesParsed === 3, skipped === 0
- exact graph edges entry->service and service->repository, every edge endpoint exists as a node
- meta derived from the fixture path

Suite time for this file: ~1.8s -> ~22ms. Note: this branch is stacked on fix/impact-tests-fixtures (#426) so CI is green for both PRs independently.

Local: 7/7 tests pass. Full suite 331/331 + typecheck + lint green.