### PR TITLE
fix(detectors): classify .github/scripts as entry points (#464)

### DIFF
--- a/packages/detectors/detectEntryPoints.ts
+++ b/packages/detectors/detectEntryPoints.ts
@@ -37,6 +37,7 @@ const NEXTJS_APP_ROUTER_FILE = /(^|\/)app\/.*\/(page|layout|loading|error|not-fo
 const NEXTJS_ROOT_APP_FILE = /(^|\/)app\/(page|layout|loading|error|not-found|route|template|default)\.(ts|tsx)$/;
 const CLI_ENTRY_FILE = /(^|\/)apps\/cli\/index\.ts$/;
 const VSCODE_EXTENSION_ENTRY_FILE = /(^|\/)apps\/vscode-extension\/src\/extension\.ts$/;
+const GITHUB_SCRIPTS_FILE = /(^|\/)\.github\/scripts\/.+\.py$/;
 
 function classify(module: ModuleInfo): string | null {
   const path = module.file.relativePath;
@@ -51,6 +52,10 @@ function classify(module: ModuleInfo): string | null {
 
   if (VSCODE_EXTENSION_ENTRY_FILE.test(path)) {
     return "VS Code extension entry point — invoked by the VS Code runtime (package.json main/activationEvents), not imported by other source files.";
+  }
+
+  if (GITHUB_SCRIPTS_FILE.test(path)) {
+    return "GitHub workflow script — invoked directly by a workflow (python3 .github/scripts/...), not imported by other source files.";
   }
 
   return null;

--- a/tests/core-detectors.test.ts
+++ b/tests/core-detectors.test.ts
@@ -178,6 +178,13 @@ describe("detectUnusedExports", () => {
     ]);
     expect(detectUnusedExports(repo)).toHaveLength(0);
   });
+
+  it("does not flag exports of GitHub workflow scripts — issue #464", () => {
+    const repo = makeRepository([
+      makeModule(".github/scripts/threatcrush-to-sarif.py", { exports: [named("to_sarif"), named("main")] }),
+    ]);
+    expect(detectUnusedExports(repo)).toHaveLength(0);
+  });
 });
 
 describe("detectOrphanFiles", () => {

--- a/tests/detector.test.ts
+++ b/tests/detector.test.ts
@@ -298,6 +298,13 @@ describe("detectEntryPoints", () => {
     expect(findings[0].reason).toContain("VS Code");
   });
 
+  it("recognizes GitHub workflow scripts as entry points (issue #464)", () => {
+    const repo = makeRepository([makeModule(".github/scripts/threatcrush-to-sarif.py")]);
+    const findings = detectEntryPoints(repo);
+    expect(findings.map((f) => f.filePath)).toEqual([".github/scripts/threatcrush-to-sarif.py"]);
+    expect(findings[0].reason).toContain("GitHub workflow");
+  });
+
   it("does not classify a plain orphaned file as an entry point", () => {
     const repo = makeRepository([makeModule("src/random.ts")]);
     expect(detectEntryPoints(repo)).toHaveLength(0);


### PR DESCRIPTION
## #464 — standalone CI scripts flagged as unused exports\n\ndetectEntryPoints gains a path convention for `.github/scripts/**/*.py` — standalone workflow scripts are invoked directly by GitHub Actions (`python3 .github/scripts/threatcrush-to-sarif.py ...`), not imported by source files. Same path-convention pattern as #463 (VS Code extension). Composes automatically into detectUnusedExports / detectOrphanFiles / detectUnusedFiles.\n\nScoped to `.github/scripts` — a generic 'standalone script' convention stays out of scope (too broad).\n\n## Validation\n- +2 tests: entryPoints reason contains 'GitHub workflow'; unused-exports skip\n- real-repo gate: threatcrush-to-sarif.py findings gone (now under detectEntryPoints), 19/19 OK\n- `npx vitest run` → 487/487 (44 files)