### PR TITLE
feat: extract CommonJS whole-object exports — module.exports = { a, b } (issue #430)

### DIFF
--- a/packages/parser/javascript/extractJs.ts
+++ b/packages/parser/javascript/extractJs.ts
@@ -129,6 +129,71 @@ function matchCommonJsExportTarget(expr: ts.Expression): string | null {
   return null;
 }
 
+/**
+ * Matches a bare whole-object CommonJS export target: the left-hand side
+ * of `module.exports = { … }` / `exports = { … }` (as opposed to the
+ * per-property `module.exports.NAME = …` handled by
+ * matchCommonJsExportTarget above).
+ */
+function isBareModuleExports(expr: ts.Expression): boolean {
+  // exports = { … }
+  if (ts.isIdentifier(expr) && expr.text === "exports") return true;
+  // module.exports = { … }
+  return (
+    ts.isPropertyAccessExpression(expr) &&
+    ts.isIdentifier(expr.expression) &&
+    expr.expression.text === "module" &&
+    expr.name.text === "exports"
+  );
+}
+
+/**
+ * Extracts the exported name from one property of a whole-object export
+ * (`module.exports = { a, b }`). Returns null for members that carry no
+ * export name (spread `...rest`) or whose key cannot be statically
+ * determined (computed `[key]: value`).
+ */
+function getObjectLiteralExportName(
+  prop: ts.ObjectLiteralElement,
+  sourceFile: ts.SourceFile
+): string | null {
+  if (ts.isSpreadAssignment(prop)) return null;
+
+  if (ts.isShorthandPropertyAssignment(prop)) {
+    return prop.name.text; // { a } -> "a"
+  }
+
+  if (ts.isPropertyAssignment(prop)) {
+    // { foo: foo } / { foo: renamed } / { "foo-bar": x } -> the KEY
+    if (
+      ts.isIdentifier(prop.name) ||
+      ts.isStringLiteral(prop.name) ||
+      ts.isNumericLiteral(prop.name)
+    ) {
+      return prop.name.text;
+    }
+    return null; // computed key [expr]: value
+  }
+
+  if (
+    ts.isMethodDeclaration(prop) ||
+    ts.isGetAccessorDeclaration(prop) ||
+    ts.isSetAccessorDeclaration(prop)
+  ) {
+    // { foo() {} } / { get foo() {} } — only statically-named methods
+    if (
+      ts.isIdentifier(prop.name) ||
+      ts.isStringLiteral(prop.name) ||
+      ts.isNumericLiteral(prop.name)
+    ) {
+      return prop.name.text;
+    }
+    return null;
+  }
+
+  return null;
+}
+
 export function extractExportsJs(sourceFile: ts.SourceFile): RawExport[] {
   const exports: RawExport[] = [];
 
@@ -216,6 +281,21 @@ export function extractExportsJs(sourceFile: ts.SourceFile): RawExport[] {
           kind: "named",
           line: getLine(sourceFile, node.getStart()),
         });
+      } else if (
+        // Whole-object assignment: `module.exports = { a, b }` /
+        // `exports = { a }`. Every property of the object literal becomes
+        // a named export. Closes the long-standing gap noted in the
+        // matchCommonJsExportTarget doc comment (issue #430).
+        isBareModuleExports(node.expression.left) &&
+        ts.isObjectLiteralExpression(node.expression.right)
+      ) {
+        const line = getLine(sourceFile, node.getStart());
+        for (const prop of node.expression.right.properties) {
+          const name = getObjectLiteralExportName(prop, sourceFile);
+          if (name !== null) {
+            exports.push({ name, kind: "named", line });
+          }
+        }
       }
     }
 

