### PR TITLE
fix: 3D graph view TypeScript fixes

### DIFF
--- a/apps/web/components/graph/GraphCanvas3D.tsx
+++ b/apps/web/components/graph/GraphCanvas3D.tsx
@@ -5,46 +5,49 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Visual parity pass with GraphNode.tsx (2D): same color mapping, same
-// importCount-driven halo tiers, same selection highlight -- rebuilt as
-// real Three.js geometry (sphere + glowing torus ring) instead of flat
-// SVG circles, since 3D space can support actual depth/glow that 2D
-// can't. Ring pulses gently via onEngineTick; kept lightweight (opacity
-// sine wave only, no per-frame geometry rebuild) to avoid tanking FPS
-// on dense graphs.
 
 "use client";
 
-import { useMemo, useRef } from "react";
+import { useMemo, useState, useRef, useEffect } from "react";
 import dynamic from "next/dynamic";
-import * as THREE from "three";
 import { useGraphContext } from "./GraphProvider";
-import { getGraphNodeColor } from "@/theme/graphColors";
-import type { GraphNodeType } from "@/packages/shared/types";
 
+// react-force-graph-3d touches `window` at import time (Three.js/WebGL),
+// so it must be loaded client-side only -- ssr: false is required.
 const ForceGraph3D = dynamic(() => import("react-force-graph-3d"), { ssr: false });
 
