### PR TITLE
feat: 2D material-style icons + type color border; P0: purge merge junk breaking 3D chunk

### DIFF
--- a/apps/web/components/graph/GraphCanvas3D.tsx
+++ b/apps/web/components/graph/GraphCanvas3D.tsx
@@ -16,7 +16,6 @@
 
 "use client";
 
-fix/graph-menu-3d-toggle
 import { useMemo, useRef } from "react";
 import dynamic from "next/dynamic";
 import * as THREE from "three";
@@ -24,18 +23,8 @@ import { useGraphContext } from "./GraphProvider";
 import { getGraphNodeColor } from "@/theme/graphColors";
 import type { GraphNodeType } from "@/packages/shared/types";
 
-import { useCallback, useMemo, useRef } from "react";
-import dynamic from "next/dynamic";
-import * as THREE from "three";
-import { useGraphContext } from "./GraphProvider";
-import { graphNodeColors } from "@/theme/graphColors";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
-import type { ForceGraphMethods } from "react-force-graph-3d";
- ARCLUX.main
-
 const ForceGraph3D = dynamic(() => import("react-force-graph-3d"), { ssr: false });
 
-fix/graph-menu-3d-toggle
 // Mirrors GraphNode.tsx (2D) thresholds exactly -- keep these two files
 // in sync if the tiers ever get tuned.
 const IMPACT_HIGH_THRESHOLD = 100;
