### PR TITLE
test(detectors): detector quality gate — mutation, adversarial, scoring suites

### DIFF
--- a/progres/status-backlog.md
+++ b/progres/status-backlog.md
@@ -2,6 +2,90 @@
 
 See PROGRES.md for the index. Split by topic from the original PROGRES-status.md.
 
+## 2026-08-15 — PLAN: detector quality gate (graph mutations + adversarial suite + scoring)
+
+> **[STATUS UPDATE, 2026-08-15]: items 1 (graph-mutation tests, 11
+> tests), 2 (adversarial suite, 15 tests) and 3 (scoring gate, 19/19 both
+> directions) are now implemented — suite green 474/474 (44 files).
+> See "UPDATE: detector quality gate — graph mutations implemented" below.**
+
+**Status:** Not Started
+
+**Context.** From a cross-project audit (MSCodeBase → ARCLUX). Claims were
+fact-checked against current code first so nothing already done gets re-done:
+- 2026-08-15 detector work already gives every one of the 19 detectors a
+  positive/negative control with real fixtures (`tests/detector.test.ts`,
+  `tests/core-detectors.test.ts`, `tests/detectors-wired.test.ts`)
+- Python relative imports are fixed & tested (issue #429 —
+  `tests/python-e2e.test.ts`, `tests/resolvePath.test.ts`)
+
+**Gap, verified this session:**
+
+1. **Graph-mutation tests** — nothing asserts that inserting an edge into an
+   acyclic graph makes `detectCircularDependency` fire (and removing it
+   clears the finding). The evalmut "add_edge_to_make_cyclic" idea, in TS:
+   `tests/mutation-graph.test.ts` — build a 3-module acyclic fixture, assert
+   no cycle, add an edge, assert cycle + exact node set, remove, assert clean.
+2. **Adversarial edge-case suite** — `tests/detectors-adversarial.test.ts`:
+   - minified one-liner (`def A():pass\ndef B():pass`) → no crash
+   - comment mentioning "A calls B, B calls A" → no false positive
+   - `if TYPE_CHECKING:` conditional import → open question: real edge or
+     skip? (tree-sitter currently extracts it as a real edge — confirm
+     whether that's desired before asserting)
+   - `getattr(obj, "method")()` dynamic call → dead-code detector must not
+     flag, or flag with `confidence: "low"`
+   - `test_*.py` / `*.test.ts` files → never flagged as dead
+3. **Scoring gate** — one run (vitest or `scripts/`): planted violation
+   across all 19 detectors → all fire; clean fixture repo → all empty.
+   Target: 19/19 both directions as a regression gate.
+
+**Why vitest, not a Python harness:** ARCLUX is TS + vitest; `tests/fixtures/`
+and `makeModule`/`makeRepository` already exist. Importing Python evalmut
+would add a second stack for a concept vitest covers natively.
+
+**Estimate:** 6-10h (2-3h mutations, 3-4h adversarial, 1-2h scoring gate).
+
+## 2026-08-15 — UPDATE: detector quality gate — graph mutations implemented
+
+**Status:** Done (items 1-3 implemented)
+
+`tests/mutation-graph.test.ts` added (11 tests, vitest): mutation-style
+suite for detectCircularDependency — acyclic baseline → 0 findings;
+plant edge c->a → cycle with exact node set + canonical rotation
+(issue #207); remove → clean (round-trip); forward-edge negative control;
+2-node cycle; entry-point rotation dedup; second cycle joins existing one
+without key collisions; unrelated-component mutation leaves finding
+untouched; self-loop documented; live-mutation ≡ fresh-index equivalence;
+sub-cycle excludes outsider node. Helpers mirror makeModule/makeRepository
+from tests/core-detectors.test.ts; mutateImports fails fast on unknown
+module ids. Full suite: 456/456 (42 files).
+
+Item 2 landed in the same pass: `tests/detectors-adversarial.test.ts`
+(15 tests). Source level (parsePython): minified one-liner, comment
+mentioning a cycle / string literal containing an import can't create
+edges, invalid syntax tolerated (ERROR nodes), empty source. Detector
+level: TYPE_CHECKING import is extracted as a real edge and closes a
+cycle — pinned current behavior, **OPEN QUESTION** (skip type-only edges
+at parse time?); test files with no importers are flagged as orphan and
+side-effect-imported test files are flagged as dead — pinned, **OPEN
+QUESTION** (exclude test files by convention like entry points?);
+dynamic-call usage is invisible to detectDeadCode (documented scope
+boundary — no call-extraction pass); namespace import counts as using
+every export (no false positive). Also fixed a latent type-error class
+uncovered while writing these: `ResolvedImport.kind` was missing in the
+makeModule helpers of core-detectors/detector/guard-inventory/runDoctor
+test files + a widened `language` param in runDoctor — all 5 files now
+LSP-clean. Suite: 471/471 (43 files).
+
+Item 3 (scoring gate): `tests/detector-score.test.ts` — registry-driven
+meta-gate iterating all 19 detectors with minimal planted-violation and
+clean fixtures: asserts every detector fires (positive) and stays empty
+(negative), plus an exact denominator check (19). Result: 19/19
+positive, 19/19 negative. Two product decisions surfaced by the
+adversarial suite are tracked as issues: #458 (TYPE_CHECKING imports as
+real edges) and #459 (test files flagged as orphan/dead). Suite:
+474/474 (44 files).
+
 ## 2026-08-13 — UPDATE: framework rule stubs — implemented
 
 All 10 remaining rule stubs in `packages/rules/*` (nextjs x4, nestjs x2,

--- a/tests/core-detectors.test.ts
+++ b/tests/core-detectors.test.ts
@@ -56,7 +56,7 @@ function makeModule(
     resolvedReExports: {},
     importedBy: opts.importedBy ?? [],
     imports,
-    resolvedImports: opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 })),
+    resolvedImports: (opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }))).map((r) => ({ ...r, kind: "static" as const })),
     calls: [],
     calledBy: [],
     implicitDependencies: [],

