### PR TITLE
test: cover editor navigation (CodeNavigator/ImpactNavigator) + architecturalDiff (issue #451)

### DIFF
--- a/tests/architectural-diff.test.ts
+++ b/tests/architectural-diff.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Integration tests for packages/diff/architecturalDiff.ts (issue #451) —
+// the core of the `arclux diff` command. Runs against a REAL git repo in a
+// temp dir (same pattern as tests/git-history.test.ts), then indexes the
+// working tree via the REAL pipeline (analyzeRepository). Pins the
+// documented MVP contract: changed files between two refs + transitive
+// consumers computed against the CURRENT tree.
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { computeArchitecturalDiff } from "../packages/diff/architecturalDiff";
+import { analyzeRepository, type AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+
+function run(dir: string, cmd: string): string {
+  return execSync(cmd, { cwd: dir, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+describe("computeArchitecturalDiff", () => {
+  let dir: string;
+  let created = false;
+  let result: AnalyzeRepositoryResult;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), "arclux-diff-test-"));
+    run(dir, "git init -b main");
+    run(dir, 'git config user.email "tester@arclux.test"');
+    run(dir, 'git config user.name "Test User"');
+
+    // v1: entry imports service imports data.
+    writeFileSync(join(dir, "entry.ts"), 'import { getService } from "./service";\nexport const entry = getService();\n');
+    writeFileSync(join(dir, "service.ts"), 'import { data } from "./data";\nexport function getService() { return data; }\n');
+    writeFileSync(join(dir, "data.ts"), 'export const data = 1;\n');
+    run(dir, 'git add . && git commit -m "v1"');
+
+    // v2: modify service.ts (its consumers are now at risk), add an unused file.
+    writeFileSync(join(dir, "service.ts"), 'import { data } from "./data";\nexport function getService() { return data + 1; }\n');
+    writeFileSync(join(dir, "unused.ts"), "export const unused = true;\n");
+    run(dir, 'git add . && git commit -m "v2"');
+
+    created = true;
+  }, 60_000);
+
+  afterAll(() => {
+    if (created) rmSync(dir, { recursive: true, force: true });
+  });
+
+  beforeAll(async () => {
+    // Index the CURRENT working tree (v2) through the real pipeline.
+    result = await analyzeRepository({ localPath: dir });
+  }, 60_000);
+
+  it("reports the files changed between the two refs with their statuses", () => {
+    const diff = computeArchitecturalDiff(result.repository, dir, "HEAD~1", "HEAD");
+    const byPath = Object.fromEntries(diff.changedFiles.map((f) => [f.path, f.status]));
+    expect(byPath["service.ts"]).toBe("modified");
+    expect(byPath["unused.ts"]).toBe("added");
+    // data.ts and entry.ts untouched in v2
+    expect(byPath["data.ts"]).toBeUndefined();
+    expect(byPath["entry.ts"]).toBeUndefined();
+  });
+
+  it("reports transitive consumers of the modified file as affected", () => {
+    const diff = computeArchitecturalDiff(result.repository, dir, "HEAD~1", "HEAD");
+    // service.ts changed -> its direct consumer entry.ts is affected.
+    expect(diff.affectedFiles).toContain("entry.ts");
+    // The added unused.ts has no importers -> not affected.
+    expect(diff.affectedFiles).not.toContain("unused.ts");
+  });
+
+  it("indexes the working tree modules for the diff to trace against", () => {
+    const ids = result.repository.getAllModules().map((m) => m.id).sort();
+    expect(ids).toEqual(["data.ts", "entry.ts", "service.ts", "unused.ts"]);
+  });
+});

--- a/tests/editor-navigation.test.ts
+++ b/tests/editor-navigation.test.ts
@@ -1,0 +1,154 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Real-mechanics tests for packages/editor/ (issue #451): CodeNavigator and
+// ImpactNavigator are consumed by the CLI open/edit commands and the
+// diagnose command's affected counts, but had zero tests. Both are pure
+// Repository logic, so fixtures follow the makeModule/makeRepository
+// convention used across tests/.
+
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { Repository } from "../packages/repository/Repository";
+import {
+  resolveModuleId,
+  openFile,
+  listDependencyTargets,
+  listDirectConsumerTargets,
+} from "../packages/editor/CodeNavigator";
+import { getImpactCount, getImpactNavigation } from "../packages/editor/ImpactNavigator";
+import type { ModuleInfo, RepositoryMeta, FileInfo } from "../packages/shared/types";
+
+function makeFile(relativePath: string): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "typescript",
+    extension: ".ts",
+    sizeBytes: 100,
+    hash: "fake-hash",
+  };
+}
+
+function makeModule(relativePath: string, overrides: Partial<ModuleInfo> = {}): ModuleInfo {
+  return {
+    id: relativePath,
+    file: makeFile(relativePath),
+    exports: [],
+    resolvedReExports: {},
+    importedBy: [],
+    imports: [],
+    resolvedImports: [],
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+    ...overrides,
+  };
+}
+
+function makeRepository(modules: ModuleInfo[], rootPath = "/virtual/repo"): Repository {
+  const meta: RepositoryMeta = {
+    id: "editor-test",
+    org: "test-org",
+    name: "editor-test",
+    defaultBranch: "main",
+    rootPath,
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+describe("CodeNavigator — resolveModuleId / openFile", () => {
+  const repo = makeRepository(
+    [makeModule("src/entry.ts")],
+    path.resolve("C:", "virtual", "repo") // Windows-safe fake root for path.relative
+  );
+
+  it("normalizes an absolute path to the POSIX module id", () => {
+    const absolute = path.join(repo.meta.rootPath, "src", "entry.ts");
+    expect(resolveModuleId(repo, absolute)).toBe("src/entry.ts");
+  });
+
+  it("openFile returns the module for a tracked path and null for an untracked one", () => {
+    const tracked = openFile(repo, path.join(repo.meta.rootPath, "src", "entry.ts"));
+    expect(tracked).not.toBeNull();
+    expect(tracked!.id).toBe("src/entry.ts");
+
+    const untracked = openFile(repo, path.join(repo.meta.rootPath, "src", "missing.ts"));
+    expect(untracked).toBeNull();
+  });
+});
+
+describe("CodeNavigator — dependency and consumer targets", () => {
+  const repo = makeRepository([
+    makeModule("entry.ts", {
+      resolvedImports: [
+        { moduleId: "service.ts", kind: "static", namedImports: ["getService"], hasDefaultImport: false, hasNamespaceImport: false, line: 3 },
+        { moduleId: "missing-target.ts", kind: "static", namedImports: [], hasDefaultImport: true, hasNamespaceImport: false, line: 4 },
+      ],
+    }),
+    makeModule("service.ts", { importedBy: ["entry.ts"] }),
+  ]);
+
+  it("lists dependency targets from resolved imports, keeping the import line", () => {
+    const targets = listDependencyTargets(repo, "entry.ts");
+    expect(targets).toEqual([
+      { moduleId: "service.ts", filePath: "service.ts", line: 3 },
+      // target not in the repository -> filePath falls back to the module id
+      { moduleId: "missing-target.ts", filePath: "missing-target.ts", line: 4 },
+    ]);
+  });
+
+  it("lists direct consumer targets from importedBy", () => {
+    const targets = listDirectConsumerTargets(repo, "service.ts");
+    expect(targets).toEqual([{ moduleId: "entry.ts", filePath: "entry.ts" }]);
+  });
+
+  it("returns [] for an unknown module", () => {
+    expect(listDependencyTargets(repo, "ghost.ts")).toEqual([]);
+    expect(listDirectConsumerTargets(repo, "ghost.ts")).toEqual([]);
+  });
+});
+
+describe("ImpactNavigator — getImpactCount / getImpactNavigation", () => {
+  const chainRepo = makeRepository([
+    makeModule("entry.ts", { imports: ["service.ts"] }),
+    makeModule("service.ts", { imports: ["repository.ts"], importedBy: ["entry.ts"] }),
+    makeModule("repository.ts", { importedBy: ["service.ts"] }),
+  ]);
+
+  it("getImpactCount reports the transitive consumer count", () => {
+    expect(getImpactCount(chainRepo, "repository.ts")).toBe(2);
+    expect(getImpactCount(chainRepo, "ghost.ts")).toBe(0);
+  });
+
+  it("getImpactNavigation returns direct consumers, affected files and the tree", () => {
+    const nav = getImpactNavigation(chainRepo, "repository.ts");
+    expect(nav.notFound).toBe(false);
+    expect(nav.moduleId).toBe("repository.ts");
+    expect(nav.directConsumers.map((t) => t.moduleId)).toEqual(["service.ts"]);
+    expect(nav.totalAffected).toBe(2);
+    expect(nav.affected.map((t) => t.moduleId)).toEqual(["service.ts", "entry.ts"]);
+    expect(nav.tree).not.toBeNull();
+    expect(nav.tree!.moduleId).toBe("repository.ts");
+  });
+
+  it("getImpactNavigation returns notFound for an unknown module", () => {
+    const nav = getImpactNavigation(chainRepo, "ghost.ts");
+    expect(nav.notFound).toBe(true);
+    expect(nav.totalAffected).toBe(0);
+    expect(nav.affected).toEqual([]);
+    expect(nav.tree).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #451

## Problem

Audit iteration 3 found two packages consumed by REAL CLI commands with zero tests:

1. **packages/editor/** — CodeNavigator (used by CLI open/edit) and ImpactNavigator (getImpactCount used by diagnose): pure Repository logic, completely untested.
2. **packages/diff/architecturalDiff.ts** — core of the `arclux diff` command: untested.

## Fix

- **tests/editor-navigation.test.ts** (8 tests): resolveModuleId POSIX-normalization, openFile tracked/untracked, listDependencyTargets (resolved imports + line, missing-target fallback), listDirectConsumerTargets, unknown-module -> []; getImpactCount chain/notFound, getImpactNavigation directConsumers/affected/tree/notFound.
- **tests/architectural-diff.test.ts** (3 tests): REAL tmp git repo (git-history.test.ts pattern) — v1 (entry -> service -> data), v2 modifies service.ts + adds unused.ts; indexes the working tree via the real analyzeRepository pipeline; asserts changedFiles statuses (modified/added) and affected = transitive consumers of the modified file only. Pins the documented MVP contract (impact vs current tree, not dual-graph).

Full suite 423/423 (412 + 11), typecheck + lint clean.