@@ -57,166 +46,21 @@ export function GraphCanvas3D() {
   const { graph, isLoading, error, selectedNodeId, selectNode, importCounts } = useGraphContext();
   const haloRingsRef = useRef<Map<string, HaloRingEntry>>(new Map());
 
-// Fan-in tiers mirror the 2D impact halo (GraphNode.tsx: IMPACT_*_THRESHOLD)
-// and the 2D LOD always-label tier (MIN_ZOOM_FOR_ALWAYS_LABEL) so an
-// "important file" reads the same in both views. importCounts comes from
-// GraphProvider (client-side fan-in over graph.edges).
-const IMPACT_HIGH_THRESHOLD = 100;
-const IMPACT_MEDIUM_THRESHOLD = 20;
-
-// Sphere radius = cbrt(val) * NODE_REL_SIZE (3d-force-graph). The base dot
-// is ~5 units; medium/high fan-in spheres are bigger AND get a ring, the
-// 3D analogue of the 2D halo circle.
-const NODE_VAL_BASE = 1;
-const NODE_VAL_MEDIUM = 2;
-const NODE_VAL_HIGH = 4;
-const NODE_REL_SIZE = 5;
-// Ring sits just outside the sphere surface: cbrt(val)*NODE_REL_SIZE + RING_GAP.
-const RING_GAP = 3;
-// Camera distance for the double-click "focus node" gesture (2D's
-// zoomToNode equivalent for the orbit camera).
-const FOCUS_CAMERA_DISTANCE = 90;
-
-interface Graph3DNodeData {
-  id: string;
-  name: string;
-  color: string;
-  fanIn: number;
-  val: number;
-}
-
-function nodeValFor(fanIn: number): number {
-  if (fanIn > IMPACT_HIGH_THRESHOLD) return NODE_VAL_HIGH;
-  if (fanIn >= IMPACT_MEDIUM_THRESHOLD) return NODE_VAL_MEDIUM;
-  return NODE_VAL_BASE;
-}
-
-export function GraphCanvas3D() {
-  const {
-    graph,
-    isLoading,
-    error,
-    selectedNodeId,
-    selectNode,
-    setHoveredNodeId,
-    setContextMenuNodeId,
-    importCounts,
-  } = useGraphContext();
-
-  // Coarse pointer = touch devices (mobile / Termux). Cheap visual wins:
-  // lower sphere geometry resolution, no link particles (they read as noise
-  // on small screens anyway) and no MSAA. Fine pointers keep full quality.
-  const isCoarsePointer = useMediaQuery("(pointer: coarse)");
-  const graphRef = useRef<ForceGraphMethods | undefined>(undefined);
-  ARCLUX.main
-
   const graphData = useMemo(() => {
     if (!graph) return { nodes: [], links: [] };
     return {
-      fix/graph-menu-3d-toggle
       nodes: graph.nodes.map((n) => ({
         id: n.id,
         name: n.label,
         type: n.type as GraphNodeType,
         importCount: importCounts.get(n.id) ?? 0,
       })),
-
-      nodes: graph.nodes.map((n) => {
-        const fanIn = importCounts.get(n.id) ?? 0;
-        return {
-          id: n.id,
-          name: n.label,
-          // Same palette as the 2D canvas (GraphNode.tsx ->
-          // getGraphNodeColor, dark mode) so a node's color doesn't change
-          // when toggling 2D/3D — otherwise the legend in GraphMenu would
-          // lie about node types.
-          color: graphNodeColors[n.type].dark,
-          fanIn,
-          val: nodeValFor(fanIn),
-        } satisfies Graph3DNodeData;
-      })
-      ARCLUX.main
       links: graph.edges.map((e) => ({
         source: e.source,
         target: e.target,
       })),
     };
   }, [graph, importCounts]);
- fix/graph-menu-3d-toggle
-
-
-  // Importance ring: a torus just outside the sphere for medium/high fan-in
-  // nodes — the 3D analogue of the 2D impact halo (GraphNode.tsx draws a
-  // 9/14px circle around the dot for the same thresholds). nodeThreeObjectExtend
-  // keeps the default sphere so nodeColor/nodeVal still drive fill/size, and
-  // the ring radius is baked into the geometry (3d-force-graph sets the
-  // sphere radius via geometry, sphere scale stays 1) so the ring never
-  // scales away from the surface.
-  const nodeThreeObject = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (node: any) => {
-      // null -> fall back to the default sphere (runtime-supported, but
-      // the d.ts types only allow Object3D, hence the cast).
-      if (node.fanIn < IMPACT_MEDIUM_THRESHOLD) return null as unknown as THREE.Object3D;
-    const radius = Math.cbrt(node.val) * NODE_REL_SIZE + RING_GAP;
-    return new THREE.Mesh(
-      new THREE.TorusGeometry(radius, 0.15, 8, 48),
-      new THREE.MeshBasicMaterial({
-        color: node.color,
-        transparent: true,
-        opacity: 0.35,
-      })
-    );
-  }, []);
-
-  // Recreated only when the selection changes, so 3d-force-graph's
-  // prop-change digest (which re-applies node material) only runs then,
-  // not on every render.
-  const nodeColor = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (node: any) => (node.id === selectedNodeId ? "#ffffff" : node.color),
-    [selectedNodeId]
-  );
-
-  const onNodeClick = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (node: any, event: MouseEvent) => {
-      selectNode(node.id);
-      // Double-click focuses the camera on the node (2D's double-click
-      // zoom-to-node equivalent).
-      if (event.detail >= 2) {
-        graphRef.current?.cameraPosition(
-          { x: node.x ?? 0, y: node.y ?? 0, z: (node.z ?? 0) + FOCUS_CAMERA_DISTANCE },
-          { x: node.x ?? 0, y: node.y ?? 0, z: node.z ?? 0 },
-          400
-        );
-      }
-    },
-    [selectNode]
-  );
-
-  const onNodeHover = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (node: any | null) => setHoveredNodeId(node ? node.id : null),
-    [setHoveredNodeId]
-  );
-
-  const onBackgroundClick = useCallback(() => selectNode(null), [selectNode]);
-
-  // Right-click opens the shared GraphContextMenu. That menu positions
-  // itself on a pointermove; right-click doesn't guarantee one fires, so
-  // synthesize it at the click coordinates.
-  const onNodeRightClick = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (node: any, event: MouseEvent) => {
-      setContextMenuNodeId(node.id);
-      window.dispatchEvent(
-        new PointerEvent("pointermove", { clientX: event.clientX, clientY: event.clientY })
-      );
-    },
-    [setContextMenuNodeId]
-  );
- ARCLUX.main
 
   if (isLoading) return <div>Loading graph...</div>;
   if (error) return <div>Error: {error}</div>;
