### PR TITLE
fix: discover .csproj manifests by extension — real Foo.csproj files were never scanned (issue #438)

### DIFF
--- a/packages/parser/core/ManifestParserInterface.ts
+++ b/packages/parser/core/ManifestParserInterface.ts
@@ -31,8 +31,17 @@ export interface ManifestParser {
    * Filename(s) this parser handles, e.g. "go.mod", "Cargo.toml" — or an
    * array for formats that span multiple filenames (build.gradle AND
    * build.gradle.kts use the same Groovy/Kotlin-DSL dependency syntax).
+   * An empty array means the parser matches ONLY via `extension`.
    */
   readonly filename: string | readonly string[];
+  /**
+   * Optional: match files by extension ANYWHERE under the repo root
+   * (e.g. ".csproj" — project files live in per-project subdirectories
+   * with arbitrary names, so an exact filename never matches). When set,
+   * ManifestRegistry.detectDependencies also walks the tree once and
+   * parses every matching file.
+   */
+  readonly extension?: string;
 
   /**
    * Parses manifest content into a flat dependency list. Must NOT throw on

--- a/packages/parser/core/ManifestRegistry.ts
+++ b/packages/parser/core/ManifestRegistry.ts
@@ -6,8 +6,8 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-import { existsSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, extname } from "node:path";
 import type { ManifestParser, ManifestDependency } from "./ManifestParserInterface";
 
 /**
@@ -25,11 +25,17 @@ import type { ManifestParser, ManifestDependency } from "./ManifestParserInterfa
  */
 export class ManifestRegistry {
   private parsersByFilename: Map<string, ManifestParser> = new Map();
+  /** Parsers that match by extension (e.g. parseCsproj) — kept separately
+   *  because an empty filename array registers nothing in the filename map. */
+  private extensionParsers: ManifestParser[] = [];
 
   register(parser: ManifestParser): void {
     const filenames = typeof parser.filename === "string" ? [parser.filename] : parser.filename;
     for (const filename of filenames) {
       this.parsersByFilename.set(filename, parser);
+    }
+    if (parser.extension) {
+      this.extensionParsers.push(parser);
     }
   }
 
@@ -47,10 +53,17 @@ export class ManifestRegistry {
    * list. A repo can legitimately have more than one manifest present
    * (e.g. a JS frontend + a Python backend in the same repo) -- all
    * matching manifests are parsed, not just the first one found.
+   *
+   * Pass 1: exact-filename lookups (join(rootPath, filename)).
+   * Pass 2: extension-based discovery — parsers that declare `extension`
+   * (e.g. parseCsproj) match files ANYWHERE under the root, since
+   * per-project manifests like Foo.csproj live in subdirectories and
+   * have arbitrary names.
    */
   detectDependencies(rootPath: string): ManifestDependency[] {
     const allDependencies: ManifestDependency[] = [];
 
+    // Pass 1: exact filenames (existing behavior, unchanged).
     for (const [filename, parser] of this.parsersByFilename) {
       const filePath = join(rootPath, filename);
       if (!existsSync(filePath)) continue;
@@ -66,7 +79,48 @@ export class ManifestRegistry {
       }
     }
 
+    // Pass 2: extension-based discovery.
+    const extensionParsers = this.extensionParsers;
+    if (extensionParsers.length > 0) {
+      const files: string[] = [];
+      walkFiles(rootPath, files);
+      for (const filePath of files) {
+        const extension = extname(filePath).toLowerCase();
+        for (const parser of extensionParsers) {
+          if (extension !== parser.extension!.toLowerCase()) continue;
+          try {
+            const content = readFileSync(filePath, "utf-8");
+            allDependencies.push(...parser.parse(content));
+          } catch {
+            continue;
+          }
+        }
+      }
+    }
+
     return allDependencies;
+  }
+}
+
+/**
+ * Recursively collects all files under `dir`. Skips node_modules/.git so a
+ * dependency scan never descends into vendored or VCS trees.
+ */
+function walkFiles(dir: string, out: string[]): void {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name === ".git") continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, out);
+    } else if (entry.isFile()) {
+      out.push(fullPath);
+    }
   }
 }
 