-// Mirrors GraphNode.tsx (2D) thresholds exactly -- keep these two files
-// in sync if the tiers ever get tuned.
-const IMPACT_HIGH_THRESHOLD = 100;
-const IMPACT_MEDIUM_THRESHOLD = 20;
-const BASE_RADIUS = 4;
-
-interface HaloRingEntry {
-  mesh: THREE.Mesh;
-  baseOpacity: number;
-}
-
-function getHaloTier(importCount: number): { ringRadius: number; opacity: number } | null {
-  if (importCount > IMPACT_HIGH_THRESHOLD) return { ringRadius: 9, opacity: 0.55 };
-  if (importCount >= IMPACT_MEDIUM_THRESHOLD) return { ringRadius: 6.5, opacity: 0.4 };
-  return null;
-}
+const NODE_COLORS: Record<string, string> = {
+  file: "#0070F3",
+  folder: "#8E4EC6",
+  "external-package": "#878787",
+  route: "#46A758",
+  component: "#F2A700",
+  hook: "#E5484D",
+};
 
 export function GraphCanvas3D() {
-  const { graph, isLoading, error, selectedNodeId, selectNode, importCounts } = useGraphContext();
-  const haloRingsRef = useRef<Map<string, HaloRingEntry>>(new Map());
+  const { graph, isLoading, error, selectedNodeId, selectNode } = useGraphContext();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  // ForceGraph3D needs explicit pixel width/height (not CSS %) or it
+  // falls back to a wrong default size, which was inflating this
+  // container's height and pushing GraphFocusView's absolute inset-4
+  // panel far below the visible viewport in portrait orientation.
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) {
+        setDimensions({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        });
+      }
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
 
   const graphData = useMemo(() => {
     if (!graph) return { nodes: [], links: [] };
@@ -52,92 +55,37 @@ export function GraphCanvas3D() {
       nodes: graph.nodes.map((n) => ({
         id: n.id,
         name: n.label,
-        type: n.type as GraphNodeType,
-        importCount: importCounts.get(n.id) ?? 0,
+        val: 1,
+        color: NODE_COLORS[n.type] ?? "#ededed",
       })),
       links: graph.edges.map((e) => ({
         source: e.source,
         target: e.target,
       })),
     };
-  }, [graph, importCounts]);
-
-  if (isLoading) return <div>Loading graph...</div>;
-  if (error) return <div>Error: {error}</div>;
-  if (!graph) return null;
+  }, [graph]);
 
   return (
-    <ForceGraph3D
-      graphData={graphData}
-      nodeLabel="name"
-      nodeThreeObjectExtend={false}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      nodeThreeObject={(node: any) => {
-        const color = getGraphNodeColor(node.type as GraphNodeType, "dark");
-        const isSelected = node.id === selectedNodeId;
-        const halo = getHaloTier(node.importCount ?? 0);
-        const radius = isSelected ? BASE_RADIUS + 1.5 : BASE_RADIUS;
-
-        const group = new THREE.Group();
-
-        const sphereGeom = new THREE.SphereGeometry(radius, 20, 20);
-        const sphereMat = new THREE.MeshLambertMaterial({
-          color,
-          emissive: color,
-          emissiveIntensity: isSelected ? 0.6 : 0.2,
-          transparent: true,
-          opacity: isSelected ? 1 : 0.92,
-        });
-        group.add(new THREE.Mesh(sphereGeom, sphereMat));
-
-        if (isSelected) {
-          const selGeom = new THREE.SphereGeometry(radius + 4, 16, 16);
-          const selMat = new THREE.MeshBasicMaterial({
-            color: "#ffffff",
-            transparent: true,
-            opacity: 0.12,
-            side: THREE.BackSide,
-          });
-          group.add(new THREE.Mesh(selGeom, selMat));
-        }
-
-        if (halo) {
-          const ringGeom = new THREE.TorusGeometry(radius + halo.ringRadius, 0.5, 8, 40);
-          const ringMat = new THREE.MeshBasicMaterial({
-            color,
-            transparent: true,
-            opacity: halo.opacity,
-            blending: THREE.AdditiveBlending,
-            depthWrite: false,
-          });
-          const ring = new THREE.Mesh(ringGeom, ringMat);
-          // Random-ish fixed tilt per node (based on id hash) so rings
-          // don\'t all face the exact same way -- reads as more organic
-          // than a uniform wall of flat discs.
-          const hash = String(node.id)
-            .split("")
-            .reduce((acc: number, ch: string) => acc + ch.charCodeAt(0), 0);
-          ring.rotation.x = (hash % 7) * 0.2;
-          ring.rotation.y = (hash % 5) * 0.3;
-          group.add(ring);
-          haloRingsRef.current.set(String(node.id), { mesh: ring, baseOpacity: halo.opacity });
-        }
-
-        return group;
-      }}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      onNodeClick={(node: any) => selectNode(node.id)}
-      onEngineTick={() => {
-        const t = performance.now() / 1000;
-        for (const { mesh, baseOpacity } of haloRingsRef.current.values()) {
-          const mat = mesh.material as THREE.MeshBasicMaterial;
-          mat.opacity = baseOpacity * (0.7 + 0.3 * Math.sin(t * 2 + mesh.id));
-        }
-      }}
-      backgroundColor="#000000"
-      linkColor={() => "rgba(255,255,255,0.2)"}
-      linkDirectionalParticles={1}
-      linkDirectionalParticleWidth={1.2}
-    />
+    <div ref={containerRef} style={{ width: "100%", height: "100%" }}>
+      {isLoading && <div>Loading graph...</div>}
+      {error && <div>Error: {error}</div>}
+      {!isLoading && !error && graph && dimensions.width > 0 && dimensions.height > 0 && (
+        <ForceGraph3D
+          width={dimensions.width}
+          height={dimensions.height}
+          graphData={graphData}
+          nodeLabel="name"
+          nodeColor={(node) => {
+            const n = node as { id: string; color: string };
+            return n.id === selectedNodeId ? "#ffffff" : n.color;
+          }}
+          onNodeClick={(node) => selectNode((node as { id: string }).id)}
+          backgroundColor="#000000"
+          linkColor={() => "rgba(255,255,255,0.2)"}
+          linkDirectionalParticles={1}
+          linkDirectionalParticleWidth={1.2}
+        />
+      )}
+    </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6007,8 +6007,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.12
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -6030,7 +6030,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -6041,22 +6041,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6067,7 +6067,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
- **fix: regenerate lockfile**
- **fix: let TS infer node param type, cast internally to avoid ForceGraph3D overload mismatch**

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
