### PR TITLE
feat: implement semantic-diff (AstDiff, SymbolDiff, DependencyDiff, DiffRenderer, SemanticDiff)

### DIFF
--- a/packages/semantic-diff/AstDiff.ts
+++ b/packages/semantic-diff/AstDiff.ts
@@ -1,11 +1,50 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 ARCLUX
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: semantic-diff/AstDiff — not yet implemented.
+// Same limitation as packages/diff/architecturalDiff.ts: does not check
+// out git refs itself. Caller supplies both file contents (from working
+// tree, git show, stash, etc). Uses the real parser via ParserRegistry —
+// does not reimplement AST walking here.
+
+import { parserRegistry } from "../parser/core/ParserRegistry";
+import type { FileInfo } from "../shared/types";
+
+export interface AstDiffResult {
+  filePath: string;
+  importsAdded: string[];
+  importsRemoved: string[];
+  exportsAdded: string[];
+  exportsRemoved: string[];
+}
+
+export async function computeAstDiff(
+  fileBefore: FileInfo,
+  contentBefore: string,
+  fileAfter: FileInfo,
+  contentAfter: string
+): Promise<AstDiffResult> {
+  const parser = parserRegistry.getParserOrThrow(fileAfter.extension);
+
+  const [before, after] = await Promise.all([
+    parser.parse(fileBefore, contentBefore),
+    parser.parse(fileAfter, contentAfter),
+  ]);
+
+  const beforeImports = new Set(before.imports.map((i) => i.source));
+  const afterImports = new Set(after.imports.map((i) => i.source));
+  const beforeExports = new Set(before.exports.map((e) => e.name));
+  const afterExports = new Set(after.exports.map((e) => e.name));
+
+  return {
+    filePath: fileAfter.relativePath,
+    importsAdded: [...afterImports].filter((s) => !beforeImports.has(s)),
+    importsRemoved: [...beforeImports].filter((s) => !afterImports.has(s)),
+    exportsAdded: [...afterExports].filter((s) => !beforeExports.has(s)),
+    exportsRemoved: [...beforeExports].filter((s) => !afterExports.has(s)),
+  };
+}

--- a/packages/semantic-diff/DependencyDiff.ts
+++ b/packages/semantic-diff/DependencyDiff.ts
@@ -1,11 +1,43 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 ARCLUX
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: semantic-diff/DependencyDiff — not yet implemented.
+// Wraps packages/diff/architecturalDiff.ts (existing) and layers per-module
+// impact on top via packages/impact/calculateAffectedFiles.ts (existing).
+// Does not reimplement graph traversal.
+
+import type { Repository } from "../repository/Repository";
+import { computeArchitecturalDiff } from "../diff/architecturalDiff";
+import { calculateAffectedFiles, type ImpactResult } from "../impact/calculateAffectedFiles";
+
+export interface DependencyDiffResult {
+  changedFiles: string[];
+  affectedModules: string[];
+  impactByModule: Record<string, ImpactResult>;
+}
+
+export function computeDependencyDiff(
+  repository: Repository,
+  repoPath: string,
+  refA: string,
+  refB: string
+): DependencyDiffResult {
+  const archDiff = computeArchitecturalDiff(repository, repoPath, refA, refB);
+
+  const impactByModule: Record<string, ImpactResult> = {};
+  for (const changed of archDiff.changedFiles) {
+    if (changed.status === "deleted") continue;
+    if (!repository.getModule(changed.path)) continue;
+    impactByModule[changed.path] = calculateAffectedFiles(repository, changed.path);
+  }
+
+  return {
+    changedFiles: archDiff.changedFiles.map((c) => c.path),
+    affectedModules: archDiff.affectedFiles,
+    impactByModule,
+  };
+}

