### PR TITLE
fix: resolve Python package-relative imports into the graph (issue #429)

### DIFF
--- a/packages/graph/resolvePath.ts
+++ b/packages/graph/resolvePath.ts
@@ -57,6 +57,35 @@ export function resolvePath(
   // relative form "." / ".." / "..pkg" (from a `from . import x` /
   // `from ..pkg import x` statement — see parsePython.ts).
   if (importSource.startsWith(".") || importSource.startsWith("/")) {
+    // Python package-relative imports use dots WITHOUT a slash (".x",
+    // "..utils", "...pkg.sub", bare "."/"..") — posix.normalize can't
+    // touch them: ".x" is a single segment, not a "./" directory step, so
+    // normalize("pkg/..utils") stays "pkg/..utils" and never matches a
+    // file. JS/TS always writes a slash ("./x", "../x"), so
+    // dots-without-slash are unambiguous Python syntax.
+    //
+    // Python semantics: N dots = N levels up from the importing MODULE,
+    // i.e. (N-1) levels up from its directory, then the (dotted) suffix.
+    // `from ..utils import x` in pkg/mod.py -> up 1 from "pkg" -> "utils".
+    const leadingDots = /^\.+/.exec(importSource);
+    if (leadingDots && importSource[leadingDots[0].length] !== "/") {
+      // `..utils` — a single segment, Python-style. `../x` has a slash
+      // right after the dots, so it must fall through to the JS branch
+      // below (a plain `/^\.+(?!\/)/` lookahead is not enough here —
+      // regex backtracking matches `../x` as one dot + `(?!\/)` seeing
+      // `.` and wrongly classifies it as Python).
+      const dotCount = leadingDots[0].length;
+      const suffix = importSource.slice(dotCount).replace(/\./g, "/");
+      let targetDir = importerDir;
+      for (let i = 1; i < dotCount; i++) {
+        targetDir = posix.dirname(targetDir);
+      }
+      const rawTarget = posix.normalize(posix.join(targetDir, suffix));
+      const resolved = tryResolveInternal(rawTarget, knownFiles);
+      if (resolved) return resolved;
+      return { type: "external", packageName: importSource };
+    }
+
     const rawTarget = posix.normalize(posix.join(importerDir, importSource));
     const resolved = tryResolveInternal(rawTarget, knownFiles);
     if (resolved) return resolved;

--- a/tests/fixtures/python-basic/app.py
+++ b/tests/fixtures/python-basic/app.py
@@ -1,0 +1,10 @@
+# Fixture for tests/python-e2e.test.ts (issue #429).
+# Import chain exercising all three Python relative-import forms:
+#   app.py:            from pkg.service import get_service   (dotted absolute)
+#   pkg/service.py:    from .repository import get_repo      (single-dot relative)
+#   pkg/repository.py: from ..utils import helper            (two-dot relative, up one level)
+from pkg.service import get_service
+
+
+def main() -> str:
+    return get_service()

--- a/tests/fixtures/python-basic/pkg/__init__.py
+++ b/tests/fixtures/python-basic/pkg/__init__.py
@@ -1,0 +1,2 @@
+# Fixture for tests/python-e2e.test.ts (issue #429).
+# Package marker for pkg/ — makes `from .service import` inside pkg/ valid.

--- a/tests/fixtures/python-basic/pkg/repository.py
+++ b/tests/fixtures/python-basic/pkg/repository.py
@@ -1,0 +1,8 @@
+# Fixture for tests/python-e2e.test.ts (issue #429).
+# Two-dot relative import: `from ..utils import helper` — one level up
+# from pkg/ to the repo root, then utils.
+from ..utils import helper
+
+
+def get_repo() -> str:
+    return helper()

--- a/tests/fixtures/python-basic/pkg/service.py
+++ b/tests/fixtures/python-basic/pkg/service.py
@@ -1,0 +1,7 @@
+# Fixture for tests/python-e2e.test.ts (issue #429).
+# Single-dot relative import: `from .repository import get_repo`.
+from .repository import get_repo
+
+
+def get_service() -> str:
+    return get_repo()

--- a/tests/fixtures/python-basic/utils.py
+++ b/tests/fixtures/python-basic/utils.py
@@ -1,0 +1,4 @@
+# Fixture for tests/python-e2e.test.ts (issue #429).
+# Target of pkg/service.py's `from .repository import get_repo`.
+def helper() -> str:
+    return "help"

--- a/tests/python-e2e.test.ts
+++ b/tests/python-e2e.test.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// End-to-end test for the Python parser through the REAL pipeline
+// (ParserRegistry -> buildIndex -> Repository -> buildDependencyGraph),
+// fixing issue #429. The parser previously had only inline-source unit
+// tests — never a full analyzeRepository run — and Python relative
+// imports (`from .x`, `from ..x`, bare `.`/`..`) silently resolved as
+// external, dropping every edge.
+//
+// Fixture (tests/fixtures/python-basic/):
+//   app.py            -> pkg/service.py      (dotted absolute: pkg.service)
+//   pkg/service.py    -> pkg/repository.py   (single-dot:   from .repository)
+//   pkg/repository.py -> utils.py            (two-dot:      from ..utils)
+
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import { analyzeRepository, type AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "python-basic");
+
+describe("Python e2e: analyzeRepository on a relative-import fixture (issue #429)", () => {
+  let result: AnalyzeRepositoryResult;
+
+  beforeAll(async () => {
+    result = await analyzeRepository({ localPath: FIXTURE_PATH });
+  }, 30_000);
+
+  it("indexes all 5 fixture modules", () => {
+    expect(result.moduleCount).toBe(5);
+    const ids = result.repository.getAllModules().map((m) => m.id).sort();
+    expect(ids).toEqual([
+      "app.py",
+      "pkg/__init__.py",
+      "pkg/repository.py",
+      "pkg/service.py",
+      "utils.py",
+    ]);
+    expect(result.scanSummary.filesScanned).toBe(5);
+    expect(result.scanSummary.filesParsed).toBe(5);
+    expect(result.scanSummary.filesSkippedNoParser).toBe(0);
+  });
+
+  it("resolves all relative-import forms into dependency edges", () => {
+    const edges = result.graph.edges.map((e) => `${e.source}->${e.target}`).sort();
+    expect(edges).toEqual([
+      "app.py->pkg/service.py",
+      "pkg/repository.py->utils.py",
+      "pkg/service.py->pkg/repository.py",
+    ]);
+  });
+
+  it("records the resolved imports on the modules themselves", () => {
+    const byId = new Map(result.repository.getAllModules().map((m) => [m.id, m]));
+    expect(byId.get("pkg/service.py")?.imports).toEqual(["pkg/repository.py"]);
+    expect(byId.get("pkg/repository.py")?.imports).toEqual(["utils.py"]);
+    expect(byId.get("app.py")?.imports).toEqual(["pkg/service.py"]);
+  });
+});

--- a/tests/resolvePath.test.ts
+++ b/tests/resolvePath.test.ts
@@ -1,0 +1,114 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unit tests for packages/graph/resolvePath.ts. Covers the Python
+// package-relative forms (issue #429): dots WITHOUT a slash (".x",
+// "..utils", bare "."/".."), which posix.normalize cannot handle — plus
+// JS/TS regression guards ("./x", "../x") to prove the JS branch is
+// untouched, and the existing Python dotted-absolute path.
+
+import { describe, it, expect } from "vitest";
+import { resolvePath } from "../packages/graph/resolvePath";
+
+function knownFiles(...files: string[]): Set<string> {
+  return new Set(files);
+}
+
+describe("resolvePath — Python package-relative imports (issue #429)", () => {
+  it("resolves `from .sub import` as a sibling module", () => {
+    const files = knownFiles("pkg/service.py", "pkg/repository.py");
+    expect(resolvePath("pkg/service.py", ".repository", files)).toEqual({
+      type: "internal",
+      moduleId: "pkg/repository.py",
+    });
+  });
+
+  it("resolves `from ..module import` one package level up", () => {
+    const files = knownFiles("utils.py", "pkg/repository.py");
+    expect(resolvePath("pkg/repository.py", "..utils", files)).toEqual({
+      type: "internal",
+      moduleId: "utils.py",
+    });
+  });
+
+  it("resolves `from ...pkg.sub import` two package levels up", () => {
+    const files = knownFiles("a/pkg/utils.py", "a/b/c/mod.py");
+    expect(resolvePath("a/b/c/mod.py", "...pkg.utils", files)).toEqual({
+      type: "internal",
+      moduleId: "a/pkg/utils.py",
+    });
+  });
+
+  it("resolves `from ..pkg.sub import` to the parent package's subtree", () => {
+    const files = knownFiles("a/pkg/utils.py", "a/b/mod.py");
+    expect(resolvePath("a/b/mod.py", "..pkg.utils", files)).toEqual({
+      type: "internal",
+      moduleId: "a/pkg/utils.py",
+    });
+  });
+
+  it("resolves bare `from . import` to the package __init__", () => {
+    const files = knownFiles("pkg/__init__.py", "pkg/mod.py");
+    expect(resolvePath("pkg/mod.py", ".", files)).toEqual({
+      type: "internal",
+      moduleId: "pkg/__init__.py",
+    });
+  });
+
+  it("resolves bare `from .. import` to the parent package __init__", () => {
+    const files = knownFiles("__init__.py", "pkg/mod.py");
+    expect(resolvePath("pkg/mod.py", "..", files)).toEqual({
+      type: "internal",
+      moduleId: "__init__.py",
+    });
+  });
+
+  it("returns external when the relative target does not exist", () => {
+    const files = knownFiles("pkg/mod.py");
+    expect(resolvePath("pkg/mod.py", "..missing", files)).toEqual({
+      type: "external",
+      packageName: "..missing",
+    });
+  });
+});
+
+describe("resolvePath — JS/TS relative imports (regression guards)", () => {
+  it("still resolves `./x` exactly as before", () => {
+    const files = knownFiles("pkg/service.ts", "pkg/entry.ts");
+    expect(resolvePath("pkg/entry.ts", "./service", files)).toEqual({
+      type: "internal",
+      moduleId: "pkg/service.ts",
+    });
+  });
+
+  it("still resolves `../x` exactly as before", () => {
+    const files = knownFiles("lib/util.ts", "pkg/entry.ts");
+    expect(resolvePath("pkg/entry.ts", "../lib/util", files)).toEqual({
+      type: "internal",
+      moduleId: "lib/util.ts",
+    });
+  });
+
+  it("still treats bare specifiers as external packages", () => {
+    const files = knownFiles("pkg/entry.ts");
+    expect(resolvePath("pkg/entry.ts", "react", files)).toEqual({
+      type: "external",
+      packageName: "react",
+    });
+  });
+});
+
+describe("resolvePath — Python dotted absolute (existing behavior guard)", () => {
+  it("resolves `pkg.service` from a root-level file", () => {
+    const files = knownFiles("pkg/service.py", "app.py");
+    expect(resolvePath("app.py", "pkg.service", files)).toEqual({
+      type: "internal",
+      moduleId: "pkg/service.py",
+    });
+  });
+});


### PR DESCRIPTION
Closes #429

## Problem

Python files using **relative** imports produced zero dependency edges — every `from .x`, `from ..x`, bare `.`/`..` import silently resolved as `external`:

```
pkg/service.py:    from .repository import get_repo  -> external  ❌ (should be pkg/repository.py)
pkg/repository.py: from ..utils import helper        -> external  ❌ (should be utils.py)
pkg/__init__.py:   from .service import get_service  -> external  ❌
```

Root cause: `resolvePath` handled all leading-dot sources with the JS branch (`posix.join` + `normalize`), which only resolves `/`-separated segments. Python's `.x` / `..x` are single segments — `normalize("pkg/..utils")` stays `pkg/..utils` and never matches.

## Fix

`resolvePath` now recognizes dots-without-slash as Python package-relative syntax: N dots = (N-1) directory levels up from the importer, then the (dotted) suffix. JS `./x`/`../x` are untouched (slash right after dots → JS branch; a plain `/^\.+(?!\/)/` lookahead was insufficient because regex backtracking misclassifies `../x` — covered by regression tests).

## Verification

- New `tests/resolvePath.test.ts` (11 unit tests): `.x`, `..x`, `...pkg.sub`, bare `.`/`..`, missing-target external fallback + JS regression guards (`./x`, `../x`, bare specifier) + dotted-absolute guard.
- New e2e `tests/python-e2e.test.ts` — the Python parser's FIRST full `analyzeRepository` run (ParserRegistry → buildIndex → Repository → graph) on `tests/fixtures/python-basic/`; asserts exact edges for all three relative forms.
- Full suite: 333 passed (6 failures are the pre-existing broken impact.test.ts on main, fixed in #426). typecheck clean.

Note: this branch is based on ARCLUX.main (f466181), independent of #426/#427.