--- a/tests/detector-score.test.ts
+++ b/tests/detector-score.test.ts
@@ -1,0 +1,365 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Scoring gate (plan entry "detector quality gate", progres/status-backlog.md
+// 2026-08-15 — item 3): ONE registry-driven run that proves every one of the
+// 19 detectors can fire on a planted violation AND stays empty on a clean
+// fixture. This is deliberately a meta-gate with minimal fixtures — the rich
+// per-detector cases live in tests/detector.test.ts / core-detectors.test.ts.
+// Keep this registry in sync with those when a detector contract changes.
+//
+// Target: 19/19 positive, 19/19 negative.
+
+import { describe, it, expect } from "vitest";
+import { Repository } from "../packages/repository/Repository";
+import { detectCircularDependency } from "../packages/detectors/detectCircularDependency";
+import { detectUnusedExports } from "../packages/detectors/detectUnusedExports";
+import { detectOrphanFiles } from "../packages/detectors/detectOrphanFiles";
+import { detectDeadCode } from "../packages/detectors/detectDeadCode";
+import { detectLargeModules } from "../packages/detectors/detectLargeModules";
+import { detectDuplicateModules } from "../packages/detectors/detectDuplicateModules";
+import { detectSharedModules } from "../packages/detectors/detectSharedModules";
+import { detectIndexFiles } from "../packages/detectors/detectIndexFiles";
+import { detectLayerViolation } from "../packages/detectors/detectLayerViolation";
+import { detectEntryPoints } from "../packages/detectors/detectEntryPoints";
+import { detectMissingExports } from "../packages/detectors/detectMissingExports";
+import { detectRouteConvention } from "../packages/detectors/detectRouteConvention";
+import { detectComponentConvention } from "../packages/detectors/detectComponentConvention";
+import { detectFeatureStructure } from "../packages/detectors/detectFeatureStructure";
+import { detectRepositoryPattern } from "../packages/detectors/detectRepositoryPattern";
+import { detectStoryConvention } from "../packages/detectors/detectStoryConvention";
+import { detectTestConvention } from "../packages/detectors/detectTestConvention";
+import { detectUnusedFiles } from "../packages/detectors/detectUnusedFiles";
+import { detectAmbiguousSymbolResolution } from "../packages/detectors/detectAmbiguousSymbolResolution";
+import type { ModuleInfo, RepositoryMeta, FileInfo, RawExport } from "../packages/shared/types";
+
+type Detector = (repository: Repository) => unknown[];
+
+function makeFile(relativePath: string, sizeBytes = 100): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "typescript",
+    extension: ".ts",
+    sizeBytes,
+    hash: `hash-${relativePath}`,
+  };
+}
+
+function named(name: string, line = 1): RawExport {
+  return { name, kind: "named", line };
+}
+
+function defaultExport(name: string, line = 1): RawExport {
+  return { name, kind: "default", line };
+}
+
+function reExport(name: string, reExportSource: string, line = 1): RawExport {
+  return { name, kind: "re-export", reExportSource, line };
+}
+
+function makeModule(
+  relativePath: string,
+  opts: {
+    exports?: RawExport[];
+    imports?: string[];
+    resolvedImports?: { moduleId: string; namedImports: string[]; hasDefaultImport: boolean; hasNamespaceImport: boolean; line: number }[];
+    importedBy?: string[];
+    resolvedReExports?: Record<string, string>;
+    sizeBytes?: number;
+  } = {}
+): ModuleInfo {
+  const imports = opts.imports ?? [];
+  return {
+    id: relativePath,
+    file: makeFile(relativePath, opts.sizeBytes),
+    exports: opts.exports ?? [],
+    resolvedReExports: opts.resolvedReExports ?? {},
+    importedBy: opts.importedBy ?? [],
+    imports,
+    resolvedImports: (opts.resolvedImports ??
+      imports.map((moduleId) => ({
+        moduleId,
+        namedImports: [],
+        hasDefaultImport: false,
+        hasNamespaceImport: false,
+        line: 1,
+      }))).map((r) => ({ ...r, kind: "static" as const })),
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "score-repo",
+    org: "test-org",
+    name: "score-repo",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+interface ScoreEntry {
+  name: string;
+  detector: Detector;
+  planted: () => Repository;
+  clean: () => Repository;
+}
+
+const REGISTRY: ScoreEntry[] = [
+  {
+    name: "detectCircularDependency",
+    detector: detectCircularDependency,
+    planted: () =>
+      makeRepository([
+        makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+        makeModule("src/b.ts", { imports: ["src/a.ts"] }),
+      ]),
+    clean: () =>
+      makeRepository([
+        makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+        makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+        makeModule("src/c.ts"),
+      ]),
+  },
+  {
+    name: "detectUnusedExports",
+    detector: detectUnusedExports,
+    planted: () => makeRepository([makeModule("src/single.ts", { exports: [named("lonely")] })]),
+    clean: () =>
+      makeRepository([
+        makeModule("src/single.ts", { exports: [named("used")] }),
+        makeModule("src/consumer.ts", {
+          imports: ["src/single.ts"],
+          resolvedImports: [{ moduleId: "src/single.ts", namedImports: ["used"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+        }),
+      ]),
+  },
+  {
+    name: "detectOrphanFiles",
+    detector: detectOrphanFiles,
+    planted: () => makeRepository([makeModule("src/dead.ts")]),
+    clean: () => makeRepository([makeModule("src/used.ts", { importedBy: ["src/main.ts"] })]),
+  },
+  {
+    name: "detectDeadCode",
+    detector: detectDeadCode,
+    planted: () =>
+      makeRepository([
+        makeModule("src/setup.ts", { exports: [named("init")], importedBy: ["src/main.ts"] }),
+        makeModule("src/main.ts", { imports: ["src/setup.ts"] }),
+      ]),
+    clean: () =>
+      makeRepository([
+        makeModule("src/setup.ts", { exports: [named("init")], importedBy: ["src/main.ts"] }),
+        makeModule("src/main.ts", {
+          imports: ["src/setup.ts"],
+          resolvedImports: [{ moduleId: "src/setup.ts", namedImports: ["init"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+        }),
+      ]),
+  },
+  {
+    name: "detectLargeModules",
+    detector: detectLargeModules,
+    planted: () => makeRepository([makeModule("src/huge.ts", { sizeBytes: 20_000 })]),
+    clean: () => makeRepository([makeModule("src/small.ts", { sizeBytes: 100 })]),
+  },
+  {
+    name: "detectDuplicateModules",
+    detector: detectDuplicateModules,
+    planted: () => {
+      const repo = makeRepository([
+        makeModule("src/a.ts", { sizeBytes: 1000 }),
+        makeModule("src/b.ts", { sizeBytes: 1000 }),
+      ]);
+      repo.getModule("src/b.ts")!.file.hash = repo.getModule("src/a.ts")!.file.hash;
+      return repo;
+    },
+    clean: () =>
+      makeRepository([
+        makeModule("src/a.ts", { sizeBytes: 1000 }),
+        makeModule("src/b.ts", { sizeBytes: 1000 }),
+      ]),
+  },
+  {
+    name: "detectSharedModules",
+    detector: detectSharedModules,
+    planted: () =>
+      makeRepository([
+        makeModule("src/util.ts", { importedBy: ["m1", "m2", "m3", "m4", "m5", "m6"] }),
+      ]),
+    clean: () => makeRepository([makeModule("src/util.ts", { importedBy: ["m1"] })]),
+  },
+  {
+    name: "detectIndexFiles",
+    detector: detectIndexFiles,
+    planted: () =>
+      makeRepository([
+        makeModule("src/index.ts", { exports: [reExport("a", "src/a.ts"), named("localFn")] }),
+      ]),
+    clean: () => makeRepository([makeModule("src/notIndex.ts", { exports: [named("x")] })]),
+  },
+  {
+    name: "detectLayerViolation",
+    detector: detectLayerViolation,
+    planted: () =>
+      makeRepository([
+        makeModule("packages/foo/index.ts", {
+          resolvedImports: [{ moduleId: "apps/web/app/page.tsx", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 3 }],
+        }),
+        makeModule("apps/web/app/page.tsx"),
+      ]),
+    clean: () =>
+      makeRepository([
+        makeModule("packages/a.ts", {
+          resolvedImports: [{ moduleId: "packages/b.ts", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }],
+        }),
+        makeModule("packages/b.ts"),
+      ]),
+  },
+  {
+    name: "detectEntryPoints",
+    detector: detectEntryPoints,
+    planted: () => makeRepository([makeModule("apps/web/app/dashboard/page.tsx")]),
+    clean: () => makeRepository([makeModule("src/random.ts")]),
+  },
+  {
+    name: "detectMissingExports",
+    detector: detectMissingExports,
+    planted: () =>
+      makeRepository([
+        makeModule("src/index.ts"),
+        makeModule("src/helper.ts", { exports: [named("helper")] }),
+      ]),
+    clean: () =>
+      makeRepository([
+        makeModule("src/index.ts", { resolvedReExports: { helper: "src/helper.ts" } }),
+        makeModule("src/helper.ts", { exports: [named("helper")] }),
+      ]),
+  },
+  {
+    name: "detectRouteConvention",
+    detector: detectRouteConvention,
+    planted: () =>
+      makeRepository([makeModule("apps/web/app/dashboard/page.tsx", { exports: [named("metadata")] })]),
+    clean: () =>
+      makeRepository([makeModule("apps/web/app/dashboard/page.tsx", { exports: [defaultExport("Dashboard")] })]),
+  },
+  {
+    name: "detectComponentConvention",
+    detector: detectComponentConvention,
+    planted: () =>
+      makeRepository([makeModule("src/components/Button.tsx", { exports: [named("Other")] })]),
+    clean: () =>
+      makeRepository([makeModule("src/components/Button.tsx", { exports: [named("Button")] })]),
+  },
+  {
+    name: "detectFeatureStructure",
+    detector: detectFeatureStructure,
+    planted: () => makeRepository([makeModule("apps/web/features/impact/useImpact.ts")]),
+    clean: () =>
+      makeRepository([
+        makeModule("apps/web/features/graph/useGraph.ts"),
+        makeModule("apps/web/features/graph/GraphStore.ts"),
+      ]),
+  },
+  {
+    name: "detectRepositoryPattern",
+    detector: detectRepositoryPattern,
+    planted: () =>
+      makeRepository([
+        makeModule("packages/a/x.ts", { imports: ["packages/b/y.ts"] }),
+        makeModule("packages/b/y.ts", { imports: ["packages/a/z.ts"] }),
+        makeModule("packages/a/z.ts"),
+      ]),
+    clean: () =>
+      makeRepository([
+        makeModule("packages/a/x.ts", { imports: ["packages/b/y.ts", "packages/a/z.ts"] }),
+        makeModule("packages/b/y.ts"),
+        makeModule("packages/a/z.ts"),
+      ]),
+  },
+  {
+    name: "detectStoryConvention",
+    detector: detectStoryConvention,
+    planted: () => makeRepository([makeModule("src/components/Button.stories.tsx")]),
+    clean: () =>
+      makeRepository([
+        makeModule("src/components/Button.tsx"),
+        makeModule("src/components/Button.stories.tsx"),
+      ]),
+  },
+  {
+    name: "detectTestConvention",
+    detector: detectTestConvention,
+    planted: () => makeRepository([makeModule("tests/parser/foo.test.ts")]),
+    clean: () =>
+      makeRepository([
+        makeModule("packages/parser/foo.ts"),
+        makeModule("tests/parser/foo.test.ts"),
+      ]),
+  },
+  {
+    name: "detectUnusedFiles",
+    detector: detectUnusedFiles,
+    planted: () => makeRepository([makeModule("src/dead.ts")]),
+    clean: () => makeRepository([makeModule("src/used.ts", { importedBy: ["src/main.ts"] })]),
+  },
+  {
+    name: "detectAmbiguousSymbolResolution",
+    detector: detectAmbiguousSymbolResolution,
+    planted: () =>
+      makeRepository([
+        makeModule("src/symbol_index.ts", { exports: [named("resolveSymbol")] }),
+        makeModule("tests/symbol_index.test.ts", { exports: [named("resolveSymbol")] }),
+      ]),
+    clean: () => makeRepository([makeModule("src/a.ts", { exports: [named("unique")] })]),
+  },
+];
+
+describe("detector score gate", () => {
+  it(`19/19 detectors fire on their planted violation (positive score)`, () => {
+    const failures: string[] = [];
+    for (const entry of REGISTRY) {
+      const findings = entry.detector(entry.planted());
+      if (findings.length === 0) failures.push(entry.name);
+    }
+    const score = REGISTRY.length - failures.length;
+    expect(
+      failures,
+      `positive score: ${score}/${REGISTRY.length} — did NOT fire: ${failures.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it(`19/19 detectors stay empty on their clean fixture (negative score)`, () => {
+    const failures: string[] = [];
+    for (const entry of REGISTRY) {
+      const findings = entry.detector(entry.clean());
+      if (findings.length > 0) failures.push(`${entry.name} (${findings.length} findings)`);
+    }
+    const score = REGISTRY.length - failures.length;
+    expect(
+      failures,
+      `negative score: ${score}/${REGISTRY.length} — false positives: ${failures.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("registry covers all 19 detectors (score denominator is exact)", () => {
+    expect(REGISTRY.length).toBe(19);
+  });
+});

--- a/tests/detector.test.ts
+++ b/tests/detector.test.ts
@@ -87,15 +87,14 @@ function makeModule(
     resolvedReExports: opts.resolvedReExports ?? {},
     importedBy: opts.importedBy ?? [],
     imports,
-    resolvedImports:
-      opts.resolvedImports ??
+    resolvedImports: (opts.resolvedImports ??
       imports.map((moduleId) => ({
         moduleId,
         namedImports: [],
         hasDefaultImport: false,
         hasNamespaceImport: false,
         line: 1,
-      })),
+      }))).map((r) => ({ ...r, kind: "static" as const })),
     calls: [],
     calledBy: [],
     implicitDependencies: [],

--- a/tests/detectors-adversarial.test.ts
+++ b/tests/detectors-adversarial.test.ts
@@ -1,0 +1,249 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Adversarial edge-case suite (plan entry "detector quality gate",
+// progres/status-backlog.md 2026-08-15 — item 2). Two layers:
+//   A. Source level: feed hostile/weird Python through parsePython and
+//      assert no crash + correct extraction (comments can't create edges,
+//      string literals can't create edges, invalid syntax is tolerated).
+//   B. Detector level: Repository fixtures attacking detector behavior on
+//      edge cases. Where current behavior is arguably wrong (TYPE_CHECKING
+//      edges, test-file findings) the test PINS current behavior and marks
+//      an OPEN QUESTION — a deliberate behavior change updates the test.
+
+import { describe, it, expect } from "vitest";
+import { Repository } from "../packages/repository/Repository";
+import { parsePython } from "../packages/parser/python/parsePython";
+import { detectCircularDependency } from "../packages/detectors/detectCircularDependency";
+import { detectDeadCode } from "../packages/detectors/detectDeadCode";
+import { detectOrphanFiles } from "../packages/detectors/detectOrphanFiles";
+import type { FileInfo, ModuleInfo, RepositoryMeta, RawExport, ResolvedImport } from "../packages/shared/types";
+
+function makePyFile(relativePath: string): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "python",
+    extension: ".py",
+    sizeBytes: 100,
+    hash: "fake-hash",
+  };
+}
+
+function named(name: string, line = 1): RawExport {
+  return { name, kind: "named", line };
+}
+
+function makeModule(
+  relativePath: string,
+  opts: {
+    imports?: string[];
+    exports?: RawExport[];
+    importedBy?: string[];
+    resolvedImports?: ResolvedImport[];
+  } = {}
+): ModuleInfo {
+  const imports = opts.imports ?? [];
+  return {
+    id: relativePath,
+    file: { ...makePyFile(relativePath), language: "typescript", extension: ".ts" },
+    exports: opts.exports ?? [],
+    resolvedReExports: {},
+    importedBy: opts.importedBy ?? [],
+    imports,
+    resolvedImports:
+      opts.resolvedImports ??
+      imports.map((moduleId) => ({
+        moduleId,
+        kind: "static",
+        namedImports: [],
+        hasDefaultImport: false,
+        hasNamespaceImport: false,
+        line: 1,
+      })),
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "test-repo",
+    org: "test-org",
+    name: "test-repo",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+async function parsePy(source: string, relativePath = "src/mod.py") {
+  return parsePython.parse(makePyFile(relativePath), source);
+}
+
+describe("adversarial — parsePython (source level)", () => {
+  it("minified one-liner does not crash and extracts definitions", async () => {
+    const parsed = await parsePy("def A():pass\ndef B():pass\nA();B()");
+    expect(parsed.warnings).toEqual([]);
+    expect(parsed.imports).toEqual([]);
+    expect(parsed.exports.map((e) => e.name)).toEqual(["A", "B"]);
+  });
+
+  it("a comment mentioning a cycle cannot create import edges", async () => {
+    const parsed = await parsePy(
+      "# A calls B, B calls A (this is a comment, not code!)\nimport os"
+    );
+    // Only the real import is extracted; the cycle-mentioning comment adds
+    // nothing to the graph.
+    expect(parsed.imports.map((i) => i.source)).toEqual(["os"]);
+  });
+
+  it("a string literal containing an import is not an import", async () => {
+    const parsed = await parsePy('s = "import os"\ntext = \'from pathlib import Path\'');
+    expect(parsed.imports).toEqual([]);
+  });
+
+  it("TYPE_CHECKING conditional import is currently extracted as a real edge (OPEN QUESTION)", async () => {
+    const parsed = await parsePy(
+      "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from B import something"
+    );
+    // Pinned current behavior: extractImports recurses into nested nodes,
+    // so the type-only import inside the if-block becomes a real edge.
+    // OPEN QUESTION: should type-only imports be edges at all? If we
+    // decide to skip them, this assertion flips to imports === [].
+    expect(
+      parsed.imports.some((i) => i.source === "B" && i.namedImports.includes("something"))
+    ).toBe(true);
+  });
+
+  it("syntactically invalid source is tolerated (ERROR node) without crashing", async () => {
+    const parsed = await parsePy("def (:");
+    expect(parsed.imports).toEqual([]);
+    expect(parsed.exports).toEqual([]);
+  });
+
+  it("empty source parses cleanly", async () => {
+    const parsed = await parsePy("");
+    expect(parsed.imports).toEqual([]);
+    expect(parsed.exports).toEqual([]);
+    expect(parsed.warnings).toEqual([]);
+  });
+});
+
+describe("adversarial — detectCircularDependency", () => {
+  it("empty repository does not crash", () => {
+    expect(detectCircularDependency(makeRepository([]))).toEqual([]);
+  });
+
+  it("a TYPE_CHECKING-only edge closes a cycle and IS flagged (OPEN QUESTION)", () => {
+    // a -> b is a real import; b -> a exists only under `if TYPE_CHECKING:`
+    // (which the parser currently extracts as a real edge — see the source
+    // level test above). The detector therefore reports a cycle. Pinned
+    // current behavior: if TYPE_CHECKING edges get skipped at parse time,
+    // this fixture becomes the negative control.
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/a.ts"] }),
+    ]);
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(1);
+    expect(new Set(findings[0].cycle)).toEqual(new Set(["src/a.ts", "src/b.ts"]));
+  });
+});
+
+describe("adversarial — detectDeadCode", () => {
+  it("empty repository does not crash", () => {
+    expect(detectDeadCode(makeRepository([]))).toEqual([]);
+  });
+
+  it("side-effect import with unused exports is flagged; dynamic-call usage is invisible (documented blind spot)", () => {
+    // `import "./setup"` with nothing referenced + every export unused =>
+    // flagged as dead. detectDeadCode has NO call-extraction pass, so a
+    // dynamic usage like getattr(module, "init")() elsewhere cannot
+    // protect it. This pins the CURRENT scope boundary (see the
+    // detector's header comment) — the finding is accurate within that
+    // scope, it just cannot see call-site usage.
+    const repo = makeRepository([
+      makeModule("src/setup.ts", { exports: [named("init")], importedBy: ["src/main.ts"] }),
+      makeModule("src/main.ts", {
+        imports: ["src/setup.ts"],
+        resolvedImports: [
+          { moduleId: "src/setup.ts", kind: "static", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        ],
+      }),
+    ]);
+    const findings = detectDeadCode(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePath).toBe("src/setup.ts");
+  });
+
+  it("namespace import counts as using every export — no false positive", () => {
+    const repo = makeRepository([
+      makeModule("src/api.ts", { exports: [named("helper")], importedBy: ["src/main.ts"] }),
+      makeModule("src/main.ts", {
+        imports: ["src/api.ts"],
+        resolvedImports: [
+          { moduleId: "src/api.ts", kind: "static", namedImports: [], hasDefaultImport: false, hasNamespaceImport: true, line: 1 },
+        ],
+      }),
+    ]);
+    expect(detectDeadCode(repo)).toEqual([]);
+  });
+
+  it("a test file NOT imported is not dead code (orphan territory, boundary check)", () => {
+    const repo = makeRepository([makeModule("src/utils.test.ts", { exports: [named("helper")] })]);
+    // importedBy === 0 => detectDeadCode skips it (that's the orphan
+    // detector's job), so no dead-code finding...
+    expect(detectDeadCode(repo)).toEqual([]);
+    // ...and detectOrphanFiles DOES flag it — see the OPEN QUESTION below.
+    expect(detectOrphanFiles(repo).map((f) => f.filePath)).toEqual(["src/utils.test.ts"]);
+  });
+
+  it("a test file imported for side effects with unused exports IS flagged (OPEN QUESTION)", () => {
+    // e.g. `import "./vitest.setup.ts"` — nothing references its exports.
+    // Pinned current behavior. OPEN QUESTION: should test files be
+    // excluded by convention (like entry points), since runners (vitest,
+    // pytest fixtures) invoke them by name rather than by import?
+    const repo = makeRepository([
+      makeModule("src/vitest.setup.ts", { exports: [named("install")], importedBy: ["src/main.ts"] }),
+      makeModule("src/main.ts", {
+        imports: ["src/vitest.setup.ts"],
+        resolvedImports: [
+          { moduleId: "src/vitest.setup.ts", kind: "static", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        ],
+      }),
+    ]);
+    const findings = detectDeadCode(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].filePath).toBe("src/vitest.setup.ts");
+  });
+});
+
+describe("adversarial — detectOrphanFiles", () => {
+  it("empty repository does not crash", () => {
+    expect(detectOrphanFiles(makeRepository([]))).toEqual([]);
+  });
+
+  it("test files with no importers are currently flagged as orphan (OPEN QUESTION)", () => {
+    const repo = makeRepository([
+      makeModule("src/utils.test.ts", { imports: ["src/utils.ts"] }),
+      makeModule("src/utils.ts"),
+    ]);
+    // No test-file exclusion exists in the entry-module set yet — same
+    // OPEN QUESTION as detectDeadCode above.
+    expect(detectOrphanFiles(repo).map((f) => f.filePath)).toContain("src/utils.test.ts");
+  });
+});

--- a/tests/guard-inventory.test.ts
+++ b/tests/guard-inventory.test.ts
@@ -76,7 +76,7 @@ function makeModule(
     resolvedReExports: {},
     importedBy: opts.importedBy ?? [],
     imports,
-    resolvedImports: opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 })),
+    resolvedImports: (opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }))).map((r) => ({ ...r, kind: "static" as const })),
     calls: [],
     calledBy: [],
     implicitDependencies: [],

--- a/tests/mutation-graph.test.ts
+++ b/tests/mutation-graph.test.ts
@@ -1,0 +1,268 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Mutation-style tests for detectCircularDependency (plan entry
+// "detector quality gate", progres/status-backlog.md 2026-08-15):
+// start from an acyclic graph, plant a cycle by mutating one module's
+// imports (the way a real edit would), assert the detector fires with
+// the exact node set, then remove the mutation and assert the finding
+// clears. Mirrors the makeModule/makeRepository helpers from
+// tests/core-detectors.test.ts.
+
+import { describe, it, expect } from "vitest";
+import { Repository } from "../packages/repository/Repository";
+import { detectCircularDependency } from "../packages/detectors/detectCircularDependency";
+import type { FileInfo, ModuleInfo, RepositoryMeta } from "../packages/shared/types";
+
+function makeFile(relativePath: string): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "typescript",
+    extension: ".ts",
+    sizeBytes: 100,
+    hash: "fake-hash",
+  };
+}
+
+function makeModule(
+  relativePath: string,
+  opts: { imports?: string[] } = {}
+): ModuleInfo {
+  const imports = opts.imports ?? [];
+  return {
+    id: relativePath,
+    file: makeFile(relativePath),
+    exports: [],
+    resolvedReExports: {},
+    importedBy: [],
+    imports,
+    resolvedImports: imports.map((moduleId) => ({
+      moduleId,
+      kind: "static",
+      namedImports: [],
+      hasDefaultImport: false,
+      hasNamespaceImport: false,
+      line: 1,
+    })),
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "test-repo",
+    org: "test-org",
+    name: "test-repo",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+/**
+ * Applies an edit to one module's imports, mirroring makeModule's
+ * resolvedImports derivation, and re-registers it in place (Repository
+ * keys modules by id, so addModule overwrites). Fails fast on unknown
+ * module ids — a typo must not silently add a phantom module.
+ */
+function mutateImports(repository: Repository, moduleId: string, imports: string[]): void {
+  const existing = repository.getModule(moduleId);
+  if (!existing) throw new Error(`mutateImports: unknown module "${moduleId}"`);
+  repository.addModule({
+    ...existing,
+    imports,
+    resolvedImports: imports.map((id) => ({
+      moduleId: id,
+      kind: "static",
+      namedImports: [],
+      hasDefaultImport: false,
+      hasNamespaceImport: false,
+      line: 1,
+    })),
+  });
+}
+
+describe("detectCircularDependency — graph mutations", () => {
+  it("baseline: acyclic chain has no findings", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+      makeModule("src/c.ts"),
+    ]);
+
+    expect(detectCircularDependency(repo)).toEqual([]);
+  });
+
+  it("adding edge c->a turns the chain into a cycle with the exact node set", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+      makeModule("src/c.ts"),
+    ]);
+
+    mutateImports(repo, "src/c.ts", ["src/a.ts"]);
+
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(1);
+    // Deterministic given insertion order [a, b, c]: DFS finds the cycle
+    // starting at a, canonicalizeCycle (issue #207) keeps that rotation.
+    expect(findings[0].cycle).toEqual(["src/a.ts", "src/b.ts", "src/c.ts", "src/a.ts"]);
+    expect(new Set(findings[0].cycle)).toEqual(new Set(["src/a.ts", "src/b.ts", "src/c.ts"]));
+  });
+
+  it("removing the mutation clears the finding (round-trip)", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+      makeModule("src/c.ts"),
+    ]);
+
+    mutateImports(repo, "src/c.ts", ["src/a.ts"]);
+    expect(detectCircularDependency(repo)).toHaveLength(1);
+
+    mutateImports(repo, "src/c.ts", []);
+    expect(detectCircularDependency(repo)).toEqual([]);
+  });
+
+  it("adding a forward (non-cycle) edge does not create a finding", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+      makeModule("src/c.ts"),
+    ]);
+
+    // a -> b -> c, plus a -> c: still acyclic.
+    mutateImports(repo, "src/a.ts", ["src/b.ts", "src/c.ts"]);
+
+    expect(detectCircularDependency(repo)).toEqual([]);
+  });
+
+  it("a 2-node cycle planted by mutation reports the pair", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts"),
+    ]);
+
+    mutateImports(repo, "src/b.ts", ["src/a.ts"]);
+
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(1);
+    const cycle = findings[0].cycle;
+    expect(cycle[0]).toBe(cycle[cycle.length - 1]); // closed loop
+    expect(new Set(cycle)).toEqual(new Set(["src/a.ts", "src/b.ts"]));
+  });
+
+  it("reports each cycle once regardless of entry-point rotation", () => {
+    // Same 3-node cycle, but c is inserted first so DFS enters through it.
+    const repo = makeRepository([
+      makeModule("src/c.ts", { imports: ["src/a.ts"] }),
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+    ]);
+
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(1);
+    expect(new Set(findings[0].cycle)).toEqual(new Set(["src/a.ts", "src/b.ts", "src/c.ts"]));
+  });
+
+  it("a mutation creating a second cycle joins the existing one without key collisions", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/a.ts"] }), // cycle A <-> B
+      makeModule("src/c.ts", { imports: ["src/d.ts"] }),
+      makeModule("src/d.ts"),
+    ]);
+
+    mutateImports(repo, "src/d.ts", ["src/c.ts"]); // cycle C <-> D
+
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(2);
+    const nodeSets = findings.map((f) => new Set(f.cycle));
+    expect(nodeSets).toContainEqual(new Set(["src/a.ts", "src/b.ts"]));
+    expect(nodeSets).toContainEqual(new Set(["src/c.ts", "src/d.ts"]));
+  });
+
+  it("a mutation in an unrelated component leaves the existing finding untouched", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/a.ts"] }), // cycle A <-> B
+      makeModule("src/c.ts", { imports: ["src/d.ts"] }),
+      makeModule("src/d.ts", { imports: ["src/e.ts"] }),
+      makeModule("src/e.ts"),
+      makeModule("src/f.ts"), // new file, no imports yet
+    ]);
+
+    const before = detectCircularDependency(repo);
+    expect(before).toHaveLength(1);
+
+    // f -> e: no path back to f (e imports nothing), so no new cycle.
+    mutateImports(repo, "src/f.ts", ["src/e.ts"]);
+
+    const after = detectCircularDependency(repo);
+    expect(after).toEqual(before);
+    expect(new Set(after[0].cycle)).toEqual(new Set(["src/a.ts", "src/b.ts"]));
+  });
+
+  it("self-loop mutation is reported (documents current behavior)", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts"),
+    ]);
+
+    mutateImports(repo, "src/b.ts", ["src/b.ts"]);
+
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].cycle).toEqual(["src/b.ts", "src/b.ts"]);
+  });
+
+  it("mutating a live repository is equivalent to a fresh index with the same state", () => {
+    const mutated = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+      makeModule("src/c.ts"),
+    ]);
+    mutateImports(mutated, "src/c.ts", ["src/a.ts"]);
+
+    const fresh = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+      makeModule("src/c.ts", { imports: ["src/a.ts"] }),
+    ]);
+
+    expect(detectCircularDependency(mutated)).toEqual(detectCircularDependency(fresh));
+  });
+
+  it("a mutation leaving one node out of the cycle reports the exact sub-cycle", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/c.ts"] }),
+      makeModule("src/c.ts", { imports: ["src/d.ts"] }),
+      makeModule("src/d.ts"),
+    ]);
+
+    // c now points back to a (cycle a,b,c) and keeps its edge to d — d
+    // stays outside the cycle.
+    mutateImports(repo, "src/c.ts", ["src/d.ts", "src/a.ts"]);
+
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(1);
+    expect(new Set(findings[0].cycle)).toEqual(new Set(["src/a.ts", "src/b.ts", "src/c.ts"]));
+    expect(findings[0].cycle).not.toContain("src/d.ts");
+  });
+});

