### PR TITLE
test: cover cache/ and db/ packages — the last uncovered packages (issue #455)

### DIFF
--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,0 +1,195 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Real-mechanics tests for packages/cache/ (issue #455) — the fingerprint
+// and cache-key logic consumed by analyzeRemoteRepository (repositoryCache/
+// graphCache) and buildIndex (fileCache). MemoryCache is also pinned here;
+// note it is currently DEAD CODE (zero importers repo-wide — verified by
+// grep), kept tested so its contract survives until something consumes it.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { Repository } from "../packages/repository/Repository";
+import { computeRepositoryFingerprint } from "../packages/cache/repositoryCache";
+import {
+  getCachedRepository,
+  setCachedRepository,
+  invalidateCachedRepository,
+  clearRepositoryCache,
+  repositoryCacheSize,
+} from "../packages/cache/repositoryCache";
+import {
+  getCachedGraph,
+  setCachedGraph,
+  invalidateCachedGraph,
+  clearGraphCache,
+  graphCacheSize,
+} from "../packages/cache/graphCache";
+import {
+  getCachedParsedFile,
+  setCachedParsedFile,
+  invalidateCachedParsedFile,
+  clearFileCache,
+  fileCacheSize,
+} from "../packages/cache/fileCache";
+import { getCacheStats, clearAllCaches } from "../packages/cache/CacheProvider";
+import { MemoryCache } from "../packages/cache/memoryCache";
+import type { RepositoryMeta } from "../packages/shared/types";
+
+function makeRepository(id: string): Repository {
+  const meta: RepositoryMeta = {
+    id,
+    org: "test-org",
+    name: id,
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  return new Repository(meta);
+}
+
+const EMPTY_GRAPH = { repositoryId: "g", nodes: [], edges: [], builtAt: new Date().toISOString() };
+
+afterEach(() => {
+  clearAllCaches();
+});
+
+describe("computeRepositoryFingerprint", () => {
+  it("is order-independent for the same file set", () => {
+    const a = [
+      { relativePath: "b.ts", hash: "h2" },
+      { relativePath: "a.ts", hash: "h1" },
+    ];
+    const b = [
+      { relativePath: "a.ts", hash: "h1" },
+      { relativePath: "b.ts", hash: "h2" },
+    ];
+    expect(computeRepositoryFingerprint(a)).toBe(computeRepositoryFingerprint(b));
+  });
+
+  it("changes when any file's content hash changes", () => {
+    const base = [{ relativePath: "a.ts", hash: "h1" }];
+    const changed = [{ relativePath: "a.ts", hash: "h2" }];
+    expect(computeRepositoryFingerprint(base)).not.toBe(computeRepositoryFingerprint(changed));
+  });
+});
+
+describe("repositoryCache", () => {
+  it("returns the cached Repository only when the fingerprint matches", () => {
+    setCachedRepository("https://github.com/x/repo", "main", "fp1", makeRepository("r1"));
+    expect(getCachedRepository("https://github.com/x/repo", "main", "fp1")).not.toBeUndefined();
+    // Same key, different fingerprint (repo content changed) -> miss.
+    expect(getCachedRepository("https://github.com/x/repo", "main", "fp2")).toBeUndefined();
+    // Different key entirely -> miss.
+    expect(getCachedRepository("https://github.com/x/repo", "dev", "fp1")).toBeUndefined();
+  });
+
+  it("invalidates a single entry and clears the whole cache", () => {
+    setCachedRepository("r", "main", "fp", makeRepository("r1"));
+    setCachedRepository("r", "dev", "fp", makeRepository("r2"));
+    expect(repositoryCacheSize()).toBe(2);
+    invalidateCachedRepository("r", "main");
+    expect(getCachedRepository("r", "main", "fp")).toBeUndefined();
+    expect(repositoryCacheSize()).toBe(1);
+    clearRepositoryCache();
+    expect(repositoryCacheSize()).toBe(0);
+  });
+});
+
+describe("graphCache", () => {
+  it("returns the cached graph only when the fingerprint matches", () => {
+    setCachedGraph("g", "main", "fp", EMPTY_GRAPH);
+    expect(getCachedGraph("g", "main", "fp")).toBe(EMPTY_GRAPH);
+    expect(getCachedGraph("g", "main", "other")).toBeUndefined();
+  });
+
+  it("invalidates and clears", () => {
+    setCachedGraph("g", "main", "fp", EMPTY_GRAPH);
+    invalidateCachedGraph("g", "main");
+    expect(graphCacheSize()).toBe(0);
+    setCachedGraph("g", "main", "fp", EMPTY_GRAPH);
+    clearGraphCache();
+    expect(graphCacheSize()).toBe(0);
+  });
+});
+
+describe("fileCache", () => {
+  const parsed = { file: {} as never, imports: [], exports: [], warnings: [] };
+
+  it("hits on identical content, misses when the file content changed", () => {
+    setCachedParsedFile("src/a.ts", "const x = 1;", parsed);
+    expect(getCachedParsedFile("src/a.ts", "const x = 1;")).toBe(parsed);
+    // Same path, different content -> the cached parse is stale.
+    expect(getCachedParsedFile("src/a.ts", "const x = 2;")).toBeUndefined();
+  });
+
+  it("invalidates a single path and clears", () => {
+    setCachedParsedFile("src/a.ts", "1", parsed);
+    setCachedParsedFile("src/b.ts", "1", parsed);
+    expect(fileCacheSize()).toBe(2);
+    invalidateCachedParsedFile("src/a.ts");
+    expect(getCachedParsedFile("src/a.ts", "1")).toBeUndefined();
+    expect(fileCacheSize()).toBe(1);
+    clearFileCache();
+    expect(fileCacheSize()).toBe(0);
+  });
+});
+
+describe("CacheProvider", () => {
+  it("aggregates sizes across the three caches", () => {
+    setCachedParsedFile("a.ts", "1", { file: {} as never, imports: [], exports: [], warnings: [] });
+    setCachedRepository("r", "main", "fp", makeRepository("r1"));
+    setCachedGraph("g", "main", "fp", EMPTY_GRAPH);
+    const stats = getCacheStats();
+    expect(stats.fileCacheSize).toBe(1);
+    expect(stats.repositoryCacheSize).toBe(1);
+    expect(stats.graphCacheSize).toBe(1);
+    expect(stats.totalEntries).toBe(3);
+    clearAllCaches();
+    expect(getCacheStats().totalEntries).toBe(0);
+  });
+});
+
+describe("MemoryCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stores and returns values without a TTL", () => {
+    const cache = new MemoryCache<string, number>();
+    cache.set("a", 1);
+    expect(cache.get("a")).toBe(1);
+    expect(cache.has("a")).toBe(true);
+    expect(cache.size).toBe(1);
+  });
+
+  it("expires entries after their TTL elapses", () => {
+    const cache = new MemoryCache<string, number>();
+    cache.set("a", 1, 1000);
+    vi.advanceTimersByTime(999);
+    expect(cache.get("a")).toBe(1);
+    vi.advanceTimersByTime(2);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.has("a")).toBe(false);
+  });
+
+  it("deletes and clears entries", () => {
+    const cache = new MemoryCache<string, number>();
+    cache.set("a", 1);
+    cache.set("b", 2);
+    expect(cache.delete("a")).toBe(true);
+    expect(cache.get("a")).toBeUndefined();
+    expect(cache.size).toBe(1);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1,0 +1,183 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Real-mechanics tests for packages/db/ (issue #455) — the JSON-file-per-
+// record client and its RepoStore/AnalysisStore/IssueStore wrappers.
+// ARCLUX_ROOT is pointed at a temp dir so nothing touches the real home
+// directory.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { putRecord, getRecord, listRecords, deleteRecord } from "../packages/db/client";
+import { saveRepo, getRepo, listRepos, deleteRepo } from "../packages/db/repositories/RepoStore";
+import { saveAnalysis, getAnalysis, listAnalysesForRepo } from "../packages/db/repositories/AnalysisStore";
+import { saveIssues, listIssuesForAnalysis, listIssuesForRepo, clearIssuesForAnalysis } from "../packages/db/repositories/IssueStore";
+import type { RepositoryMeta } from "../packages/shared/types";
+import type { AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+import type { Issue } from "../packages/engine/contract";
+import { Repository } from "../packages/repository/Repository";
+
+const OLD_ARCLUX_ROOT = process.env.ARCLUX_ROOT;
+let root: string;
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "arclux-db-test-"));
+  process.env.ARCLUX_ROOT = root;
+});
+
+afterAll(() => {
+  if (OLD_ARCLUX_ROOT === undefined) delete process.env.ARCLUX_ROOT;
+  else process.env.ARCLUX_ROOT = OLD_ARCLUX_ROOT;
+  rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(root, { recursive: true });
+});
+
+afterEach(() => {
+  // nothing persists across tests — root is recreated per test
+});
+
+interface SampleRecord {
+  id: string;
+  value: string;
+}
+
+describe("db client", () => {
+  it("round-trips a record and strips __schemaVersion on read", () => {
+    putRecord<SampleRecord>("repos", { id: "r1", value: "v" });
+    const read = getRecord<SampleRecord>("repos", "r1");
+    expect(read).toEqual({ id: "r1", value: "v" });
+    expect(read).not.toHaveProperty("__schemaVersion");
+  });
+
+  it("returns null for a missing record and for a corrupt file", () => {
+    expect(getRecord("repos", "nope")).toBeNull();
+    const dir = join(root, "db", "repos");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "corrupt.json"), "not json");
+    expect(getRecord("repos", "corrupt")).toBeNull();
+  });
+
+  it("lists records and skips corrupt files without throwing", () => {
+    putRecord<SampleRecord>("repos", { id: "a", value: "1" });
+    putRecord<SampleRecord>("repos", { id: "b", value: "2" });
+    const dir = join(root, "db", "repos");
+    writeFileSync(join(dir, "corrupt.json"), "not json");
+    const records = listRecords<SampleRecord>("repos");
+    expect(records.map((r) => r.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("deletes a record and tolerates deleting a missing one", () => {
+    putRecord<SampleRecord>("repos", { id: "a", value: "1" });
+    deleteRecord("repos", "a");
+    expect(getRecord("repos", "a")).toBeNull();
+    expect(() => deleteRecord("repos", "missing")).not.toThrow();
+  });
+});
+
+describe("RepoStore", () => {
+  const meta: RepositoryMeta = {
+    id: "repo-1",
+    org: "acme",
+    name: "app",
+    defaultBranch: "main",
+    rootPath: "/repo/app",
+    detectedFrameworks: ["react"],
+    packageManager: "npm",
+    analyzedAt: "2026-08-15T00:00:00.000Z",
+  };
+
+  it("saves and reads a repo from RepositoryMeta", () => {
+    saveRepo(meta);
+    expect(getRepo("repo-1")).toEqual(meta);
+  });
+
+  it("lists all saved repos and deletes one", () => {
+    saveRepo(meta);
+    saveRepo({ ...meta, id: "repo-2", name: "other" });
+    expect(listRepos().map((r) => r.id).sort()).toEqual(["repo-1", "repo-2"]);
+    deleteRepo("repo-1");
+    expect(getRepo("repo-1")).toBeNull();
+  });
+});
+
+function fakeResult(moduleCount: number, nodes: number, edges: number): AnalyzeRepositoryResult {
+  const meta: RepositoryMeta = {
+    id: "local",
+    org: "local",
+    name: "app",
+    defaultBranch: "local",
+    rootPath: "/repo/app",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: "2026-08-15T10:00:00.000Z",
+  };
+  return {
+    meta,
+    moduleCount,
+    graph: {
+      repositoryId: "g",
+      nodes: Array.from({ length: nodes }, (_, i) => ({ id: `n${i}`, type: "file", label: `n${i}` })),
+      edges: Array.from({ length: edges }, (_, i) => ({ id: `e${i}`, source: "a", target: "b", type: "import" })),
+      builtAt: "2026-08-15T10:00:00.000Z",
+    },
+    scanSummary: { filesScanned: 0, filesParsed: 0, filesSkippedNoParser: 0, skippedByExtension: {} },
+    repository: new Repository(meta),
+    dependencies: [],
+  };
+}
+
+describe("AnalysisStore", () => {
+  it("saves an analysis summary and reads it back", () => {
+    const record = saveAnalysis("repo-1", fakeResult(12, 20, 31));
+    const read = getAnalysis(record.id);
+    expect(read).not.toBeNull();
+    expect(read!.repoId).toBe("repo-1");
+    expect(read!.moduleCount).toBe(12);
+    expect(read!.nodeCount).toBe(20);
+    expect(read!.edgeCount).toBe(31);
+  });
+
+  it("lists analyses for a repo, most recent first", () => {
+    const older = saveAnalysis("repo-1", { ...fakeResult(1, 1, 1), meta: { ...fakeResult(1, 1, 1).meta, analyzedAt: "2026-08-15T08:00:00.000Z" } });
+    const newer = saveAnalysis("repo-1", { ...fakeResult(2, 2, 2), meta: { ...fakeResult(2, 2, 2).meta, analyzedAt: "2026-08-15T09:00:00.000Z" } });
+    saveAnalysis("repo-2", fakeResult(3, 3, 3));
+    const forRepo = listAnalysesForRepo("repo-1");
+    expect(forRepo.map((r) => r.id)).toEqual([newer.id, older.id]);
+  });
+});
+
+describe("IssueStore", () => {
+  const issues: Issue[] = [
+    { source: "detector", checkId: "circularDependency", severity: "error", message: "cycle" },
+    { source: "rule", checkId: "requirePage", severity: "warning", message: "no page" },
+  ];
+
+  it("saves issues tied to an analysis and lists them by analysis/repo", () => {
+    const records = saveIssues("repo-1", "analysis-1", issues);
+    expect(records).toHaveLength(2);
+    const byAnalysis = listIssuesForAnalysis("analysis-1");
+    expect(byAnalysis.map((r) => r.checkId).sort()).toEqual(["circularDependency", "requirePage"]);
+    expect(listIssuesForAnalysis("analysis-2")).toEqual([]);
+    expect(listIssuesForRepo("repo-1")).toHaveLength(2);
+    expect(listIssuesForRepo("repo-2")).toEqual([]);
+  });
+
+  it("clears all issues for one analysis run", () => {
+    saveIssues("repo-1", "analysis-1", issues);
+    saveIssues("repo-1", "analysis-2", [issues[0]]);
+    clearIssuesForAnalysis("analysis-1");
+    expect(listIssuesForAnalysis("analysis-1")).toEqual([]);
+    expect(listIssuesForAnalysis("analysis-2")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #455

## Problem

Audit iteration 4: cache/ and db/ were the last two packages with zero test references.

1. **packages/cache/** — fingerprint/cache-key mechanics consumed by analyzeRemoteRepository (repositoryCache/graphCache) and buildIndex (fileCache). Also CacheProvider and MemoryCache (MemoryCache is currently DEAD CODE — zero importers, verified by grep; pinned anyway so its contract survives).
2. **packages/db/** — JSON-file-per-record client (putRecord/getRecord/listRecords/deleteRecord, __schemaVersion stripping, corrupt/missing tolerance, ARCLUX_ROOT override) + RepoStore/AnalysisStore/IssueStore wrappers.

## Fix

- **tests/cache.test.ts** (12 tests): fingerprint order-independence + content-sensitivity, repositoryCache/graphCache hit/miss/invalidate/clear/size semantics, fileCache content-hash staleness, CacheProvider stats aggregation, MemoryCache set/get/TTL-expiry (fake timers)/delete/clear.
- **tests/db.test.ts** (10 tests, ARCLUX_ROOT -> tmp dir): client roundtrip + schema-version stripping + missing/corrupt tolerance + list-skip-corrupt + delete semantics; RepoStore save/get/list/delete; AnalysisStore save/get + per-repo list sorted most-recent-first; IssueStore save/list-by-analysis/repo + clearIssuesForAnalysis.

Full suite 445/445 (423 + 22), typecheck + lint clean.