--- a/packages/semantic-diff/DiffRenderer.ts
+++ b/packages/semantic-diff/DiffRenderer.ts
@@ -1,11 +1,50 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 ARCLUX
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: semantic-diff/DiffRenderer — not yet implemented.
+import type { SymbolDiffResult } from "./SymbolDiff";
+import type { AstDiffResult } from "./AstDiff";
+import type { DependencyDiffResult } from "./DependencyDiff";
+
+export interface DiffRenderInput {
+  symbolDiff?: SymbolDiffResult;
+  astDiffs?: AstDiffResult[];
+  dependencyDiff?: DependencyDiffResult;
+}
+
+export function renderSemanticDiff(parts: DiffRenderInput): string {
+  const lines: string[] = [];
+
+  if (parts.symbolDiff) {
+    lines.push("## Symbol changes");
+    for (const s of parts.symbolDiff.added) lines.push(`  + ${s.name} (${s.moduleId})`);
+    for (const s of parts.symbolDiff.removed) lines.push(`  - ${s.name} (${s.moduleId})`);
+    for (const m of parts.symbolDiff.moved) lines.push(`  ~ ${m.name} moved ${m.from} -> ${m.to}`);
+    lines.push("");
+  }
+
+  if (parts.astDiffs) {
+    lines.push("## AST changes");
+    for (const a of parts.astDiffs) {
+      lines.push(`  ${a.filePath}`);
+      a.importsAdded.forEach((i) => lines.push(`    + import ${i}`));
+      a.importsRemoved.forEach((i) => lines.push(`    - import ${i}`));
+      a.exportsAdded.forEach((e) => lines.push(`    + export ${e}`));
+      a.exportsRemoved.forEach((e) => lines.push(`    - export ${e}`));
+    }
+    lines.push("");
+  }
+
+  if (parts.dependencyDiff) {
+    lines.push("## Dependency & impact");
+    lines.push(`  Changed files: ${parts.dependencyDiff.changedFiles.length}`);
+    lines.push(`  Affected modules: ${parts.dependencyDiff.affectedModules.length}`);
+    for (const mod of parts.dependencyDiff.affectedModules) lines.push(`    * ${mod}`);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/semantic-diff/SemanticDiff.ts
+++ b/packages/semantic-diff/SemanticDiff.ts
@@ -1,11 +1,54 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 ARCLUX
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: semantic-diff/SemanticDiff — not yet implemented.
+// Entry point for the semantic-diff pipeline (blueprint: text -> symbol ->
+// AST -> dependency -> impact -> architectural). AstDiff is intentionally
+// NOT auto-wired here: it needs per-file before/after content, and (like
+// architecturalDiff.ts) this repo does not yet check out git refs into a
+// second working tree. Call computeAstDiff separately per-file when you
+// have both contents available (working tree + git show, stash, etc).
+
+import type { Repository } from "../repository/Repository";
+import { getChangedFiles } from "../diff/gitDiff";
+import { computeDependencyDiff, type DependencyDiffResult } from "./DependencyDiff";
+import { computeSymbolDiff, type SymbolDiffResult } from "./SymbolDiff";
+import { renderSemanticDiff } from "./DiffRenderer";
+
+export interface SemanticDiffOptions {
+  repository: Repository;
+  repoPath: string;
+  refA: string;
+  refB: string;
+  /** Optional second Repository snapshot (indexed at refB) for symbol-level diffing. Skipped if omitted. */
+  repositoryAfter?: Repository;
+}
+
+export interface SemanticDiffResult {
+  changedFiles: string[];
+  dependencyDiff: DependencyDiffResult;
+  symbolDiff?: SymbolDiffResult;
+  rendered: string;
+}
+
+export function computeSemanticDiff(options: SemanticDiffOptions): SemanticDiffResult {
+  const changed = getChangedFiles(options.repoPath, options.refA, options.refB);
+  const dependencyDiff = computeDependencyDiff(options.repository, options.repoPath, options.refA, options.refB);
+
+  const symbolDiff = options.repositoryAfter
+    ? computeSymbolDiff(options.repository, options.repositoryAfter)
+    : undefined;
+
+  const rendered = renderSemanticDiff({ symbolDiff, dependencyDiff });
+
+  return {
+    changedFiles: changed.map((c) => c.path),
+    dependencyDiff,
+    symbolDiff,
+    rendered,
+  };
+}

--- a/packages/semantic-diff/SymbolDiff.ts
+++ b/packages/semantic-diff/SymbolDiff.ts
@@ -1,11 +1,50 @@
-/**
- * Copyright 2026 ARCLUX
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- */
+// Copyright 2026 ARCLUX
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: semantic-diff/SymbolDiff — not yet implemented.
+// Wraps packages/language/SymbolEngine.ts (existing, issue #348). Does not
+// reimplement symbol resolution — just diffs two SymbolEngine snapshots.
+
+import { SymbolEngine, type SymbolInfo } from "../language/SymbolEngine";
+import type { Repository } from "../repository/Repository";
+
+export interface SymbolMove {
+  name: string;
+  from: string;
+  to: string;
+}
+
+export interface SymbolDiffResult {
+  added: SymbolInfo[];
+  removed: SymbolInfo[];
+  moved: SymbolMove[];
+}
+
+const engine = new SymbolEngine();
+
+function symbolKey(s: SymbolInfo): string {
+  return `${s.moduleId}::${s.name}`;
+}
+
+export function computeSymbolDiff(repoBefore: Repository, repoAfter: Repository): SymbolDiffResult {
+  const before = engine.getSymbols(repoBefore);
+  const after = engine.getSymbols(repoAfter);
+
+  const beforeMap = new Map(before.map((s) => [symbolKey(s), s]));
+  const afterMap = new Map(after.map((s) => [symbolKey(s), s]));
+
+  const added = after.filter((s) => !beforeMap.has(symbolKey(s)));
+  const removed = before.filter((s) => !afterMap.has(symbolKey(s)));
+
+  const moved: SymbolMove[] = [];
+  for (const rem of removed) {
+    const match = added.find((a) => a.name === rem.name);
+    if (match) moved.push({ name: rem.name, from: rem.moduleId, to: match.moduleId });
+  }
+
+  return { added, removed, moved };
+}


### PR DESCRIPTION
- **Log CI bug: impact.test.ts mock missing getModule method**
- **fix: increase timeout for full-repo analyzeRepository test**
- **feat: implement semantic-diff pipeline (wires existing diff/language/impact packages)**

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