--- a/tests/runDoctor.test.ts
+++ b/tests/runDoctor.test.ts
@@ -13,9 +13,9 @@ import { describe, it, expect } from "vitest";
 import { Repository } from "../packages/repository/Repository";
 import { runDoctor, safeRun } from "../packages/engine/runDoctor";
 import type { DoctorFinding } from "../packages/engine/runDoctor";
-import type { ModuleInfo, RepositoryMeta, FileInfo, RawExport } from "../packages/shared/types";
+import type { ModuleInfo, RepositoryMeta, FileInfo, RawExport, SupportedLanguage } from "../packages/shared/types";
 
-function makeFile(relativePath: string, language = "typescript"): FileInfo {
+function makeFile(relativePath: string, language: SupportedLanguage = "typescript"): FileInfo {
   return {
     absolutePath: `/virtual/repo/${relativePath}`,
     relativePath,
@@ -50,7 +50,7 @@ function makeModule(
     resolvedReExports: {},
     importedBy: [],
     imports,
-    resolvedImports: opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 })),
+    resolvedImports: (opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }))).map((r) => ({ ...r, kind: "static" as const })),
     calls: [],
     calledBy: [],
     implicitDependencies: [],


### PR DESCRIPTION
## Detector quality gate (progres/status-backlog.md 2026-08-15, items 1-3)