--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -379,3 +379,15 @@ Contributor commit added apps/cli/commands/{edit,logs,open,verify}.ts using expo
 **Status:** Fixed (PR #426, closes issue #424)
 
 Original diagnosis ("mock/plain object doesn't implement getModule") was inaccurate. Root cause: impact functions were refactored from `(moduleId, graph)` to `(repository, moduleId)` and the test file still used the old signature on an empty Repository (which also has no `graph` property — graph is built separately by buildDependencyGraph). Fix: rewrote tests/impact.test.ts with real ModuleInfo fixtures (makeModule/makeRepository convention from tests/graph.test.ts) covering chain (entry->service->repository), circular (a->b->c->a, cycle guard), fan-out (a->{b,c}) and notFound behavior — 12 tests, all green. Related: tests/pipeline.test.ts fixed in PR #427 (issue #425): `/tmp/test` ThreatCrush finding was a false positive (path never touched — throws before I/O), replaced with portable os.tmpdir() path; weak `moduleCount >= 0` assertions replaced with deterministic fixture (tests/fixtures/pipeline-basic/, entry->service->repository) asserting exact moduleCount/edges/scanSummary (~1.8s -> ~22ms).
+
+## 2026-08-15 — Python relative imports resolve as external: from .x / from ..x / bare . and .. dropped from graph
+
+**Status:** Fixed (PR #431, closes issue #429)
+
+Python files using relative imports got ZERO dependency edges: `from .repository import x` in pkg/service.py, `from ..utils import x` in pkg/repository.py, `from .service import x` in pkg/__init__.py — all resolved as external. Root cause: resolvePath handled every leading-dot source with the JS branch (posix.join+normalize), which only resolves `/`-separated segments; Python's `.x`/`..x` are single segments, so normalize("pkg/..utils") stays "pkg/..utils" and never matches. Fix: dots-without-slash → Python package-relative branch (N dots = N-1 dirname steps up + dotted suffix); JS `./x`/`../x` untouched (naive `/^\.+(?!\/)/` lookahead misclassifies `../x` via regex backtracking — fixed with full-dot-run + explicit char check). +11 unit tests (tests/resolvePath.test.ts, first ever for this file) + first e2e for Python parser (tests/python-e2e.test.ts on tests/fixtures/python-basic/: all 3 relative forms produce exact graph edges).
+
+## 2026-08-15 — CommonJS whole-object exports not extracted: module.exports = { a, b } silently yields zero exports
+
+**Status:** Fixed (PR #432, closes issue #430)
+
+Known gap (documented in extractJs.ts + PROGRES.md): extractExportsJs only recognized per-property assignment (module.exports.NAME=/exports.NAME=); `module.exports = {…}` has bare LHS `module.exports` which matchCommonJsExportTarget never matched — exports silently dropped. Fix: bare `module.exports =`/`exports =` with ObjectLiteralExpression RHS → each property is a named export (shorthand `{a}`, renamed key `{foo: renamed}` → "foo", string keys, methods/getters; spread + computed keys skipped). +6 tests in tests/parser/javascript.test.ts. Single-value assignment (`module.exports = fn`) still out of scope (follow-up).

--- a/tests/parser/javascript.test.ts
+++ b/tests/parser/javascript.test.ts
@@ -89,4 +89,55 @@ describe("parseCommonJs", () => {
     expect(names).toContain("readFile");
     expect(names).toContain("SIZE");
   });
+
+  it("extracts whole-object exports: module.exports = { a, b } (issue #430)", async () => {
+    const parsed = await parseCommonJs.parse(
+      makeFile("src/obj.cjs", ".cjs"),
+      "const a = 1; const b = 2;\nmodule.exports = { a, b };"
+    );
+    const names = parsed.exports.map((e) => e.name);
+    expect(names).toEqual(["a", "b"]);
+    expect(parsed.exports.every((e) => e.kind === "named")).toBe(true);
+  });
+
+  it("extracts whole-object exports with renamed keys: module.exports = { foo: renamed }", async () => {
+    const parsed = await parseCommonJs.parse(
+      makeFile("src/renamed.cjs", ".cjs"),
+      "const renamed = 42;\nmodule.exports = { foo: renamed };"
+    );
+    // The EXPORTED name is the object key ("foo"), not the local binding.
+    expect(parsed.exports.map((e) => e.name)).toEqual(["foo"]);
+  });
+
+  it("supports the shorthand-and-longhand mix and skips spreads (issue #430)", async () => {
+    const parsed = await parseCommonJs.parse(
+      makeFile("src/mix.cjs", ".cjs"),
+      "const a = 1; const rest = { x: 1 };\nmodule.exports = { a, foo: rest, ...rest };"
+    );
+    expect(parsed.exports.map((e) => e.name)).toEqual(["a", "foo"]);
+  });
+
+  it("extracts methods and string keys in whole-object exports", async () => {
+    const parsed = await parseCommonJs.parse(
+      makeFile("src/methods.cjs", ".cjs"),
+      'module.exports = { run() {}, "dash-key": 1 };'
+    );
+    expect(parsed.exports.map((e) => e.name)).toEqual(["run", "dash-key"]);
+  });
+
+  it("combines whole-object and per-property assignments", async () => {
+    const parsed = await parseCommonJs.parse(
+      makeFile("src/combined.cjs", ".cjs"),
+      "module.exports = { a };\nmodule.exports.b = 2;"
+    );
+    expect(parsed.exports.map((e) => e.name)).toEqual(["a", "b"]);
+  });
+
+  it("handles bare `exports = { … }` assignment", async () => {
+    const parsed = await parseCommonJs.parse(
+      makeFile("src/exports-assign.cjs", ".cjs"),
+      "exports = { a, b };"
+    );
+    expect(parsed.exports.map((e) => e.name)).toEqual(["a", "b"]);
+  });
 });


### PR DESCRIPTION
Closes #430

## Problem

CommonJS files exporting via **whole-object assignment** reported zero exports:

```js
module.exports = { a, b };        // nothing extracted
module.exports = { foo: renamed }; // nothing extracted
```

`extractExportsJs` (packages/parser/javascript/extractJs.ts) only recognized per-property assignment (`module.exports.NAME =`, `exports.NAME =`) via `matchCommonJsExportTarget`. For `module.exports = {…}` the LHS is bare `module.exports` — the matcher expects `module.exports.NAME`, returns null, and the export is silently dropped. This was a documented known gap (extractJs.ts doc comment + PROGRES.md) affecting parseJs, parseJsx and parseCommonJs.

## Fix

`extractExportsJs` now detects bare `module.exports =` / `exports =` assignments whose RHS is an object literal and emits each property as a named export:

- `{ a, b }` (shorthand) → `a`, `b`
- `{ foo: foo }` / `{ foo: renamed }` → `foo` (the exported name is the KEY)
- `{ "dash-key": x }`, `{ m() {} }`, getters/setters → included
- `...spread` and computed keys `[k]: v` → skipped (no static name)

Single-value assignment (`module.exports = fn`) remains out of scope — object literals are the named gap; noted for follow-up.

## Verification

6 new tests in tests/parser/javascript.test.ts covering all forms + the mixed per-property/whole-object combination. 12/12 in that file; full suite 325 passed (6 failures are the pre-existing broken impact.test.ts on main, fixed in #426); typecheck + lint clean.

Note: this branch is based on ARCLUX.main (f466181), independent of #426/#427/#431.