@@ -224,10 +68,8 @@ export function GraphCanvas3D() {
 
   return (
     <ForceGraph3D
-      ref={graphRef}
       graphData={graphData}
       nodeLabel="name"
-     fix/graph-menu-3d-toggle
       nodeThreeObjectExtend={false}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       nodeThreeObject={(node: any) => {
@@ -292,26 +134,10 @@ export function GraphCanvas3D() {
           mat.opacity = baseOpacity * (0.7 + 0.3 * Math.sin(t * 2 + mesh.id));
         }
       }}
-
-      nodeVal="val"
-      nodeColor={nodeColor}
-      nodeRelSize={NODE_REL_SIZE}
-      nodeOpacity={0.9}
-      nodeResolution={isCoarsePointer ? 6 : 8}
-      nodeThreeObject={nodeThreeObject}
-      nodeThreeObjectExtend
-      onNodeClick={onNodeClick}
-      onNodeHover={onNodeHover}
-      onNodeRightClick={onNodeRightClick}
-      onBackgroundClick={onBackgroundClick}
-      ARCLUX.main
       backgroundColor="#000000"
       linkColor={() => "rgba(255,255,255,0.2)"}
-      linkDirectionalParticles={isCoarsePointer ? 0 : 1}
+      linkDirectionalParticles={1}
       linkDirectionalParticleWidth={1.2}
-      showNavInfo={false}
-      controlType="orbit"
-      rendererConfig={{ antialias: !isCoarsePointer, powerPreference: "high-performance" }}
     />
   );
 }

