### PR TITLE
fix(detectors): detectRepositoryPattern excludes type-only edges + real-repo score gate

### DIFF
--- a/packages/detectors/detectRepositoryPattern.ts
+++ b/packages/detectors/detectRepositoryPattern.ts
@@ -17,6 +17,11 @@
 // detectCircularDependency.ts, applied to a package-id graph derived via
 // the same "first two path segments" grouping calculateAffectedModules.ts
 // uses.
+//
+// Type-only edges (TS `import type`, Python `if TYPE_CHECKING:`) are
+// excluded from the package graph, matching detectCircularDependency.ts's
+// runtime-cycle semantics (decision #458, Variant C): a package pair linked
+// only by type imports has no runtime dependency between them.
 
 import type { Repository } from "../repository/Repository";
 
@@ -37,7 +42,15 @@ export function detectRepositoryPattern(repository: Repository): RepositoryPatte
   const packageGraph = new Map<string, Set<string>>();
   for (const module of modules) {
     const fromPackage = packageIdOf(module.file.relativePath);
+    // Type-only edges are compile-time deps, not runtime package
+    // dependencies (decision #458-C, same as detectCircularDependency.ts).
+    const typeOnlyTargets = new Set(
+      (module.resolvedImports ?? [])
+        .filter((r) => r.kind === "type-only")
+        .map((r) => r.moduleId)
+    );
     for (const importedId of module.imports) {
+      if (typeOnlyTargets.has(importedId)) continue;
       const importedModule = repository.getModule(importedId);
       if (!importedModule) continue;
       const toPackage = packageIdOf(importedModule.file.relativePath);

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -10,7 +10,7 @@ documented there in full rather than duplicated here.
 | Script | What it does | Status |
 |---|---|---|
 | `testManifests.ts` | Manual verification: runs each manifest parser against a real manifest file (go.mod, Cargo.toml, etc) copied to `~/manifest-samples`, prints results for eyeball-checking | Working |
-| `testPlayground.ts` | Runs the full pipeline against `playground/*` fixture repos | Working |
+| `testPlayground.ts` | Runs the full pipeline + all 19 detectors against `playground/*` fixtures or the repo itself (`. --local`); real-repo score summary (19/19 OK), exit 1 on crash/malformed output | Working |
 | `checkCollaboratorMarkers.ts` | Detects files referenced in an assigned GitHub issue that don't have an in-file comment mentioning the issue number | Working |
 | `check-diary.ts` | Validates AGENT_DIARY.md structure — every `**Status:**` must have a `## ` header within 2 lines (catches the P-003 orphaned-body failure class). Wired into the pre-commit hook as a best-effort check | Working |
 | `build.ts` | Unclear purpose — `package.json`'s `"build"` script uses `turbo run build` directly, not this file. Empty, not wired to anything. | Not started |

--- a/scripts/testPlayground.ts
+++ b/scripts/testPlayground.ts
@@ -37,6 +37,10 @@ import { detectStoryConvention } from "../packages/detectors/detectStoryConventi
 import { detectMissingExports } from "../packages/detectors/detectMissingExports";
 import { detectFeatureStructure } from "../packages/detectors/detectFeatureStructure";
 import { detectRepositoryPattern } from "../packages/detectors/detectRepositoryPattern";
+import { detectDeadCode } from "../packages/detectors/detectDeadCode";
+import { detectLayerViolation } from "../packages/detectors/detectLayerViolation";
+import { detectAmbiguousSymbolResolution } from "../packages/detectors/detectAmbiguousSymbolResolution";
+import type { Repository } from "../packages/repository/Repository";
 import { parserRegistry } from "../packages/parser/core/ParserRegistry";
 import { parseTs } from "../packages/parser/typescript/parseTs";
 import { parsePython } from "../packages/parser/python/parsePython";
@@ -97,22 +101,61 @@ async function main() {
   const graph = buildDependencyGraph(repository);
   console.log(`Graph: ${graph.nodes.length} nodes, ${graph.edges.length} edges`);
 
-  printList("detectCircularDependency", detectCircularDependency(repository), (c) => JSON.stringify(c));
-  printList("detectUnusedExports", detectUnusedExports(repository), (f) => `${f.filePath}:${f.line} — ${f.message}`);
-  printList("detectOrphanFiles", detectOrphanFiles(repository), (f) => f.message);
-  printList("detectLargeModules", detectLargeModules(repository), (f) => f.message);
-  printList("detectDuplicateModules", detectDuplicateModules(repository), (g) => `[${g.filePaths.join(", ")}]`);
-  printList("detectSharedModules", detectSharedModules(repository), (f) => f.message);
-  printList("detectIndexFiles", detectIndexFiles(repository), (f) => f.message);
-  printList("detectEntryPoints", detectEntryPoints(repository), (f) => `${f.filePath} — ${f.reason}`);
-  printList("detectUnusedFiles", detectUnusedFiles(repository), (f) => f.message);
-  printList("detectComponentConvention", detectComponentConvention(repository), (f) => f.message);
-  printList("detectRouteConvention", detectRouteConvention(repository), (f) => f.message);
-  printList("detectTestConvention", detectTestConvention(repository), (f) => f.message);
-  printList("detectStoryConvention", detectStoryConvention(repository), (f) => f.message);
-  printList("detectMissingExports", detectMissingExports(repository), (f) => f.message);
-  printList("detectFeatureStructure", detectFeatureStructure(repository), (f) => f.message);
-  printList("detectRepositoryPattern", detectRepositoryPattern(repository), (f) => f.message);
+  // Real-repo detector score: every detector must run without throwing and
+  // return an array of objects. Findings are informational — exit code 1 is
+  // reserved for crashes / malformed output (catches the class of bugs
+  // synthetic fixtures miss, e.g. the 263-byte stub duplicate-modules
+  // incident, status-detectors.md 2026-08-03).
+  const DETECTORS: {
+    name: string;
+    run: (r: Repository) => unknown[];
+    format: (f: unknown) => string;
+  }[] = [
+    { name: "detectCircularDependency", run: detectCircularDependency, format: (c) => JSON.stringify(c) },
+    { name: "detectUnusedExports", run: detectUnusedExports, format: (f) => `${(f as { filePath: string }).filePath}:${(f as { line: number }).line} — ${(f as { message: string }).message}` },
+    { name: "detectOrphanFiles", run: detectOrphanFiles, format: (f) => (f as { message: string }).message },
+    { name: "detectDeadCode", run: detectDeadCode, format: (f) => (f as { message: string }).message },
+    { name: "detectLargeModules", run: detectLargeModules, format: (f) => (f as { message: string }).message },
+    { name: "detectDuplicateModules", run: detectDuplicateModules, format: (g) => `[${(g as { filePaths: string[] }).filePaths.join(", ")}]` },
+    { name: "detectSharedModules", run: detectSharedModules, format: (f) => (f as { message: string }).message },
+    { name: "detectIndexFiles", run: detectIndexFiles, format: (f) => (f as { message: string }).message },
+    { name: "detectLayerViolation", run: detectLayerViolation, format: (f) => { const x = f as { ruleName: string; importedFilePath: string; line: number }; return `${x.ruleName} → ${x.importedFilePath}:${x.line}`; } },
+    { name: "detectEntryPoints", run: detectEntryPoints, format: (f) => `${(f as { filePath: string }).filePath} — ${(f as { reason: string }).reason}` },
+    { name: "detectUnusedFiles", run: detectUnusedFiles, format: (f) => (f as { message: string }).message },
+    { name: "detectComponentConvention", run: detectComponentConvention, format: (f) => (f as { message: string }).message },
+    { name: "detectRouteConvention", run: detectRouteConvention, format: (f) => (f as { message: string }).message },
+    { name: "detectTestConvention", run: detectTestConvention, format: (f) => (f as { message: string }).message },
+    { name: "detectStoryConvention", run: detectStoryConvention, format: (f) => (f as { message: string }).message },
+    { name: "detectMissingExports", run: detectMissingExports, format: (f) => (f as { message: string }).message },
+    { name: "detectFeatureStructure", run: detectFeatureStructure, format: (f) => (f as { message: string }).message },
+    { name: "detectRepositoryPattern", run: detectRepositoryPattern, format: (f) => JSON.stringify(f) },
+    { name: "detectAmbiguousSymbolResolution", run: detectAmbiguousSymbolResolution, format: (f) => { const x = f as { symbolName: string; severity: string }; return `${x.symbolName} (${x.severity})`; } },
+  ];
+
+  const failures: string[] = [];
+  for (const entry of DETECTORS) {
+    try {
+      const findings = entry.run(repository);
+      if (
+        !Array.isArray(findings) ||
+        findings.some((item) => typeof item !== "object" || item === null)
+      ) {
+        failures.push(`${entry.name}: malformed output (expected array of objects)`);
+        continue;
+      }
+      printList(entry.name, findings as object[], entry.format);
+    } catch (err) {
+      failures.push(`${entry.name}: threw ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const ok = DETECTORS.length - failures.length;
+  console.log(`\n=== Detector score (real repo): ${ok}/${DETECTORS.length} OK ===`);
+  if (failures.length > 0) {
+    console.error("FAILURES:");
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
 
   console.log("");
 }

--- a/tests/detectors-adversarial.test.ts
+++ b/tests/detectors-adversarial.test.ts
@@ -23,6 +23,7 @@ import { detectCircularDependency } from "../packages/detectors/detectCircularDe
 import { detectDeadCode } from "../packages/detectors/detectDeadCode";
 import { detectOrphanFiles } from "../packages/detectors/detectOrphanFiles";
 import { detectUnusedExports } from "../packages/detectors/detectUnusedExports";
+import { detectRepositoryPattern } from "../packages/detectors/detectRepositoryPattern";
 import { isTestFilePath } from "../packages/detectors/testFiles";
 import type { FileInfo, ModuleInfo, RepositoryMeta, RawExport, ResolvedImport } from "../packages/shared/types";
 
@@ -272,6 +273,30 @@ describe("adversarial — detectUnusedExports", () => {
       }),
     ]);
     expect(detectUnusedExports(repo)).toEqual([]);
+  });
+});
+
+describe("adversarial — detectRepositoryPattern", () => {
+  it("a package cycle closed only by a type-only edge is not reported (decision #458)", () => {
+    // runtime -> security is a real (value) edge; security -> runtime is
+    // type-only (TS `import type` / Python `if TYPE_CHECKING:`). No runtime
+    // package cycle exists — mirrors detectCircularDependency's handling.
+    const repo = makeRepository([
+      makeModule("packages/runtime/pm.ts", {
+        imports: ["packages/security/sandbox.ts"],
+        resolvedImports: [
+          { moduleId: "packages/security/sandbox.ts", kind: "static", namedImports: ["Sandbox"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        ],
+      }),
+      makeModule("packages/security/sandbox.ts", {
+        imports: ["packages/runtime/spec.ts"],
+        resolvedImports: [
+          { moduleId: "packages/runtime/spec.ts", kind: "type-only", namedImports: ["ProcessSpec"], hasDefaultImport: false, hasNamespaceImport: false, line: 1 },
+        ],
+      }),
+      makeModule("packages/runtime/spec.ts"),
+    ]);
+    expect(detectRepositoryPattern(repo)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What & why\nRunning the real-repo detector gate (`npx tsx scripts/testPlayground.ts .`) surfaced a false positive: **packages/runtime ↔ packages/security** reported as a package cycle — but the security → runtime edge is **type-only** (`import type { ProcessSpec }`). `detectCircularDependency` received the type-only filter (decision #458-C, PR #461) but its package-level counterpart `detectRepositoryPattern` did not — a consistency gap.

## Changes
- **`packages/detectors/detectRepositoryPattern.ts`**: skip type-only edges when building the package graph (same `resolvedImports.kind === "type-only"` filter as `detectCircularDependency`). Real repo result: **0 findings** (was 1 false positive).
- **`tests/detectors-adversarial.test.ts`**: +1 test — a package cycle closed only by a type-only edge is not reported.
- **`scripts/testPlayground.ts`**: upgraded to a real-repo **detector score gate** — all 19 detectors (added the missing detectDeadCode / detectLayerViolation / detectAmbiguousSymbolResolution) with output-shape validation (array of objects), a `N/19 OK` summary, and exit 1 on crash/malformed output. Catches the class of bugs synthetic fixtures miss (e.g. the 263-byte stub duplicate-modules incident).
- **`scripts/README.md`**: row updated.

## Validation
- `npx vitest run` → **482/482 (44 files)**
- `npx tsx scripts/testPlayground.ts .` → 589 modules, 1114 edges, **19/19 OK**, detectRepositoryPattern 0 findings