### PR TITLE
fix: Maven pom.xml parser — exclude plugin and dependencyManagement dependencies (issue #434)

### DIFF
--- a/packages/parser/java/parseGradlePom.ts
+++ b/packages/parser/java/parseGradlePom.ts
@@ -43,10 +43,25 @@ function parseGradle(content: string): ManifestDependency[] {
 
 function parseMaven(content: string): ManifestDependency[] {
   const dependencies: ManifestDependency[] = [];
+
+  // Strip non-project <dependency> contexts BEFORE matching blocks:
+  //   - <plugin><dependencies>   — the PLUGIN's own classpath, not the
+  //     project's (Maven compiles/executes the plugin with those, they do
+  //     not land on the project's dependency list).
+  //   - <dependencyManagement>    — version management only; entries there
+  //     do not add anything to the classpath unless also declared under
+  //     <dependencies>.
+  // Neither section nests itself nor contains the other, and profiles
+  // (<profiles><profile><dependencies>) are NOT stripped — their
+  // dependencies ARE project dependencies (conditional, but real).
+  const projectOnly = content
+    .replace(/<plugin>[\s\S]*?<\/plugin>/g, "")
+    .replace(/<dependencyManagement>[\s\S]*?<\/dependencyManagement>/g, "");
+
   const blockPattern = /<dependency>([\s\S]*?)<\/dependency>/g;
 
   let blockMatch: RegExpExecArray | null;
-  while ((blockMatch = blockPattern.exec(content)) !== null) {
+  while ((blockMatch = blockPattern.exec(projectOnly)) !== null) {
     const block = blockMatch[1];
     const groupId = block.match(/<groupId>([^<]+)<\/groupId>/)?.[1];
     const artifactId = block.match(/<artifactId>([^<]+)<\/artifactId>/)?.[1];

--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -391,3 +391,9 @@ Python files using relative imports got ZERO dependency edges: `from .repository
 **Status:** Fixed (PR #432, closes issue #430)
 
 Known gap (documented in extractJs.ts + PROGRES.md): extractExportsJs only recognized per-property assignment (module.exports.NAME=/exports.NAME=); `module.exports = {…}` has bare LHS `module.exports` which matchCommonJsExportTarget never matched — exports silently dropped. Fix: bare `module.exports =`/`exports =` with ObjectLiteralExpression RHS → each property is a named export (shorthand `{a}`, renamed key `{foo: renamed}` → "foo", string keys, methods/getters; spread + computed keys skipped). +6 tests in tests/parser/javascript.test.ts. Single-value assignment (`module.exports = fn`) still out of scope (follow-up).
+
+## 2026-08-15 — Maven pom.xml parser: regex captures plugin and dependencyManagement dependencies as project deps
+
+**Status:** Fixed (PR #435, closes issue #434)
+
+parseMaven matched `<dependency>` blocks with a blanket regex in ANY context — probe: 2 false positives out of 4 (`maven-shared-utils` from `<plugin><dependencies>` — plugin's own classpath; `guava` from `<dependencyManagement>` — version management only). Fix: strip `<plugin>…</plugin>` and `<dependencyManagement>…</dependencyManagement>` before block matching (neither nests itself nor the other; profile deps KEPT — conditional but real). Also: FIRST tests ever for the manifest package (tests/manifest.test.ts, 8: parsePom kinds/scopes/plugin/dependencyManagement/profile/malformed, parseGradle_ patterns) + wiring proven e2e (status-core's «not wired to analyzeRepository» was outdated — detectDependencies IS called by both local/remote paths; fixture java-basic with pom.xml + Main.java asserts dependencies = 3 project deps only). suite 359/359.

--- a/tests/fixtures/java-basic/pom.xml
+++ b/tests/fixtures/java-basic/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>java-app</artifactId>
+  <version>1.0.0</version>
+
+  <!-- Project dependencies: the ONLY <dependency> blocks that belong in
+       the dependency list (issue #434). -->
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>6.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <!-- Plugin dependencies: the plugin's own classpath, NOT project deps.
+       Must be excluded (issue #434). -->
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+            <version>3.4.2</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+  <!-- Version management only, not a declared classpath dependency.
+       Must be excluded (issue #434). -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.0.0-jre</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <!-- Profile dependencies ARE project dependencies (conditional). -->
+  <profiles>
+    <profile>
+      <id>dev</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.projectlombok</groupId>
+          <artifactId>lombok</artifactId>
+          <version>1.18.30</version>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+</project>

--- a/tests/fixtures/java-basic/src/com/example/Main.java
+++ b/tests/fixtures/java-basic/src/com/example/Main.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("hello");
+    }
+}

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -1,0 +1,154 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Manifest parser tests — the FIRST tests for this package (issue #434).
+// parsePom previously captured <dependency> blocks from <plugin> and
+// <dependencyManagement> sections as project dependencies. Also proves the
+// manifest -> analyzeRepository wiring end-to-end (status-core's "not
+// wired" claim was already outdated — detectDependencies IS called by both
+// analyzeLocalPath and analyzeRemoteRepository).
+
+import { describe, it, expect, beforeAll } from "vitest";
+import path from "node:path";
+import { parsePom, parseGradle_ } from "../packages/parser/java/parseGradlePom";
+import { analyzeRepository, type AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+
+const FIXTURE_PATH = path.join(__dirname, "fixtures", "java-basic");
+
+describe("parsePom", () => {
+  it("extracts project dependencies with correct kinds (test scope -> dev)", () => {
+    const deps = parsePom.parse(`
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>6.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>
+`);
+    expect(deps).toEqual([
+      { name: "org.springframework:spring-core", versionRange: "6.1.0", kind: "runtime" },
+      { name: "junit:junit", versionRange: "4.13.2", kind: "dev" },
+    ]);
+  });
+
+  it("excludes <plugin> dependencies (plugin classpath, not project deps)", () => {
+    const deps = parsePom.parse(`
+<project>
+  <dependencies>
+    <dependency><groupId>a</groupId><artifactId>b</artifactId><version>1</version></dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <dependencies>
+          <dependency><groupId>org.apache.maven.shared</groupId><artifactId>maven-shared-utils</artifactId></dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>
+`);
+    expect(deps.map((d) => d.name)).toEqual(["a:b"]);
+  });
+
+  it("excludes <dependencyManagement> entries (version management, not declared deps)", () => {
+    const deps = parsePom.parse(`
+<project>
+  <dependencyManagement>
+    <dependencies>
+      <dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>33.0.0-jre</version></dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency><groupId>a</groupId><artifactId>b</artifactId><version>1</version></dependency>
+  </dependencies>
+</project>
+`);
+    expect(deps.map((d) => d.name)).toEqual(["a:b"]);
+  });
+
+  it("KEEPS profile dependencies (conditional but real project deps)", () => {
+    const deps = parsePom.parse(`
+<project>
+  <dependencies>
+    <dependency><groupId>a</groupId><artifactId>b</artifactId><version>1</version></dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>dev</id>
+      <dependencies>
+        <dependency><groupId>org.projectlombok</groupId><artifactId>lombok</artifactId><version>1.18.30</version></dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+</project>
+`);
+    const names = deps.map((d) => d.name).sort();
+    expect(names).toEqual(["a:b", "org.projectlombok:lombok"]);
+  });
+
+  it("returns [] on malformed input instead of throwing", () => {
+    expect(parsePom.parse("this is not xml at all")).toEqual([]);
+    expect(parsePom.parse("")).toEqual([]);
+  });
+});
+
+describe("parseGradle_", () => {
+  it("extracts implementation/api/runtimeOnly as runtime, testImplementation as dev", () => {
+    const deps = parseGradle_.parse(`
+dependencies {
+    implementation 'org.springframework:spring-core:6.1.0'
+    api "com.google.guava:guava:33.0.0-jre"
+    testImplementation 'junit:junit:4.13.2'
+    runtimeOnly 'ch.qos.logback:logback-classic:1.4.14'
+}
+`);
+    const summary = deps.map((d) => `${d.name}:${d.kind}`).sort();
+    expect(summary).toEqual([
+      "ch.qos.logback:logback-classic:runtime",
+      "com.google.guava:guava:runtime",
+      "junit:junit:dev",
+      "org.springframework:spring-core:runtime",
+    ]);
+  });
+});
+
+describe("Manifest wiring e2e: pom.xml through analyzeRepository (issue #434)", () => {
+  let result: AnalyzeRepositoryResult;
+
+  beforeAll(async () => {
+    result = await analyzeRepository({ localPath: FIXTURE_PATH });
+  }, 30_000);
+
+  it("surfaces only project dependencies (no plugin / dependencyManagement entries)", () => {
+    const names = result.dependencies.map((d) => d.name).sort();
+    expect(names).toEqual([
+      "junit:junit",
+      "org.projectlombok:lombok",
+      "org.springframework:spring-core",
+    ]);
+    expect(result.dependencies.every((d) => !d.name.includes("maven-shared-utils"))).toBe(true);
+    expect(result.dependencies.every((d) => !d.name.includes("guava"))).toBe(true);
+  });
+
+  it("indexes the Java source alongside the manifest", () => {
+    expect(result.moduleCount).toBe(1);
+    const ids = result.repository.getAllModules().map((m) => m.id);
+    expect(ids).toEqual(["src/com/example/Main.java"]);
+  });
+});


### PR DESCRIPTION
Closes #434

## Problem

`parsePom` matched `<dependency>` blocks with a blanket regex in ANY context. Probe with a realistic pom.xml showed 2 false positives out of 4:

```
org.apache.maven.shared:maven-shared-utils  <- FALSE POSITIVE (inside <plugin><dependencies>)
com.google.guava:guava                      <- FALSE POSITIVE (inside <dependencyManagement>)
```

Maven semantics: plugin dependencies are the plugin's own classpath; dependencyManagement is version management — neither belongs on the project's dependency list.

## Fix

`parseMaven` now strips `<plugin>…</plugin>` and `<dependencyManagement>…</dependencyManagement>` sections before matching `<dependency>` blocks (neither nests itself nor the other, so a non-greedy strip is safe). Profile dependencies are KEPT — they are conditional but real project dependencies.

## Also in this PR

- **First tests ever for the manifest package** (`tests/manifest.test.ts`, 8 tests): parsePom project deps + test-scope→dev, plugin exclusion, dependencyManagement exclusion, profile deps kept, malformed input → [] (never throw); parseGradle_ implementation/api/runtimeOnly/testImplementation patterns.
- **Wiring proven end-to-end**: the analysis claimed manifest parsers are "not wired into analyzeRepository" — that was already outdated (`manifestRegistry.detectDependencies` is called by both analyzeLocalPath and analyzeRemoteRepository). New e2e fixture `tests/fixtures/java-basic/` (pom.xml + Main.java) through `analyzeRepository({localPath})` asserts `result.dependencies` contains ONLY the 3 project deps and the Java module is indexed.

Full suite: 359/359 (351 on main + 8 new). typecheck + lint clean.