--- a/apps/web/components/graph/GraphFocusView.tsx
+++ b/apps/web/components/graph/GraphFocusView.tsx
@@ -51,7 +51,7 @@ function NodeIcon({ node, size = 16 }: { node: GraphNodeData; size?: number }) {
     <svg width={size} height={size} viewBox="-8 -8 16 16" className="shrink-0">
       <circle r={7} fill={color} opacity={0.9} />
       <path
-        d={getNodeIconPath(type)}
+        d={getNodeIconPath(type, node.label)}
         fill="none"
         stroke="#fff"
         strokeWidth={0.9}

--- a/apps/web/components/graph/GraphNode.tsx
+++ b/apps/web/components/graph/GraphNode.tsx
@@ -180,13 +180,14 @@ function GraphNodeComponent({
       <circle
         r={radius}
         fill={color}
-        stroke={isSelected ? "#fff" : "transparent"}
-        strokeWidth={1.5}
+        stroke={isSelected ? "#fff" : color}
+        strokeWidth={isSelected ? 1.5 : 0.8}
+        strokeOpacity={isSelected ? 1 : 0.4}
         opacity={isDimmed ? 0.3 : isSelected || isHovered ? 1 : 0.85}
       />
       {zoomScale >= MIN_ZOOM_FOR_ICON && (
         <path
-          d={getNodeIconPath(effectiveType)}
+          d={getNodeIconPath(effectiveType, node.label)}
           fill="none"
           stroke="#fff"
           strokeWidth={0.6}

--- a/apps/web/components/graph/nodeIcons.tsx
+++ b/apps/web/components/graph/nodeIcons.tsx
@@ -9,21 +9,114 @@
 import type { GraphNodeType } from "@/packages/shared/types";
 
 /**
- * Minimal SVG path icons per node type, drawn inside GraphNode's circle.
- * Deliberately simple single-path shapes (not a full icon library import
- * like lucide-react here) — these get rendered once per node, and a graph
- * can have thousands of nodes (see the 1,842-node reference mockup this
- * was scoped down from). Each path is designed to fit inside an 8x8
- * viewBox centered at origin, matching GraphNode's BASE_RADIUS.
+ * Minimal SVG path icons for node rendering. Deliberately simple
+ * single-path shapes (not a full icon library import like lucide-react
+ * here) — these get rendered once per node, and a graph can have
+ * thousands of nodes (see the 1,842-node reference mockup this was
+ * scoped down from). Each path is designed to fit inside an 8x8 viewBox
+ * centered at origin, matching GraphNode's BASE_RADIUS.
+ *
+ * Node-type icons (getNodeIconPath) are used for non-file node types
+ * (folder/package/route/component/hook). File nodes resolve their icon
+ * from the FILE NAME via getMaterialIcon — a Material-Icon-Theme-style
+ * mapping (file extension / special folder names), so a .py node looks
+ * different from a .ts node.
  */
-export function getNodeIconPath(type: GraphNodeType): string {
+
+// ---------------------------------------------------------------------------
+// Material-style file icons, keyed by lowercased extension. Values are
+// simple recognizable shapes (not pixel-perfect Material assets) drawn in
+// the same ±3.5 coordinate box as the node-type icons.
+// ---------------------------------------------------------------------------
+
+// Generic code file (page with folded corner) — TS/JS default.
+const CODE_FILE = "M-2.5,-3.5 L0.5,-3.5 L2.5,-1.5 L2.5,3.5 L-2.5,3.5 Z M0.5,-3.5 L0.5,-1.5 L2.5,-1.5";
+// Python-ish: two interlocked loops (simplified infinity/snake motif).
+const PYTHON_FILE = "M-2,-2 Q0,-3.6 2,-2 Q3.6,0 2,2 Q0,3.6 -2,2 Q-3.6,0 -2,-2 M-2,2 L2,-2";
+// Config: curly braces.
+const CONFIG_FILE = "M-1.5,-3.5 L-1.5,-1.5 C-1.5,0 -2.5,0.5 -2.5,0 C-2.5,-0.5 -1.5,0 -1.5,1.5 L-1.5,3.5 M1.5,-3.5 L1.5,-1.5 C1.5,0 2.5,0.5 2.5,0 C2.5,-0.5 1.5,0 1.5,1.5 L1.5,3.5";
+// Documentation: page with text lines.
+const DOC_FILE = "M-2.5,-3.5 L2.5,-3.5 L2.5,3.5 L-2.5,3.5 Z M-1.5,-1.5 L1.5,-1.5 M-1.5,0 L1.5,0 M-1.5,1.5 L0.5,1.5";
+// Docker: stacked container boxes.
+const DOCKER_FILE = "M-3,-3 L3,-3 L3,-1 L-3,-1 Z M-3,-1 L3,-1 L1.5,2 L-1.5,2 Z M-1.5,2 L1.5,2";
+// Database: cylinder (ellipse + body).
+const DATABASE_FILE = "M-3,-1 C-3,-2.8 3,-2.8 3,-1 C3,0.8 -3,0.8 -3,-1 M-3,-1 L-3,2 C-3,3.8 3,3.8 3,2 L3,-1";
+
+const MATERIAL_FILE_ICONS: Record<string, string> = {
+  ".py": PYTHON_FILE,
+  ".ts": CODE_FILE,
+  ".tsx": CODE_FILE,
+  ".js": CODE_FILE,
+  ".jsx": CODE_FILE,
+  ".json": CONFIG_FILE,
+  ".yaml": CONFIG_FILE,
+  ".yml": CONFIG_FILE,
+  ".toml": CONFIG_FILE,
+  ".env": CONFIG_FILE,
+  ".md": DOC_FILE,
+  ".txt": DOC_FILE,
+  ".sql": DATABASE_FILE,
+  ".db": DATABASE_FILE,
+};
+
+// ---------------------------------------------------------------------------
+// Material-style folder icons, keyed by lowercased folder name. All inherit
+// the base folder silhouette; the extras mark the architectural role.
+// ---------------------------------------------------------------------------
+
+const FOLDER_BASE = "M-3,-2 L-1,-2 L-0.2,-1 L3,-1 L3,2.5 L-3,2.5 Z";
+// Source: folder with a solid dot in the middle.
+const FOLDER_SRC = FOLDER_BASE + " M0,0.8 A1.3 1.3 0 1 1 0.1,0.8";
+// Test: folder with a checkmark.
+const FOLDER_TEST = FOLDER_BASE + " M-1.2,0.8 L0,2 L2,-1";
+// Components: folder with a plus.
+const FOLDER_COMPONENTS = FOLDER_BASE + " M0,-1.3 L0,2.3 M-1.8,0.5 L1.8,0.5";
+// Core: folder with a star.
+const FOLDER_CORE = FOLDER_BASE + " M0,-0.2 L0.7,0.9 L2,1.2 L1.2,2.2 L1.4,3.5 L0,2.8 L-1.4,3.5 L-1.2,2.2 L-2,1.2 L-0.7,0.9 Z";
+// Utils: folder with a gear-ish ring + center dot.
+const FOLDER_UTILS = FOLDER_BASE + " M0,0.8 A1.6 1.6 0 1 1 0.1,0.8 M0,0.8 A0.7 0.7 0 1 1 0.05,0.8";
+
+const MATERIAL_FOLDER_ICONS: Record<string, string> = {
+  src: FOLDER_SRC,
+  tests: FOLDER_TEST,
+  test: FOLDER_TEST,
+  components: FOLDER_COMPONENTS,
+  core: FOLDER_CORE,
+  utils: FOLDER_UTILS,
+};
+
+/**
+ * Material-Icon-Theme-style resolver: returns an SVG path for a node based
+ * on its file name (extension) or, for folders, its directory name.
+ * Unknown extensions fall back to a generic code file; unknown folders to
+ * the base folder silhouette.
+ */
+export function getMaterialIcon(fileName: string, isFolder: boolean): string {
+  if (isFolder) {
+    return MATERIAL_FOLDER_ICONS[fileName.toLowerCase()] ?? FOLDER_BASE;
+  }
+
+  // Name-based specials (no extension to key on).
+  if (fileName === "Dockerfile" || fileName.startsWith("docker-compose")) {
+    return DOCKER_FILE;
+  }
+
+  const extMatch = /(\.[^.]+)$/.exec(fileName);
+  const ext = extMatch ? extMatch[1].toLowerCase() : "";
+  return MATERIAL_FILE_ICONS[ext] ?? CODE_FILE;
+}
+
+/**
+ * Icon path for a node, keyed by node type. File/folder nodes with a known
+ * file name get the Material-style icon resolved from that name; all other
+ * types use their fixed shape.
+ */
+export function getNodeIconPath(type: GraphNodeType, fileName?: string): string {
   switch (type) {
     case "file":
-      // Simple document/page shape
-      return "M-2.5,-3.5 L0.5,-3.5 L2.5,-1.5 L2.5,3.5 L-2.5,3.5 Z M0.5,-3.5 L0.5,-1.5 L2.5,-1.5";
+      return fileName ? getMaterialIcon(fileName, false) : CODE_FILE;
     case "folder":
-      // Folder shape
-      return "M-3,-2 L-1,-2 L-0.2,-1 L3,-1 L3,2.5 L-3,2.5 Z";
+      return fileName ? getMaterialIcon(fileName, true) : FOLDER_BASE;
     case "external-package":
       // Package/box shape (hexagon-ish cube outline, simplified to a diamond)
       return "M0,-3.2 L3,0 L0,3.2 L-3,0 Z M-3,0 L3,0 M0,-3.2 L0,3.2";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,11 +34,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    fix/graph-menu-3d-toggle
     "@types/three": "^0.185.4",
-
-    "@types/three": "^0.185.0",
-    ARCLUX.main
     "eslint": "^9",
     "eslint-config-next": "16.2.12",
     "tailwindcss": "^4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,11 +156,7 @@ importers:
         specifier: ^19
         version: 19.2.3(@types/react@19.2.17)
       '@types/three':
- fix/graph-menu-3d-toggle
-        specifier: ^0.185.
-        
-        specifier: ^0.185.0
-    ARCLUX.main
+        specifier: ^0.185.4
         version: 0.185.4
       eslint:
         specifier: ^9
@@ -1325,12 +1321,9 @@ packages:
 
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
-   fix/graph-menu-3d-toggle
 
   '@tweenjs/tween.js@25.0.0':
     resolution: {integrity: sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==}
-
-  ARCLUX.main
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -5117,11 +5110,8 @@ snapshots:
     optional: true
 
   '@tweenjs/tween.js@23.1.3': {}
-   fix/graph-menu-3d-toggle
 
   '@tweenjs/tween.js@25.0.0': {}
-
-ARCLUX.main
 
   '@tybys/wasm-util@0.10.3':
     dependencies:
@@ -6017,8 +6007,8 @@ ARCLUX.main
       '@next/eslint-plugin-next': 16.2.12
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -6040,7 +6030,7 @@ ARCLUX.main
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6051,22 +6041,22 @@ ARCLUX.main
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6077,7 +6067,7 @@ ARCLUX.main
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -7779,7 +7769,7 @@ ARCLUX.main
 
   three-render-objects@1.42.0(three@0.185.1):
     dependencies:
-      '@tweenjs/tween.js': 23.1.3
+      '@tweenjs/tween.js': 25.0.0
       accessor-fn: 1.5.3
       float-tooltip: 1.7.5
       kapsule: 1.16.3

--- a/progres/status-web.md
+++ b/progres/status-web.md
@@ -730,3 +730,9 @@ Root cause of "uniform blue" 2D nodes: packages/graph/buildDependencyGraph.ts em
 **Status:** In Progress
 
 Visual polish (GraphCanvas/GraphNode/GraphEdge, all 2D-only): (1) fade-out — selecting or hovering a node dims everything NOT connected to it (connected set memoized per active node; nodes opacity 0.3, edges 0.12, selected/hovered stay full) so the active subgraph reads instantly; (2) selection glow — double accent ring (r+5 @ 0.5, r+8 @ 0.15) around the selected node; (3) route-link edges now dashed ("4 3") per the edge legend. Edge colors already matched the legend via getGraphEdgeColor (import #454545 / export #9D7CD8 / call #52A8FF / route-link #56B6C2). z-index overlay layering verified (Search z-10 left, Menu z-10/20 right, FocusView z-20, context menu z-50). tsc 0, lint 0, suite 487/487.
+
+## 2026-08-16 — 2D: material-style icons by file extension/folder + type color border; P0 junk purge
+
+**Status:** In Progress
+
+(1) nodeIcons.tsx: getMaterialIcon(fileName, isFolder) — extension-based icons (.py/.ts/.tsx/.js/.json/.yaml/.toml/.env/.md/.txt/.sql/.db, Dockerfile/docker-compose) and architectural folder icons (src/tests/components/core/utils); getNodeIconPath(type, fileName?) resolves file/folder nodes through it, others keep their type shape. GraphNode + GraphFocusView pass node.label. (2) GraphNode: thin node-type-colored border (stroke 0.8 @ 0.4; white + glow when selected) — legend badge look. (3) P0: PR #474's merge commit (6fb8557) injected merge-conflict junk lines ("fix/graph-menu-3d-toggle", "ARCLUX.main") into GraphCanvas3D.tsx (7 sites), apps/web/package.json (broken JSON), pnpm-lock.yaml (6 sites) — broke 3D chunk (ChunkLoadError) and tsc. Restored all 3 files from the clean 9c066ae (kept 3D dev's rich-visual commit, @types/three ^0.185.4). tsc 0, lint 0, suite 487/487.


### PR DESCRIPTION
## What changed
2D graph polish + P0 fix (branch: only apps/web/components/graph 2D files + the P0 restore):

### 1. Material-style icon mapping (nodeIcons.tsx)
- New `getMaterialIcon(fileName, isFolder)`: extension-keyed icons — `.py` (python loops), `.ts/.tsx/.js/.jsx` (code file), `.json/.yaml/.toml/.env` (braces), `.md/.txt` (doc lines), `.sql/.db` (cylinder), `Dockerfile`/`docker-compose*` (containers)
- Architectural folder icons: `src` (dot), `tests/test` (check), `components` (plus), `core` (star), `utils` (gear-ish ring)
- `getNodeIconPath(type, fileName?)` now resolves file/folder nodes through it; GraphNode + GraphFocusView pass `node.label`
- Unknown extensions/names fall back to generic shapes

### 2. Node-type color border (GraphNode.tsx)
- Every node gets a thin border in its legend type color (stroke 0.8 @ opacity 0.4); selected node keeps white stroke + glow rings

### 3. P0: merge-conflict junk purge
PR #474's merge commit (6fb8557) injected junk lines (`fix/graph-menu-3d-toggle`, `ARCLUX.main`) into:
- `GraphCanvas3D.tsx` — 7 sites, duplicated imports/consts/functions (broke the 3D chunk → ChunkLoadError, and tsc)
- `apps/web/package.json` — broken JSON (duplicate @types/three + junk lines)
- `pnpm-lock.yaml` — 6 junk sites

Restored all three from the clean `9c066ae` (3D dev's own commit, keeping rich-visual work and `@types/three ^0.185.4`).

## How was this verified
- `npx tsc --noEmit -p apps/web/tsconfig.json` → 0 errors (was: 8 errors from junk)
- `npx eslint` on changed files → 0 errors
- `npx vitest run` → 44 files / 487 tests passed
- `grep` for junk lines across repo → 0 remaining
- 3D files touched ONLY to purge junk (restored to the clean commit); no functional 3D changes by this PR

## Checklist
- [x] npx tsc --noEmit -p apps/web/tsconfig.json
- [x] Updated progres/status-web.md with dated entry
- [x] Doesn't duplicate existing file/logic (checked with grep)
- [x] 3D files: restored to clean state, no new 3D logic added
