### PR TITLE
fix(detectors): classify the VS Code extension entry file as an entry point (#463)

### DIFF
--- a/packages/detectors/detectEntryPoints.ts
+++ b/packages/detectors/detectEntryPoints.ts
@@ -36,6 +36,7 @@ export interface EntryPointFinding {
 const NEXTJS_APP_ROUTER_FILE = /(^|\/)app\/.*\/(page|layout|loading|error|not-found|route|template|default)\.(ts|tsx)$/;
 const NEXTJS_ROOT_APP_FILE = /(^|\/)app\/(page|layout|loading|error|not-found|route|template|default)\.(ts|tsx)$/;
 const CLI_ENTRY_FILE = /(^|\/)apps\/cli\/index\.ts$/;
+const VSCODE_EXTENSION_ENTRY_FILE = /(^|\/)apps\/vscode-extension\/src\/extension\.ts$/;
 
 function classify(module: ModuleInfo): string | null {
   const path = module.file.relativePath;
@@ -46,6 +47,10 @@ function classify(module: ModuleInfo): string | null {
 
   if (CLI_ENTRY_FILE.test(path)) {
     return "CLI entry point — invoked directly by the runtime (e.g. tsx/node), not imported by other source files.";
+  }
+
+  if (VSCODE_EXTENSION_ENTRY_FILE.test(path)) {
+    return "VS Code extension entry point — invoked by the VS Code runtime (package.json main/activationEvents), not imported by other source files.";
   }
 
   return null;

--- a/tests/core-detectors.test.ts
+++ b/tests/core-detectors.test.ts
@@ -171,6 +171,13 @@ describe("detectUnusedExports", () => {
     const repo = makeRepository([makeModule("apps/cli/index.ts", { exports: [named("main")] })]);
     expect(detectUnusedExports(repo)).toHaveLength(0);
   });
+
+  it("does not flag exports of the VS Code extension entry file — issue #463", () => {
+    const repo = makeRepository([
+      makeModule("apps/vscode-extension/src/extension.ts", { exports: [named("activate"), named("deactivate")] }),
+    ]);
+    expect(detectUnusedExports(repo)).toHaveLength(0);
+  });
 });
 
 describe("detectOrphanFiles", () => {
@@ -188,6 +195,11 @@ describe("detectOrphanFiles", () => {
 
   it("does not flag the CLI entry point as orphan — issue #4", () => {
     const repo = makeRepository([makeModule("apps/cli/index.ts")]);
+    expect(detectOrphanFiles(repo)).toHaveLength(0);
+  });
+
+  it("does not flag the VS Code extension entry file as orphan — issue #463", () => {
+    const repo = makeRepository([makeModule("apps/vscode-extension/src/extension.ts")]);
     expect(detectOrphanFiles(repo)).toHaveLength(0);
   });
 

--- a/tests/detector.test.ts
+++ b/tests/detector.test.ts
@@ -291,6 +291,13 @@ describe("detectEntryPoints", () => {
     expect(detectEntryPoints(repo).map((f) => f.filePath)).toEqual(["apps/cli/index.ts"]);
   });
 
+  it("recognizes the VS Code extension entry file (issue #463)", () => {
+    const repo = makeRepository([makeModule("apps/vscode-extension/src/extension.ts")]);
+    const findings = detectEntryPoints(repo);
+    expect(findings.map((f) => f.filePath)).toEqual(["apps/vscode-extension/src/extension.ts"]);
+    expect(findings[0].reason).toContain("VS Code");
+  });
+
   it("does not classify a plain orphaned file as an entry point", () => {
     const repo = makeRepository([makeModule("src/random.ts")]);
     expect(detectEntryPoints(repo)).toHaveLength(0);


### PR DESCRIPTION
## #463 — VS Code extension entry points flagged as unused exports\n\ndetectEntryPoints gains a path convention for `apps/vscode-extension/src/extension.ts` — its `activate`/`deactivate` exports are invoked by the VS Code runtime (package.json `main` + `activationEvents`), not by an import statement, so flagging them was a false positive (found by the real-repo gate, testPlayground .).\n\nComposes automatically into detectUnusedExports / detectOrphanFiles / detectUnusedFiles via the existing entry-set wiring — same pattern as `apps/cli/index.ts`. Path-based convention, no package.json I/O (per the detector's design principle).\n\n## Validation\n- +3 tests: entryPoints reason contains 'VS Code'; unused-exports skip; orphan skip\n- real-repo gate: activate/deactivate findings gone (extension.ts now listed under detectEntryPoints), 19/19 OK\n- `npx vitest run` → 485/485 (44 files)