--- a/packages/parser/csharp/parseCsproj.ts
+++ b/packages/parser/csharp/parseCsproj.ts
@@ -19,7 +19,13 @@ import type { ManifestParser, ManifestDependency } from "../core/ManifestParserI
 // solution-level concept in .NET via project references, not per-package),
 // so every PackageReference is reported as "runtime".
 export const parseCsproj: ManifestParser = {
-  filename: ".csproj",
+  // .csproj files live in per-project subdirectories with arbitrary names
+  // (src/MyApp/MyApp.csproj) — an exact filename lookup would only ever
+  // match a file literally named ".csproj" at the repo root. Match by
+  // extension instead; ManifestRegistry.detectDependencies walks the tree
+  // for parsers that declare `extension` (issue #438).
+  filename: [],
+  extension: ".csproj",
 
   parse(content: string): ManifestDependency[] {
     const dependencies: ManifestDependency[] = [];

--- a/tests/fixtures/csharp-basic/src/MyApp/MyApp.csproj
+++ b/tests/fixtures/csharp-basic/src/MyApp/MyApp.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -13,14 +13,18 @@
 // wired" claim was already outdated — detectDependencies IS called by both
 // analyzeLocalPath and analyzeRemoteRepository).
 
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import path from "node:path";
+import os from "node:os";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { parsePom, parseGradle_ } from "../packages/parser/java/parseGradlePom";
+import { parseCsproj } from "../packages/parser/csharp/parseCsproj";
 import { manifestRegistry } from "../packages/parser/core/ManifestRegistry";
 import { analyzeRepository, ensureParsersRegistered, type AnalyzeRepositoryResult } from "../packages/engine/pipeline";
 
 const FIXTURE_PATH = path.join(__dirname, "fixtures", "java-basic");
 const GRADLE_KTS_FIXTURE = path.join(__dirname, "fixtures", "gradle-kts-basic");
+const CSHARP_FIXTURE = path.join(__dirname, "fixtures", "csharp-basic");
 
 describe("parsePom", () => {
   it("extracts project dependencies with correct kinds (test scope -> dev)", () => {
@@ -162,6 +166,59 @@ describe("parsePom", () => {
   });
 });
 
+describe("parseCsproj", () => {
+  it("extracts PackageReference — self-closing and open/close forms", () => {
+    const deps = parseCsproj.parse(`
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0"></PackageReference>
+  </ItemGroup>
+</Project>
+`);
+    expect(deps).toEqual([
+      { name: "Newtonsoft.Json", versionRange: "13.0.3", kind: "runtime" },
+      { name: "Microsoft.Extensions.Logging", versionRange: "8.0.0", kind: "runtime" },
+    ]);
+  });
+
+  it("matches by extension, not by an exact filename (issue #438)", () => {
+    expect(parseCsproj.filename).toEqual([]);
+    expect(parseCsproj.extension).toBe(".csproj");
+    expect(manifestRegistry.getParserForFilename(".csproj")).toBeUndefined();
+  });
+});
+
+describe("ManifestRegistry — extension-based discovery (issue #438)", () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    ensureParsersRegistered();
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "arclux-csproj-"));
+    mkdirSync(path.join(tempDir, "src", "MyApp"), { recursive: true });
+    mkdirSync(path.join(tempDir, "src", "MyApp", "Tests"), { recursive: true });
+    writeFileSync(
+      path.join(tempDir, "src", "MyApp", "MyApp.csproj"),
+      `<Project><ItemGroup><PackageReference Include="Newtonsoft.Json" Version="13.0.3" /></ItemGroup></Project>`
+    );
+    // Nested deeper + a distractor file to prove the walk is recursive and targeted.
+    writeFileSync(
+      path.join(tempDir, "src", "MyApp", "Tests", "MyApp.Tests.csproj"),
+      `<Project><ItemGroup><PackageReference Include="xunit" Version="2.6.6" /></ItemGroup></Project>`
+    );
+    writeFileSync(path.join(tempDir, "README.md"), "# not a manifest\n");
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("finds nested .csproj files via the extension pass", () => {
+    const names = manifestRegistry.detectDependencies(tempDir).map((d) => d.name).sort();
+    expect(names).toEqual(["Newtonsoft.Json", "xunit"]);
+  });
+});
+
 describe("parseGradle_", () => {
   it("extracts implementation/api/runtimeOnly as runtime, testImplementation as dev", () => {
     const deps = parseGradle_.parse(`
@@ -249,5 +306,21 @@ describe("Manifest wiring e2e: build.gradle.kts through analyzeRepository", () =
   it("surfaces Kotlin DSL dependencies from build.gradle.kts", () => {
     const names = result.dependencies.map((d) => d.name).sort();
     expect(names).toEqual(["junit:junit", "org.springframework:spring-core"]);
+  });
+});
+
+describe("Manifest wiring e2e: nested MyApp.csproj through analyzeRepository (issue #438)", () => {
+  let result: AnalyzeRepositoryResult;
+
+  beforeAll(async () => {
+    result = await analyzeRepository({ localPath: CSHARP_FIXTURE });
+  }, 30_000);
+
+  it("surfaces NuGet PackageReference dependencies from a nested .csproj", () => {
+    const names = result.dependencies.map((d) => d.name).sort();
+    expect(names).toEqual([
+      "Microsoft.Extensions.Logging",
+      "Newtonsoft.Json",
+    ]);
   });
 });


### PR DESCRIPTION
Closes #438

## Problem

`parseCsproj` registered `filename: ".csproj"` — an exact filename lookup. `ManifestRegistry.detectDependencies` does `join(rootPath, filename)`, which only matches a file literally named `.csproj` at the repo root. Real .NET projects have per-project files in subdirectories with arbitrary names (`src/MyApp/MyApp.csproj`), so every real .csproj was silently skipped and NuGet dependencies never reached `AnalyzeRepositoryResult.dependencies`.

## Fix

- `ManifestParserInterface`: optional `extension?: string` — match files by extension ANYWHERE under the repo root.
- `ManifestRegistry`: keeps extension-parsers in a separate list (an empty `filename` array registers nothing in the filename map — caught by the first test run); `detectDependencies` does a second pass with ONE recursive walk (skipping node_modules/.git) parsing every file whose extension matches.
- `parseCsproj`: `filename: []`, `extension: ".csproj"`.

## Verification

4 new tests (tests/manifest.test.ts, 18 total): parseCsproj unit (self-closing + open/close PackageReference forms), registration moved from filename to extension, registry extension pass on a temp dir with NESTED csproj files + a distractor file, e2e fixture `tests/fixtures/csharp-basic/src/MyApp/MyApp.csproj` through `analyzeRepository` (dependencies = the 2 NuGet packages).

Full suite 369/369 (365 + 4), typecheck + lint clean. Blast radius verified via MCP (impact_analysis: low risk, only ManifestRegistry.ts affected — callers confirmed by direct read: pipeline.ts analyzeLocalPath/analyzeRemoteRepository).