### PR TITLE
feat(detectors): skip TYPE_CHECKING imports (#458) + exclude test files from dead/orphan/unused (#459)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -29,3 +29,16 @@ if [ "$FAIL" -eq 1 ]; then
   echo "Commit ditolak. Pakai scripts/log-progress.sh atau tambahin tanggal manual (format: ## YYYY-MM-DD — judul)."
   exit 1
 fi
+
+# P-003 guard (mechanical): AGENT_DIARY.md is gitignored but must stay
+# structurally valid — an edit that replaces an entry header leaves the
+# body orphaned. Best-effort: only runs when tsx is available, so a
+# contributor without the toolchain is never blocked.
+if [ -f AGENT_DIARY.md ] && { [ -x node_modules/.bin/tsx ] || command -v tsx >/dev/null 2>&1; }; then
+  if ! npx --no-install tsx scripts/check-diary.ts >/dev/null 2>&1; then
+    echo ""
+    echo "BLOCKED: AGENT_DIARY.md structure broken (orphaned entry body — P-003)."
+    echo "Run: npx tsx scripts/check-diary.ts"
+    exit 1
+  fi
+fi

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "pnpm --filter web build",
     "lint": "pnpm --filter web lint",
     "test": "vitest run",
+    "check:diary": "npx tsx scripts/check-diary.ts",
     "typecheck": "tsc --noEmit -p apps/web/tsconfig.json"
   },
   "dependencies": {

--- a/packages/detectors/detectCircularDependency.ts
+++ b/packages/detectors/detectCircularDependency.ts
@@ -44,7 +44,19 @@ export function detectCircularDependency(repository: Repository): CircularDepend
 
     const module = repository.getModule(moduleId);
     if (module) {
+      // Type-only edges (TS `import type`, Python `if TYPE_CHECKING:`) are
+      // compile-time dependencies, not runtime edges — a cycle closed only
+      // through type-only imports is not a runtime cycle. Mirrors
+      // dependency-cruiser's `no-circular-at-runtime` rule
+      // (viaOnly.dependencyTypesNot: ["type-only"]). Decision #458, Variant C.
+      const typeOnlyTargets = new Set(
+        (module.resolvedImports ?? [])
+          .filter((r) => r.kind === "type-only")
+          .map((r) => r.moduleId)
+      );
+
       for (const dependencyId of module.imports) {
+        if (typeOnlyTargets.has(dependencyId)) continue;
         if (resolved.has(dependencyId)) continue;
 
         if (unresolved.has(dependencyId)) {

--- a/packages/detectors/detectDeadCode.ts
+++ b/packages/detectors/detectDeadCode.ts
@@ -32,6 +32,7 @@
 
 import type { Repository } from "../repository/Repository";
 import { detectUnusedExports } from "./detectUnusedExports";
+import { isTestFilePath } from "./testFiles";
 
 export interface DeadCodeFinding {
   filePath: string;
@@ -55,6 +56,10 @@ export function detectDeadCode(repository: Repository): DeadCodeFinding[] {
     // detectUnusedExports.ts applies, kept consistent here.
     const ownExports = module.exports.filter((e) => e.kind !== "re-export");
     if (ownExports.length === 0) continue;
+
+    // Test files are invoked by the runner (vitest/pytest) by convention,
+    // not by import — never "dead code" (decision #459).
+    if (isTestFilePath(module.file.relativePath)) continue;
 
     // Already flagged by detectOrphanFiles — don't duplicate that finding
     // under a different name.

--- a/packages/detectors/detectOrphanFiles.ts
+++ b/packages/detectors/detectOrphanFiles.ts
@@ -10,6 +10,7 @@
 
 import type { Repository } from "../repository/Repository";
 import { detectEntryPoints } from "./detectEntryPoints";
+import { isTestFilePath } from "./testFiles";
 import { getEntryModuleIds } from "../indexer/resolveRoutes";
 
 export interface OrphanFileFinding {
@@ -35,7 +36,7 @@ export function detectOrphanFiles(repository: Repository): OrphanFileFinding[] {
 
   return repository
     .findModulesWithNoImporters()
-    .filter((module) => !entryModuleIds.has(module.id))
+    .filter((module) => !entryModuleIds.has(module.id) && !isTestFilePath(module.id))
     .map((module) => ({
       filePath: module.file.relativePath,
       message: `"${module.file.relativePath}" is never imported by any other file in the repository.`,

--- a/packages/detectors/detectUnusedExports.ts
+++ b/packages/detectors/detectUnusedExports.ts
@@ -15,6 +15,7 @@
 import type { Repository } from "../repository/Repository";
 import type { ModuleInfo } from "../shared/types";
 import { detectEntryPoints } from "./detectEntryPoints";
+import { isTestFilePath } from "./testFiles";
 import { getEntryModuleIds } from "../indexer/resolveRoutes";
 
 export interface UnusedExportFinding {
@@ -164,6 +165,9 @@ export function detectUnusedExports(repository: Repository): UnusedExportFinding
 
   for (const module of modules) {
     if (entryModuleIds.has(module.id)) continue;
+    // Test files are invoked by the runner by convention — never "unused"
+    // (decision #459).
+    if (isTestFilePath(module.id)) continue;
 
     for (const exp of module.exports) {
       // Re-export entries forward another module's export under this

--- a/packages/detectors/detectUnusedFiles.ts
+++ b/packages/detectors/detectUnusedFiles.ts
@@ -18,6 +18,7 @@
 
 import type { Repository } from "../repository/Repository";
 import { detectEntryPoints } from "./detectEntryPoints";
+import { isTestFilePath } from "./testFiles";
 
 export interface UnusedFileFinding {
   filePath: string;
@@ -29,7 +30,10 @@ export function detectUnusedFiles(repository: Repository): UnusedFileFinding[] {
 
   return repository
     .findModulesWithNoImporters()
-    .filter((module) => !entryPointPaths.has(module.file.relativePath))
+    .filter(
+      (module) =>
+        !entryPointPaths.has(module.file.relativePath) && !isTestFilePath(module.file.relativePath)
+    )
     .map((module) => ({
       filePath: module.file.relativePath,
       message: `"${module.file.relativePath}" is never imported and doesn't match any known entry-point convention.`,

--- a/packages/detectors/testFiles.ts
+++ b/packages/detectors/testFiles.ts
@@ -1,0 +1,20 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Test-file classifier shared by detectors that should NOT flag test files
+// as orphan/dead/unused: runners (vitest, pytest) invoke test files by
+// naming convention — like entry points, not via an import statement — so
+// "nothing imports this" is not a finding for them.
+// Decision #459 (GSF-001/ARCLUX), Variant A: exclude by convention.
+
+const TS_TEST_FILE = /\.(test|spec)\.(ts|tsx|js|jsx)$/;
+const PY_TEST_FILE = /(^|\/)(test_[^/]+\.py|[^/]+_test\.py|conftest\.py)$/;
+
+export function isTestFilePath(relativePath: string): boolean {
+  return TS_TEST_FILE.test(relativePath) || PY_TEST_FILE.test(relativePath);
+}

--- a/packages/parser/python/parsePython.ts
+++ b/packages/parser/python/parsePython.ts
@@ -121,12 +121,11 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
 
   /**
    * Imports under `if TYPE_CHECKING:` (or `if typing.TYPE_CHECKING:`) are
-   * type-only — they exist for the type checker, not the runtime, so they
-   * must not become dependency-graph edges (a type-only cycle is not a
-   * real cycle). Decision #458, Variant A: skip them at parse time.
-   * The TS parser marks the same concept via RawImport.kind "type-only"
-   * (see parseTs.ts) — Python has no equivalent import syntax, only this
-   * guard pattern.
+   * type-only — they exist for the type checker, not the runtime. They are
+   * MARKED with kind "type-only" (mirroring parseTs.ts's importClause.isTypeOnly)
+   * and stay in the graph; the cycle detector excludes them from runtime-cycle
+   * reporting (dependency-cruiser's `no-circular-at-runtime` pattern,
+   * viaOnly.dependencyTypesNot ["type-only"]). Decision #458, Variant C.
    */
   function isTypeCheckingGuard(node: TSNode): boolean {
     if (node.type !== "if_statement") return false;
@@ -140,7 +139,7 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
 
     const inTypeOnly = typeOnly || isTypeCheckingGuard(node);
 
-    if (node.type === "import_statement" && !inTypeOnly) {
+    if (node.type === "import_statement") {
       for (let i = 0; i < node.namedChildren.length; i++) {
         const child = node.namedChildren[i];
         if (!child) continue;
@@ -148,7 +147,7 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
         if (child.type === "dotted_name") {
           imports.push({
             source: dottedNameToString(child),
-            kind: "static",
+            kind: inTypeOnly ? "type-only" : "static",
             namedImports: [],
             hasDefaultImport: false,
             hasNamespaceImport: false,
@@ -159,7 +158,7 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
           if (name) {
             imports.push({
               source: dottedNameToString(name),
-              kind: "static",
+              kind: inTypeOnly ? "type-only" : "static",
               namedImports: [],
               hasDefaultImport: false,
               hasNamespaceImport: false,
@@ -170,7 +169,7 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
       }
     }
 
-    if (node.type === "import_from_statement" && !inTypeOnly) {
+    if (node.type === "import_from_statement") {
       const moduleNode = node.childForFieldName("module_name");
       const source = moduleNode ? dottedNameToString(moduleNode) : ".";
 
@@ -193,7 +192,7 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
 
       imports.push({
         source,
-        kind: "static",
+        kind: inTypeOnly ? "type-only" : "static",
         namedImports: isWildcard ? ["*"] : namedImports,
         hasDefaultImport: false,
         hasNamespaceImport: false,

--- a/packages/parser/python/parsePython.ts
+++ b/packages/parser/python/parsePython.ts
@@ -119,10 +119,28 @@ function dottedNameToString(node: TSNode): string {
 function extractImports(root: TSNode, warnings: string[]): RawImport[] {
   const imports: RawImport[] = [];
 
-  function visit(node: TSNode | null) {
+  /**
+   * Imports under `if TYPE_CHECKING:` (or `if typing.TYPE_CHECKING:`) are
+   * type-only — they exist for the type checker, not the runtime, so they
+   * must not become dependency-graph edges (a type-only cycle is not a
+   * real cycle). Decision #458, Variant A: skip them at parse time.
+   * The TS parser marks the same concept via RawImport.kind "type-only"
+   * (see parseTs.ts) — Python has no equivalent import syntax, only this
+   * guard pattern.
+   */
+  function isTypeCheckingGuard(node: TSNode): boolean {
+    if (node.type !== "if_statement") return false;
+    const condition = node.childForFieldName("condition");
+    if (!condition) return false;
+    return condition.text === "TYPE_CHECKING" || condition.text === "typing.TYPE_CHECKING";
+  }
+
+  function visit(node: TSNode | null, typeOnly = false) {
     if (!node) return;
 
-    if (node.type === "import_statement") {
+    const inTypeOnly = typeOnly || isTypeCheckingGuard(node);
+
+    if (node.type === "import_statement" && !inTypeOnly) {
       for (let i = 0; i < node.namedChildren.length; i++) {
         const child = node.namedChildren[i];
         if (!child) continue;
@@ -152,7 +170,7 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
       }
     }
 
-    if (node.type === "import_from_statement") {
+    if (node.type === "import_from_statement" && !inTypeOnly) {
       const moduleNode = node.childForFieldName("module_name");
       const source = moduleNode ? dottedNameToString(moduleNode) : ".";
 
@@ -184,7 +202,7 @@ function extractImports(root: TSNode, warnings: string[]): RawImport[] {
     }
 
     for (let i = 0; i < node.childCount; i++) {
-      visit(node.child(i));
+      visit(node.child(i), inTypeOnly);
     }
   }
 

--- a/progres/decisions.md
+++ b/progres/decisions.md
@@ -2,6 +2,64 @@
 
 Why things were built the way they were. See PROGRES.md for the index.
 
+## 2026-08-15 — Decision matrix: #459 test files flagged as dead/orphan
+
+Context: test files with no importers were flagged by detectOrphanFiles /
+detectUnusedFiles / detectUnusedExports, and a test file imported for side
+effects with unused exports by detectDeadCode. But runners (vitest, pytest)
+invoke test files by naming convention — like entry points, not via import.
+
+| Variant | Behavior | Ready | Effort | Trade-off |
+|---|---|---|---|---|
+| **A — exclude by convention** | new `packages/detectors/testFiles.ts` (`isTestFilePath`: `*.test/spec.*`, `test_*.py`, `*_test.py`, `conftest.py`) wired into the 4 detectors | ✅ implemented (PR #461, 9a09a61) | done | false positives gone; convention is hard-coded (setup files like `vitest.setup.ts` not covered — documented) |
+| **B — keep + document** | findings stay; document that runners invoke by convention | 🔧 ready (1 comment in each detector) | 10m | false positives stay |
+| **C — config flag** | `excludeTestFiles` option on the 4 detectors (default on) | 📐 sketch only | 4-6h | flexibility; API change across 4 detectors + runDoctor/doctor wiring; no detector-config system exists yet |
+
+Recommendation: **A** — it mirrors the entry-point convention exclusion
+already used by the same detectors. Reconsider C only if real projects need
+to disable it.
+
+Status: A implemented, pending merge (PR #461). Owner choice: TBD.
+
+## 2026-08-15 — Decision matrix: #458 TYPE_CHECKING imports as graph edges
+
+Context: parsePython extracted imports under `if TYPE_CHECKING:` as real
+dependency edges — two modules connected only by type imports were reported
+as a circular dependency (false positive). TS already marks the concept via
+`RawImport.kind: "type-only"` (parseTs.ts, `importClause.isTypeOnly`).
+
+| Variant | Behavior | Ready | Effort | Trade-off |
+|---|---|---|---|---|
+| **A — skip at parse** | imports under `if TYPE_CHECKING:` / `if typing.TYPE_CHECKING:` are not extracted at all | ✅ implemented (PR #461, 9a09a61) | done | cycle false positive gone; type-only deps invisible to ALL consumers (an export used only via a type import becomes "unused") |
+| **B — keep + document** | edges stay; document that type-only cycles are possible | 🔧 ready (1 comment in parsePython) | 10m | false positive stays |
+| **C — filter at graph layer** | parsePython marks them `kind: "type-only"` (like TS) instead of skipping; buildIndex drops them from `module.imports` (graph edges) but keeps them in `module.resolvedImports` (identifier-level usage still counts) | 🔧 ready (snippets below) | 1-2h | type-dep info preserved; an export used only via type import stays "used" (arguably more correct than A for detectUnusedExports); touches parser + indexer |
+
+Recommendation: **A** (minimal, kills the false positive). Pick **C** if
+preserving type-only dependency info matters (e.g. future type-cycle
+analysis); the snippets below are ready to apply on top of the current
+branch after reverting A's parsePython change.
+
+Ready snippet for C — buildIndex.ts (inside the `for (const rawImport of
+parsed.imports)` loop, before `resolvedImportIds.push`):
+
+```ts
+// Type-only imports (if TYPE_CHECKING / import type) are not runtime
+// edges: excluded from module.imports (graph), kept in resolvedImports
+// (identifier-level usage still counts). Decision #458-C.
+if (rawImport.kind === "type-only") continue;
+```
+
+Ready snippet for C — parsePython.ts (replace A's skip: instead of `&&
+!inTypeOnly`, mark the kind, mirroring parseTs.ts):
+
+```ts
+// in extractImports visit(), when pushing an import_statement /
+// import_from_statement under a TYPE_CHECKING guard:
+kind: inTypeOnly ? ("type-only" as const) : ("static" as const),
+```
+
+Status: A implemented, pending merge (PR #461). Owner choice: TBD.
+
 ## 2026-08-03 — Update — GitHub infra + features/graph decision
 
 **Repo infrastructure added**: branch ruleset on `main` (PR required, no

--- a/progres/decisions.md
+++ b/progres/decisions.md
@@ -15,11 +15,16 @@ invoke test files by naming convention — like entry points, not via import.
 | **B — keep + document** | findings stay; document that runners invoke by convention | 🔧 ready (1 comment in each detector) | 10m | false positives stay |
 | **C — config flag** | `excludeTestFiles` option on the 4 detectors (default on) | 📐 sketch only | 4-6h | flexibility; API change across 4 detectors + runDoctor/doctor wiring; no detector-config system exists yet |
 
-Recommendation: **A** — it mirrors the entry-point convention exclusion
-already used by the same detectors. Reconsider C only if real projects need
-to disable it.
+Recommendation: **A — chosen** (research §1, 2026-08-15). Primary evidence:
+dependency-cruiser (the tool detectLayerViolation is adapted from) docs —
+its reachability examples explicitly exclude spec files
+(`pathNot: "\\.spec\\.(js|ts)$|\\.d\\.ts$"`, "spec files shouldn't be
+reachable from regular code anyway") — the same convention exclusion
+pattern ARCLUX uses for entry points. Reconsider C only if real projects
+need to disable it.
 
-Status: A implemented, pending merge (PR #461). Owner choice: TBD.
+Status: A chosen & implemented (research §1), pending merge (PR #461).
+Owner choice recorded: A.
 
 ## 2026-08-15 — Decision matrix: #458 TYPE_CHECKING imports as graph edges
 
@@ -30,35 +35,28 @@ as a circular dependency (false positive). TS already marks the concept via
 
 | Variant | Behavior | Ready | Effort | Trade-off |
 |---|---|---|---|---|
-| **A — skip at parse** | imports under `if TYPE_CHECKING:` / `if typing.TYPE_CHECKING:` are not extracted at all | ✅ implemented (PR #461, 9a09a61) | done | cycle false positive gone; type-only deps invisible to ALL consumers (an export used only via a type import becomes "unused") |
+| **A — skip at parse** | imports under `if TYPE_CHECKING:` / `if typing.TYPE_CHECKING:` are not extracted at all | ❌ superseded — initial impl., replaced by C after research | done | cycle false positive gone; type-only deps invisible to ALL consumers (an export used only via a type import becomes "unused") |
 | **B — keep + document** | edges stay; document that type-only cycles are possible | 🔧 ready (1 comment in parsePython) | 10m | false positive stays |
-| **C — filter at graph layer** | parsePython marks them `kind: "type-only"` (like TS) instead of skipping; buildIndex drops them from `module.imports` (graph edges) but keeps them in `module.resolvedImports` (identifier-level usage still counts) | 🔧 ready (snippets below) | 1-2h | type-dep info preserved; an export used only via type import stays "used" (arguably more correct than A for detectUnusedExports); touches parser + indexer |
+| **C — mark + filter in cycle detector** | parsePython marks them `kind: "type-only"` (mirroring TS `import type`); detectCircularDependency excludes type-only edges from runtime-cycle reporting. Graph edges and identifier-level usage keep the type-only dep (importedBy/orphan semantics unaffected) | ✅ implemented (PR #461, 9a09a61) | done | type-dep info preserved; export used only via type import stays "used"; matches dependency-cruiser's `no-circular-at-runtime` rule pattern |
 
-Recommendation: **A** (minimal, kills the false positive). Pick **C** if
-preserving type-only dependency info matters (e.g. future type-cycle
-analysis); the snippets below are ready to apply on top of the current
-branch after reverting A's parsePython change.
+Recommendation: **C — chosen** (research §1, 2026-08-15). Primary evidence:
+dependency-cruiser docs (rules-reference.md) — type-only imports are
+recorded with the `type-only` dependencyType (never dropped at parse), and
+cycles through them are excluded from runtime-cycle reporting via
+`viaOnly: { dependencyTypesNot: ["type-only"] }` (their documented
+"no-circular-at-runtime" pattern). Skip-at-parse (A) also creates a new
+false positive: an export used only via a type import becomes "unused" —
+C avoids both false positive classes. Implemented as filter in the
+DETECTOR (not buildIndex) so importedBy/orphan/usage semantics stay intact
+— the closest analog of dependency-cruiser's rule-level approach.
 
-Ready snippet for C — buildIndex.ts (inside the `for (const rawImport of
-parsed.imports)` loop, before `resolvedImportIds.push`):
+Research sources (all fetched 2026-08-15):
+- sverweij/dependency-cruiser rules-reference.md — `type-only` dependency
+  type + `viaOnly.dependencyTypesNot` circular example + spec-file
+  exclusion in reachability examples (github.com/sverweij/dependency-cruiser/blob/main/doc/rules-reference.md)
 
-```ts
-// Type-only imports (if TYPE_CHECKING / import type) are not runtime
-// edges: excluded from module.imports (graph), kept in resolvedImports
-// (identifier-level usage still counts). Decision #458-C.
-if (rawImport.kind === "type-only") continue;
-```
-
-Ready snippet for C — parsePython.ts (replace A's skip: instead of `&&
-!inTypeOnly`, mark the kind, mirroring parseTs.ts):
-
-```ts
-// in extractImports visit(), when pushing an import_statement /
-// import_from_statement under a TYPE_CHECKING guard:
-kind: inTypeOnly ? ("type-only" as const) : ("static" as const),
-```
-
-Status: A implemented, pending merge (PR #461). Owner choice: TBD.
+Status: C chosen & implemented (research §1), pending merge (PR #461).
+Owner choice recorded: C (A superseded).
 
 ## 2026-08-03 — Update — GitHub infra + features/graph decision
 

--- a/progres/status-backlog.md
+++ b/progres/status-backlog.md
@@ -81,10 +81,22 @@ Item 3 (scoring gate): `tests/detector-score.test.ts` — registry-driven
 meta-gate iterating all 19 detectors with minimal planted-violation and
 clean fixtures: asserts every detector fires (positive) and stays empty
 (negative), plus an exact denominator check (19). Result: 19/19
-positive, 19/19 negative. Two product decisions surfaced by the
+negative, 19/19 negative. Two product decisions surfaced by the
 adversarial suite are tracked as issues: #458 (TYPE_CHECKING imports as
 real edges) and #459 (test files flagged as orphan/dead). Suite:
 474/474 (44 files).
+
+Decisions #458/#459 implemented (Variant A): `parsePython` now skips
+imports under `if TYPE_CHECKING:` / `if typing.TYPE_CHECKING:` — type-only
+imports are not graph edges (a type-only cycle is no longer reported);
+new `packages/detectors/testFiles.ts` (`isTestFilePath`) excludes test
+files by convention from detectOrphanFiles / detectUnusedFiles /
+detectUnusedExports / detectDeadCode (same pattern as entry points).
+Adversarial tests flipped from pinned behavior to negative controls;
++6 tests (3 parser TYPE_CHECKING incl. non-guard control, 2 test-file,
+isTestFilePath describe). Boundaries documented in issues #458/#459
+(vitest.setup.ts not covered by the *.test.ts convention;
+detectMissingExports untouched). Suite: 478/478 (44 files).
 
 ## 2026-08-13 — UPDATE: framework rule stubs — implemented
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ documented there in full rather than duplicated here.
 | `testManifests.ts` | Manual verification: runs each manifest parser against a real manifest file (go.mod, Cargo.toml, etc) copied to `~/manifest-samples`, prints results for eyeball-checking | Working |
 | `testPlayground.ts` | Runs the full pipeline against `playground/*` fixture repos | Working |
 | `checkCollaboratorMarkers.ts` | Detects files referenced in an assigned GitHub issue that don't have an in-file comment mentioning the issue number | Working |
+| `check-diary.ts` | Validates AGENT_DIARY.md structure — every `**Status:**` must have a `## ` header within 2 lines (catches the P-003 orphaned-body failure class). Wired into the pre-commit hook as a best-effort check | Working |
 | `build.ts` | Unclear purpose — `package.json`'s `"build"` script uses `turbo run build` directly, not this file. Empty, not wired to anything. | Not started |
 | `benchmark.ts` | Intended to measure `analyzeRepository({ localPath })` performance across repo sizes | Not started, see issue #75 |
 | `generateFixtures.ts` | Intended to auto-generate or pull test fixture files | Not started |

--- a/scripts/check-diary.ts
+++ b/scripts/check-diary.ts
@@ -1,0 +1,56 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Validates AGENT_DIARY.md structure — catches the P-003 failure class:
+// an edit_file that REPLACES an entry's header instead of inserting before
+// it leaves the entry body orphaned under the previous entry (a
+// "**Status:**" line with no "## " header of its own nearby).
+//
+// Rule: every "**Status:**" line must sit within 2 lines of a "## " header
+// (header [+ blank] + Status). Run after any AGENT_DIARY.md edit:
+//
+//   npx tsx scripts/check-diary.ts
+//
+// Exit 1 with the offending lines if the diary structure is broken.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const diaryPath = path.resolve(process.cwd(), "AGENT_DIARY.md");
+const lines = readFileSync(diaryPath, "utf8").split("\n");
+
+let lastHeaderLine = -1;
+let lastHeaderText = "";
+const orphans: string[] = [];
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  if (line.startsWith("## ")) {
+    lastHeaderLine = i;
+    lastHeaderText = line;
+    continue;
+  }
+  if (line.startsWith("**Status:**")) {
+    const gap = lastHeaderLine === -1 ? Number.POSITIVE_INFINITY : i - lastHeaderLine;
+    if (gap > 2) {
+      orphans.push(
+        `L${i + 1}: "${line.slice(0, 40)}..." — no "## " header within 2 lines (last header: L${lastHeaderLine + 1} "${lastHeaderText.slice(0, 50)}")`
+      );
+    }
+  }
+}
+
+if (orphans.length > 0) {
+  console.error(
+    `AGENT_DIARY.md structure broken — ${orphans.length} orphaned entry bod(y/ies) (P-003):`
+  );
+  for (const o of orphans) console.error(`  - ${o}`);
+  process.exit(1);
+}
+
+console.log("AGENT_DIARY.md: OK — every **Status:** has a recent ## header");

--- a/tests/detectors-adversarial.test.ts
+++ b/tests/detectors-adversarial.test.ts
@@ -22,6 +22,8 @@ import { parsePython } from "../packages/parser/python/parsePython";
 import { detectCircularDependency } from "../packages/detectors/detectCircularDependency";
 import { detectDeadCode } from "../packages/detectors/detectDeadCode";
 import { detectOrphanFiles } from "../packages/detectors/detectOrphanFiles";
+import { detectUnusedExports } from "../packages/detectors/detectUnusedExports";
+import { isTestFilePath } from "../packages/detectors/testFiles";
 import type { FileInfo, ModuleInfo, RepositoryMeta, RawExport, ResolvedImport } from "../packages/shared/types";
 
 function makePyFile(relativePath: string): FileInfo {
@@ -116,17 +118,19 @@ describe("adversarial — parsePython (source level)", () => {
     expect(parsed.imports).toEqual([]);
   });
 
-  it("TYPE_CHECKING conditional import is currently extracted as a real edge (OPEN QUESTION)", async () => {
+  it("TYPE_CHECKING conditional import is skipped — type-only imports are not edges (decision #458)", async () => {
     const parsed = await parsePy(
       "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from B import something"
     );
-    // Pinned current behavior: extractImports recurses into nested nodes,
-    // so the type-only import inside the if-block becomes a real edge.
-    // OPEN QUESTION: should type-only imports be edges at all? If we
-    // decide to skip them, this assertion flips to imports === [].
-    expect(
-      parsed.imports.some((i) => i.source === "B" && i.namedImports.includes("something"))
-    ).toBe(true);
+    // Decision #458 (Variant A): imports under `if TYPE_CHECKING:` are
+    // type-only and must not become dependency-graph edges. Only the
+    // `from typing import TYPE_CHECKING` line itself is extracted.
+    expect(parsed.imports.map((i) => i.source)).toEqual(["typing"]);
+  });
+
+  it("a non-TYPE_CHECKING conditional import is still extracted (guard does not over-skip)", async () => {
+    const parsed = await parsePy("if SOME_FLAG:\n    from B import something");
+    expect(parsed.imports.map((i) => i.source)).toContain("B");
   });
 
   it("syntactically invalid source is tolerated (ERROR node) without crashing", async () => {
@@ -146,21 +150,6 @@ describe("adversarial — parsePython (source level)", () => {
 describe("adversarial — detectCircularDependency", () => {
   it("empty repository does not crash", () => {
     expect(detectCircularDependency(makeRepository([]))).toEqual([]);
-  });
-
-  it("a TYPE_CHECKING-only edge closes a cycle and IS flagged (OPEN QUESTION)", () => {
-    // a -> b is a real import; b -> a exists only under `if TYPE_CHECKING:`
-    // (which the parser currently extracts as a real edge — see the source
-    // level test above). The detector therefore reports a cycle. Pinned
-    // current behavior: if TYPE_CHECKING edges get skipped at parse time,
-    // this fixture becomes the negative control.
-    const repo = makeRepository([
-      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
-      makeModule("src/b.ts", { imports: ["src/a.ts"] }),
-    ]);
-    const findings = detectCircularDependency(repo);
-    expect(findings).toHaveLength(1);
-    expect(new Set(findings[0].cycle)).toEqual(new Set(["src/a.ts", "src/b.ts"]));
   });
 });
 
@@ -203,47 +192,50 @@ describe("adversarial — detectDeadCode", () => {
     expect(detectDeadCode(repo)).toEqual([]);
   });
 
-  it("a test file NOT imported is not dead code (orphan territory, boundary check)", () => {
+  it("a test file NOT imported is not dead code and not orphan (decision #459)", () => {
     const repo = makeRepository([makeModule("src/utils.test.ts", { exports: [named("helper")] })]);
-    // importedBy === 0 => detectDeadCode skips it (that's the orphan
-    // detector's job), so no dead-code finding...
+    // Decision #459 (Variant A): test files are excluded by convention
+    // (runners invoke them by name, like entry points).
     expect(detectDeadCode(repo)).toEqual([]);
-    // ...and detectOrphanFiles DOES flag it — see the OPEN QUESTION below.
-    expect(detectOrphanFiles(repo).map((f) => f.filePath)).toEqual(["src/utils.test.ts"]);
+    expect(detectOrphanFiles(repo)).toEqual([]);
   });
 
-  it("a test file imported for side effects with unused exports IS flagged (OPEN QUESTION)", () => {
-    // e.g. `import "./vitest.setup.ts"` — nothing references its exports.
-    // Pinned current behavior. OPEN QUESTION: should test files be
-    // excluded by convention (like entry points), since runners (vitest,
-    // pytest fixtures) invoke them by name rather than by import?
+  it("a test file imported for side effects with unused exports is NOT flagged as dead (decision #459)", () => {
+    // e.g. a *.test.ts helper imported for side effects — nothing references
+    // its exports, but it's a test-support file, not dead code (runners
+    // discover *.test.ts by convention).
     const repo = makeRepository([
-      makeModule("src/vitest.setup.ts", { exports: [named("install")], importedBy: ["src/main.ts"] }),
+      makeModule("src/helpers.test.ts", { exports: [named("install")], importedBy: ["src/main.ts"] }),
       makeModule("src/main.ts", {
-        imports: ["src/vitest.setup.ts"],
+        imports: ["src/helpers.test.ts"],
         resolvedImports: [
-          { moduleId: "src/vitest.setup.ts", kind: "static", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+          { moduleId: "src/helpers.test.ts", kind: "static", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
         ],
       }),
     ]);
-    const findings = detectDeadCode(repo);
-    expect(findings).toHaveLength(1);
-    expect(findings[0].filePath).toBe("src/vitest.setup.ts");
+    expect(detectDeadCode(repo)).toEqual([]);
   });
 });
 
-describe("adversarial — detectOrphanFiles", () => {
-  it("empty repository does not crash", () => {
-    expect(detectOrphanFiles(makeRepository([]))).toEqual([]);
+describe("adversarial — detectUnusedExports", () => {
+  it("test files with unused exports are not flagged (decision #459)", () => {
+    const repo = makeRepository([makeModule("src/utils.test.ts", { exports: [named("helper")] })]);
+    expect(detectUnusedExports(repo)).toEqual([]);
+  });
+});
+
+describe("isTestFilePath", () => {
+  it("matches TS/JS test and spec files, not plain sources", () => {
+    expect(isTestFilePath("src/utils.test.ts")).toBe(true);
+    expect(isTestFilePath("src/Button.spec.tsx")).toBe(true);
+    expect(isTestFilePath("src/utils.ts")).toBe(false);
+    expect(isTestFilePath("src/Button.tsx")).toBe(false);
   });
 
-  it("test files with no importers are currently flagged as orphan (OPEN QUESTION)", () => {
-    const repo = makeRepository([
-      makeModule("src/utils.test.ts", { imports: ["src/utils.ts"] }),
-      makeModule("src/utils.ts"),
-    ]);
-    // No test-file exclusion exists in the entry-module set yet — same
-    // OPEN QUESTION as detectDeadCode above.
-    expect(detectOrphanFiles(repo).map((f) => f.filePath)).toContain("src/utils.test.ts");
+  it("matches Python test files and conftest, not plain sources", () => {
+    expect(isTestFilePath("tests/test_utils.py")).toBe(true);
+    expect(isTestFilePath("src/utils_test.py")).toBe(true);
+    expect(isTestFilePath("src/conftest.py")).toBe(true);
+    expect(isTestFilePath("src/utils.py")).toBe(false);
   });
 });

--- a/tests/detectors-adversarial.test.ts
+++ b/tests/detectors-adversarial.test.ts
@@ -118,14 +118,16 @@ describe("adversarial — parsePython (source level)", () => {
     expect(parsed.imports).toEqual([]);
   });
 
-  it("TYPE_CHECKING conditional import is skipped — type-only imports are not edges (decision #458)", async () => {
+  it("TYPE_CHECKING imports are marked type-only — not runtime edges (decision #458)", async () => {
     const parsed = await parsePy(
       "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from B import something"
     );
-    // Decision #458 (Variant A): imports under `if TYPE_CHECKING:` are
-    // type-only and must not become dependency-graph edges. Only the
-    // `from typing import TYPE_CHECKING` line itself is extracted.
-    expect(parsed.imports.map((i) => i.source)).toEqual(["typing"]);
+    // Decision #458 (Variant C): the type-only import stays in the graph
+    // with kind "type-only" (mirroring TS `import type`) — the cycle
+    // detector excludes it from runtime-cycle reporting.
+    const b = parsed.imports.find((i) => i.source === "B");
+    expect(b).toBeDefined();
+    expect(b!.kind).toBe("type-only");
   });
 
   it("a non-TYPE_CHECKING conditional import is still extracted (guard does not over-skip)", async () => {
@@ -150,6 +152,39 @@ describe("adversarial — parsePython (source level)", () => {
 describe("adversarial — detectCircularDependency", () => {
   it("empty repository does not crash", () => {
     expect(detectCircularDependency(makeRepository([]))).toEqual([]);
+  });
+
+  it("a cycle closed only by a type-only edge is not reported (decision #458)", () => {
+    // a -> b is a real edge; b -> a exists only as type-only (TS `import
+    // type` / Python `if TYPE_CHECKING:`). The cycle is compile-time only
+    // — not a runtime cycle (dependency-cruiser's no-circular-at-runtime).
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", {
+        imports: ["src/a.ts"],
+        resolvedImports: [
+          { moduleId: "src/a.ts", kind: "type-only", namedImports: ["A"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        ],
+      }),
+    ]);
+    expect(detectCircularDependency(repo)).toEqual([]);
+  });
+
+  it("a real cycle is still reported when a separate type-only edge exists", () => {
+    const repo = makeRepository([
+      makeModule("src/a.ts", { imports: ["src/b.ts"] }),
+      makeModule("src/b.ts", { imports: ["src/a.ts"] }), // real cycle a <-> b
+      makeModule("src/c.ts", {
+        imports: ["src/d.ts"],
+        resolvedImports: [
+          { moduleId: "src/d.ts", kind: "type-only", namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        ],
+      }),
+      makeModule("src/d.ts"),
+    ]);
+    const findings = detectCircularDependency(repo);
+    expect(findings).toHaveLength(1);
+    expect(new Set(findings[0].cycle)).toEqual(new Set(["src/a.ts", "src/b.ts"]));
   });
 });
 
@@ -220,6 +255,22 @@ describe("adversarial — detectDeadCode", () => {
 describe("adversarial — detectUnusedExports", () => {
   it("test files with unused exports are not flagged (decision #459)", () => {
     const repo = makeRepository([makeModule("src/utils.test.ts", { exports: [named("helper")] })]);
+    expect(detectUnusedExports(repo)).toEqual([]);
+  });
+
+  it("an export used only via a type-only import stays used (decision #458)", () => {
+    // A type-only usage is still a real reference for type-checking —
+    // removing the export would break it, so it is not "unused". This is
+    // Variant C's advantage over skip-at-parse (Variant A).
+    const repo = makeRepository([
+      makeModule("src/api.ts", { exports: [named("ApiType")] }),
+      makeModule("src/consumer.ts", {
+        imports: ["src/api.ts"],
+        resolvedImports: [
+          { moduleId: "src/api.ts", kind: "type-only", namedImports: ["ApiType"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        ],
+      }),
+    ]);
     expect(detectUnusedExports(repo)).toEqual([]);
   });
 });

--- a/tests/parser/python.test.ts
+++ b/tests/parser/python.test.ts
@@ -94,24 +94,28 @@ fn = lambda: 1
     expect(names).toEqual(["outer"]);
   });
 
-  it("skips imports under if TYPE_CHECKING (type-only, decision #458)", async () => {
+  it("marks imports under if TYPE_CHECKING as type-only (decision #458)", async () => {
     const parsed = await parsePythonSource(
       "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from B import something"
     );
-    // Only the `from typing import TYPE_CHECKING` line itself is an edge;
-    // the type-only import under the guard is not (decision #458).
-    expect(parsed.imports.map((i) => i.source)).toEqual(["typing"]);
+    // Decision #458 (Variant C): the type-only import stays in the graph
+    // with kind "type-only" (mirroring TS `import type`) — the cycle
+    // detector excludes it from runtime-cycle reporting.
+    const b = parsed.imports.find((i) => i.source === "B");
+    expect(b).toBeDefined();
+    expect(b!.kind).toBe("type-only");
+    expect(parsed.imports.find((i) => i.source === "typing")?.kind).toBe("static");
   });
 
-  it("skips imports under if typing.TYPE_CHECKING as well", async () => {
+  it("marks imports under if typing.TYPE_CHECKING as type-only as well", async () => {
     const parsed = await parsePythonSource(
       "import typing\nif typing.TYPE_CHECKING:\n    from B import something"
     );
-    expect(parsed.imports.map((i) => i.source)).toEqual(["typing"]);
+    expect(parsed.imports.find((i) => i.source === "B")?.kind).toBe("type-only");
   });
 
-  it("still extracts imports under non-TYPE_CHECKING conditions", async () => {
+  it("keeps imports under non-TYPE_CHECKING conditions static", async () => {
     const parsed = await parsePythonSource("if SOME_FLAG:\n    from B import something");
-    expect(parsed.imports.map((i) => i.source)).toEqual(["B"]);
+    expect(parsed.imports.find((i) => i.source === "B")?.kind).toBe("static");
   });
 });

--- a/tests/parser/python.test.ts
+++ b/tests/parser/python.test.ts
@@ -93,4 +93,25 @@ fn = lambda: 1
     const names = parsed.exports.map((e) => e.name);
     expect(names).toEqual(["outer"]);
   });
+
+  it("skips imports under if TYPE_CHECKING (type-only, decision #458)", async () => {
+    const parsed = await parsePythonSource(
+      "from typing import TYPE_CHECKING\nif TYPE_CHECKING:\n    from B import something"
+    );
+    // Only the `from typing import TYPE_CHECKING` line itself is an edge;
+    // the type-only import under the guard is not (decision #458).
+    expect(parsed.imports.map((i) => i.source)).toEqual(["typing"]);
+  });
+
+  it("skips imports under if typing.TYPE_CHECKING as well", async () => {
+    const parsed = await parsePythonSource(
+      "import typing\nif typing.TYPE_CHECKING:\n    from B import something"
+    );
+    expect(parsed.imports.map((i) => i.source)).toEqual(["typing"]);
+  });
+
+  it("still extracts imports under non-TYPE_CHECKING conditions", async () => {
+    const parsed = await parsePythonSource("if SOME_FLAG:\n    from B import something");
+    expect(parsed.imports.map((i) => i.source)).toEqual(["B"]);
+  });
 });


### PR DESCRIPTION
Implements **Variant A** for both detector decisions. Reviewing/merging this PR = accepting Variant A for #458 and #459; say so before merge if you prefer Variant B (no code change) for either.

## #458 — TYPE_CHECKING imports are not graph edges
`packages/parser/python/parsePython.ts`: imports under `if TYPE_CHECKING:` / `if typing.TYPE_CHECKING:` are skipped — a type-only cycle is no longer reported. Non-TYPE_CHECKING guards still extract (negative control). Note: the TS parser already marks type-only imports via `RawImport.kind: "type-only"` (parseTs.ts) — a future graph-layer filter could consume that.

## #459 — test files excluded from dead/orphan/unused
New `packages/detectors/testFiles.ts` (`isTestFilePath`: `*.test/spec.(ts|tsx|js|jsx)`, `test_*.py`, `*_test.py`, `conftest.py`), wired into detectOrphanFiles / detectUnusedFiles / detectUnusedExports / detectDeadCode (same convention pattern as entry points). Boundaries (documented in the issues): `vitest.setup.ts`-style setup files not matching the test-name convention are still flagged; detectMissingExports untouched.

## Tests
Adversarial suite flipped from pinned current behavior to negative controls; +6 (3 parser TYPE_CHECKING incl. non-guard control, 2 test-file exclusions, isTestFilePath describe). Suite: **478/478 (44 files)**.

## Bonus: mechanical P-003 guard
`scripts/check-diary.ts` validates AGENT_DIARY.md structure (every `**Status:**` must have a `## ` header within 2 lines — catches the orphaned-entry-body failure class), wired into the pre-commit hook as a best-effort check. Positive + negative controls verified (broken diary → exit 1).