Proves the 19 detectors actually work instead of just looking like they do.

### New test files (29 tests)
- **tests/mutation-graph.test.ts** (11) — mutation-style suite for detectCircularDependency: plant an edge into an acyclic graph → cycle with exact node set; remove → clean (round-trip); rotation dedup (issue #207); second cycle without key collisions; live-mutation ≡ fresh-index equivalence; self-loop documented.
- **tests/detectors-adversarial.test.ts** (15) — source-level parsePython attacks (minified one-liner, comments/string literals can't create edges, invalid-syntax ERROR nodes tolerated, empty source) + detector-level edge cases: TYPE_CHECKING edges pinned as real (decision tracked in #458), test-file findings pinned (#459), dynamic-call blind spot documented, namespace import no false positive.
- **tests/detector-score.test.ts** (3) — registry-driven meta-gate: all 19 detectors must fire on a planted violation AND stay empty on a clean fixture. Score: 19/19 positive, 19/19 negative.

### Type fixes in existing test files
ResolvedImport.kind was missing in the makeModule helpers of core-detectors/detector/guard-inventory/runDoctor (latent — vitest/esbuild doesn't type-check) + widened language param in runDoctor. All 5 files now LSP-clean.

### Validation
npx vitest run → 474/474 (44 files).

### Notes
Open product decisions tracked as issues #458 (TYPE_CHECKING imports → real edges?) and #459 (test files → orphan/dead?); the adversarial tests pin current behavior and flip to negative controls once decided.