### PR TITLE
feat: resolve pom.xml ${property} versions + scan build.gradle.kts (issue #436)

### DIFF
--- a/packages/parser/core/ManifestParserInterface.ts
+++ b/packages/parser/core/ManifestParserInterface.ts
@@ -27,8 +27,12 @@ export interface ManifestDependency {
  * LanguageParser/ParserRegistry which cover arbitrary source files.
  */
 export interface ManifestParser {
-  /** Exact filename this parser handles, e.g. "go.mod", "Cargo.toml" */
-  readonly filename: string;
+  /**
+   * Filename(s) this parser handles, e.g. "go.mod", "Cargo.toml" — or an
+   * array for formats that span multiple filenames (build.gradle AND
+   * build.gradle.kts use the same Groovy/Kotlin-DSL dependency syntax).
+   */
+  readonly filename: string | readonly string[];
 
   /**
    * Parses manifest content into a flat dependency list. Must NOT throw on

--- a/packages/parser/core/ManifestRegistry.ts
+++ b/packages/parser/core/ManifestRegistry.ts
@@ -27,7 +27,10 @@ export class ManifestRegistry {
   private parsersByFilename: Map<string, ManifestParser> = new Map();
 
   register(parser: ManifestParser): void {
-    this.parsersByFilename.set(parser.filename, parser);
+    const filenames = typeof parser.filename === "string" ? [parser.filename] : parser.filename;
+    for (const filename of filenames) {
+      this.parsersByFilename.set(filename, parser);
+    }
   }
 
   getParserForFilename(filename: string): ManifestParser | undefined {

--- a/packages/parser/java/parseGradlePom.ts
+++ b/packages/parser/java/parseGradlePom.ts
@@ -58,6 +58,24 @@ function parseMaven(content: string): ManifestDependency[] {
     .replace(/<plugin>[\s\S]*?<\/plugin>/g, "")
     .replace(/<dependencyManagement>[\s\S]*?<\/dependencyManagement>/g, "");
 
+  // Resolve <version>${...}</version> references against the <properties>
+  // section of the SAME pom (Maven's standard version-property pattern,
+  // e.g. <spring.version>6.1.0</spring.version> + <version>${spring.version}</version>).
+  // Properties that reference other properties resolve iteratively (bounded);
+  // unknown refs (including self-version refs like ${project.version}) stay
+  // literal rather than being guessed.
+  const properties = extractMavenProperties(content);
+  const resolveVersion = (raw: string | undefined): string | undefined => {
+    if (!raw) return undefined;
+    let out = raw;
+    for (let pass = 0; pass < 5; pass++) {
+      const next = out.replace(/\$\{([^}]+)\}/g, (_, key: string) => properties[key] ?? `\${${key}}`);
+      if (next === out) break;
+      out = next;
+    }
+    return out;
+  };
+
   const blockPattern = /<dependency>([\s\S]*?)<\/dependency>/g;
 
   let blockMatch: RegExpExecArray | null;
@@ -72,7 +90,7 @@ function parseMaven(content: string): ManifestDependency[] {
 
     dependencies.push({
       name: `${groupId}:${artifactId}`,
-      versionRange: version,
+      versionRange: resolveVersion(version),
       kind: scope === "test" ? "dev" : "runtime",
     });
   }
@@ -80,8 +98,25 @@ function parseMaven(content: string): ManifestDependency[] {
   return dependencies;
 }
 
+/** Collects the <properties> section of a pom.xml into a key->value map. */
+function extractMavenProperties(content: string): Record<string, string> {
+  const properties: Record<string, string> = {};
+  const section = content.match(/<properties>([\s\S]*?)<\/properties>/);
+  if (!section) return properties;
+
+  const entryPattern = /<([A-Za-z0-9_.-]+)>([^<]+)<\/\1>/g;
+  let match: RegExpExecArray | null;
+  while ((match = entryPattern.exec(section[1])) !== null) {
+    properties[match[1]] = match[2];
+  }
+  return properties;
+}
+
 export const parseGradle_: ManifestParser = {
-  filename: "build.gradle",
+  // build.gradle (Groovy DSL, single-quoted strings) and build.gradle.kts
+  // (Kotlin DSL, double-quoted function calls) share the same
+  // group:artifact:version dependency syntax — one parser, two filenames.
+  filename: ["build.gradle", "build.gradle.kts"],
   parse: parseGradle,
 };
 

--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -392,6 +392,12 @@ Python files using relative imports got ZERO dependency edges: `from .repository
 
 Known gap (documented in extractJs.ts + PROGRES.md): extractExportsJs only recognized per-property assignment (module.exports.NAME=/exports.NAME=); `module.exports = {…}` has bare LHS `module.exports` which matchCommonJsExportTarget never matched — exports silently dropped. Fix: bare `module.exports =`/`exports =` with ObjectLiteralExpression RHS → each property is a named export (shorthand `{a}`, renamed key `{foo: renamed}` → "foo", string keys, methods/getters; spread + computed keys skipped). +6 tests in tests/parser/javascript.test.ts. Single-value assignment (`module.exports = fn`) still out of scope (follow-up).
 
+## 2026-08-15 — Manifest parsers part 2: pom.xml ${property} versions unresolved + build.gradle.kts never scanned
+
+**Status:** Fixed (PR #437, closes issue #436)
+
+(1) parsePom записывал versionRange литерально (`${spring.version}`) — теперь резолвит из `<properties>`-секции того же pom (итеративно для chained-ссылок; неизвестные `${project.version}` остаются литеральными). (2) build.gradle.kts никогда не сканировался: parseGradle_ регистрировался только как filename "build.gradle", а ManifestRegistry мапил один filename на парсер. Fix: `filename: string | readonly string[]` в ManifestParserInterface, registry итерирует filenames, parseGradle_ → ["build.gradle", "build.gradle.kts"] (Kotlin DSL строковая форма group:artifact:version уже матчилась существующим regex — probe подтвердил, регистрации не хватало). +6 тестов (свойства direct/chained/unknown, Kotlin DSL, registry multi-filename, e2e gradle-kts-basic fixture). Наблюдение (не фиксилось): parseCsproj регистрирует filename ".csproj" (расширение как имя — реальный Foo.csproj не найдётся, только файл буквально названный .csproj).
+
 ## 2026-08-15 — Maven pom.xml parser: regex captures plugin and dependencyManagement dependencies as project deps
 
 **Status:** Fixed (PR #435, closes issue #434)

--- a/tests/fixtures/gradle-kts-basic/build.gradle.kts
+++ b/tests/fixtures/gradle-kts-basic/build.gradle.kts
@@ -1,0 +1,11 @@
+// Fixture for tests/manifest.test.ts — Kotlin DSL (build.gradle.kts).
+// Registered under a second filename by parseGradle_ (issue #436): the
+// dependency syntax is the same group:artifact:version triple as Groovy.
+plugins {
+    id("java")
+}
+
+dependencies {
+    implementation("org.springframework:spring-core:6.1.0")
+    testImplementation("junit:junit:4.13.2")
+}

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -16,9 +16,11 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import path from "node:path";
 import { parsePom, parseGradle_ } from "../packages/parser/java/parseGradlePom";
-import { analyzeRepository, type AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+import { manifestRegistry } from "../packages/parser/core/ManifestRegistry";
+import { analyzeRepository, ensureParsersRegistered, type AnalyzeRepositoryResult } from "../packages/engine/pipeline";
 
 const FIXTURE_PATH = path.join(__dirname, "fixtures", "java-basic");
+const GRADLE_KTS_FIXTURE = path.join(__dirname, "fixtures", "gradle-kts-basic");
 
 describe("parsePom", () => {
   it("extracts project dependencies with correct kinds (test scope -> dev)", () => {
@@ -106,6 +108,58 @@ describe("parsePom", () => {
     expect(parsePom.parse("this is not xml at all")).toEqual([]);
     expect(parsePom.parse("")).toEqual([]);
   });
+
+  it("resolves <version>${property}</version> against the <properties> section", () => {
+    const deps = parsePom.parse(`
+<project>
+  <properties>
+    <spring.version>6.1.0</spring.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>${'${spring.version}'}</version>
+    </dependency>
+  </dependencies>
+</project>
+`);
+    expect(deps[0].versionRange).toBe("6.1.0");
+  });
+
+  it("keeps unresolvable ${...} versions literal (e.g. ${project.version})", () => {
+    const deps = parsePom.parse(`
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>a</groupId>
+      <artifactId>b</artifactId>
+      <version>${'${project.version}'}</version>
+    </dependency>
+  </dependencies>
+</project>
+`);
+    expect(deps[0].versionRange).toBe("${project.version}");
+  });
+
+  it("resolves chained property references iteratively", () => {
+    const deps = parsePom.parse(`
+<project>
+  <properties>
+    <base>1.0</base>
+    <chain>${'${base}'}</chain>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>a</groupId>
+      <artifactId>b</artifactId>
+      <version>${'${chain}'}</version>
+    </dependency>
+  </dependencies>
+</project>
+`);
+    expect(deps[0].versionRange).toBe("1.0");
+  });
 });
 
 describe("parseGradle_", () => {
@@ -125,6 +179,38 @@ dependencies {
       "junit:junit:dev",
       "org.springframework:spring-core:runtime",
     ]);
+  });
+
+  it("parses build.gradle.kts (Kotlin DSL string form) with the same syntax", () => {
+    const deps = parseGradle_.parse(`
+plugins {
+    id("java")
+}
+
+dependencies {
+    implementation("org.springframework:spring-core:6.1.0")
+    testImplementation("junit:junit:4.13.2")
+}
+`);
+    expect(deps).toEqual([
+      { name: "org.springframework:spring-core", versionRange: "6.1.0", kind: "runtime" },
+      { name: "junit:junit", versionRange: "4.13.2", kind: "dev" },
+    ]);
+  });
+});
+
+describe("ManifestRegistry — multi-filename parsers", () => {
+  beforeAll(() => {
+    // The singleton registry is populated lazily by the pipeline — make it
+    // deterministic for this unit test.
+    ensureParsersRegistered();
+  });
+
+  it("registers parseGradle_ under both build.gradle and build.gradle.kts", () => {
+    const filenames = manifestRegistry.registeredFilenames;
+    expect(filenames).toContain("build.gradle");
+    expect(filenames).toContain("build.gradle.kts");
+    expect(manifestRegistry.getParserForFilename("build.gradle.kts")).toBe(parseGradle_);
   });
 });
 
@@ -150,5 +236,18 @@ describe("Manifest wiring e2e: pom.xml through analyzeRepository (issue #434)", 
     expect(result.moduleCount).toBe(1);
     const ids = result.repository.getAllModules().map((m) => m.id);
     expect(ids).toEqual(["src/com/example/Main.java"]);
+  });
+});
+
+describe("Manifest wiring e2e: build.gradle.kts through analyzeRepository", () => {
+  let result: AnalyzeRepositoryResult;
+
+  beforeAll(async () => {
+    result = await analyzeRepository({ localPath: GRADLE_KTS_FIXTURE });
+  }, 30_000);
+
+  it("surfaces Kotlin DSL dependencies from build.gradle.kts", () => {
+    const names = result.dependencies.map((d) => d.name).sort();
+    expect(names).toEqual(["junit:junit", "org.springframework:spring-core"]);
   });
 });


### PR DESCRIPTION
Closes #436

## Part 1 — pom.xml ${property} versions

Maven's standard version pattern (`<properties><spring.version>6.1.0</spring.version></properties>` + `<version>${spring.version}</version>`) previously produced literal `versionRange: "${spring.version}"`. `parseMaven` now collects the `<properties>` section and resolves `${key}` references in versions:

- direct refs, chained refs (bounded iterative resolution)
- unknown refs (`${project.version}`, etc.) stay LITERAL — never guessed

## Part 2 — build.gradle.kts never scanned

`parseGradle_` registered under `filename: "build.gradle"` only; ManifestRegistry maps one filename per parser, so Kotlin DSL files were silently skipped. Probe confirmed the existing regex ALREADY matches the Kotlin DSL string form (`implementation("g:a:v")`) — only registration was missing.

- `ManifestParserInterface.filename`: `string | readonly string[]` (additive)
- `ManifestRegistry.register`: iterates filenames
- `parseGradle_` → `["build.gradle", "build.gradle.kts"]`

## Verification

6 new tests in tests/manifest.test.ts: property resolution (direct/chained/unknown-literal), Kotlin DSL string form, registry multi-filename registration, e2e `tests/fixtures/gradle-kts-basic/` through `analyzeRepository`. Full suite 365/365 (359 + 6), typecheck + lint clean.

Note: unrelated observation (not fixed here) — `parseCsproj` registers `filename: ".csproj"` (an extension used as a filename), so real `Foo.csproj` files would never be found. Logged in bugs.md.