### PR TITLE
fix: code drawer overlay + 3D camera controls + node click single-surface

### DIFF
--- a/apps/web/components/graph/GraphCanvas3D.tsx
+++ b/apps/web/components/graph/GraphCanvas3D.tsx
@@ -8,10 +8,12 @@
 
 "use client";
 
-import { useMemo, useState, useRef, useEffect } from "react";
+import { useEffect, useMemo, useRef, useState, type MutableRefObject } from "react";
 import dynamic from "next/dynamic";
 import * as THREE from "three";
 import { useGraphContext } from "./GraphProvider";
+import { getEffectiveNodeType } from "./GraphNode";
+import type { ForceGraphMethods } from "react-force-graph-3d";
 
 const ForceGraph3D = dynamic(() => import("react-force-graph-3d"), { ssr: false });
 
@@ -110,7 +112,13 @@ function buildNodeObject(node: NodeDatum): THREE.Object3D {
   return group;
 }
 
-export function GraphCanvas3D() {
+export interface GraphCanvas3DProps {
+  /** Mutable handle the parent fills with the live ForceGraph3D instance;
+   * GraphMenu reads it to drive camera zoom/fit in 3D mode. */
+  fgRef: MutableRefObject<ForceGraphMethods | undefined>;
+}
+
+export function GraphCanvas3D({ fgRef }: GraphCanvas3DProps) {
   const { graph, isLoading, error, selectedNodeId, selectNode, importCounts } = useGraphContext();
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
@@ -131,7 +139,7 @@ export function GraphCanvas3D() {
     if (!graph) return { nodes: [], links: [] };
     return {
       nodes: graph.nodes.map((n) => {
-        const baseColor = NODE_COLORS[n.type] ?? "#ededed";
+        const baseColor = NODE_COLORS[getEffectiveNodeType(n)] ?? "#ededed";
         const importCount = importCounts.get(n.id) ?? 0;
         return {
           id: n.id,
@@ -151,6 +159,7 @@ export function GraphCanvas3D() {
       {error && <div>Error: {error}</div>}
       {!isLoading && !error && graph && dimensions.width > 0 && dimensions.height > 0 && (
         <ForceGraph3D
+          ref={fgRef}
           width={dimensions.width}
           height={dimensions.height}
           graphData={graphData}

--- a/apps/web/components/graph/GraphFocusView.tsx
+++ b/apps/web/components/graph/GraphFocusView.tsx
@@ -112,6 +112,16 @@ export function GraphFocusView() {
   const node = graph?.nodes.find((n) => n.id === selectedNodeId);
   if (!node || !graph || !isFocusPanelOpen) return null;
 
+  // Single source of truth (see GraphViewport.tsx CodeDrawer): "file"-type
+  // nodes open the right-side Code Drawer (File/Dependencies/Impact tabs),
+  // so this central modal must NOT render for them — otherwise both panels
+  // stack and the drawer clips the modal's right half. Non-file nodes
+  // (folders, external packages) have no drawer (FileDetails hits
+  // /api/file), so they keep this modal as their only inspection surface.
+  // Gate on the RAW backend type to mirror ExplorerPanel's isOpen check,
+  // not getEffectiveNodeType (which only reclassifies for color).
+  if (node.type === "file") return null;
+
   const dependencies = graph.edges
     .filter((e) => e.source === node.id)
     .map((e) => graph.nodes.find((n) => n.id === e.target))

--- a/apps/web/components/graph/GraphMenu.tsx
+++ b/apps/web/components/graph/GraphMenu.tsx
@@ -23,6 +23,7 @@ import { useGraphContext } from "./GraphProvider";
 import { Button } from "@/components/ui/button";
 import { graphNodeColors, graphEdgeColors } from "@/theme/graphColors";
 import type { GraphNodeType, GraphEdgeType } from "@/packages/shared/types";
+import type { ForceGraphMethods } from "react-force-graph-3d";
 
 const nodeLabels: Record<GraphNodeType, string> = {
   file: "File",
@@ -40,9 +41,71 @@ const edgeLabels: Record<GraphEdgeType, string> = {
   "route-link": "Route link",
 };
 
-export function GraphMenu({ is3D, onToggle3D }: { is3D?: boolean; onToggle3D?: () => void } = {}) {
+/**
+ * Narrow surface of the ForceGraph3D instance the view controls need. The
+ * library's own types require a `position` argument on cameraPosition even
+ * though calling it with none returns the current camera coords (getter),
+ * so the ref is cast to this shape once at the call site.
+ */
+interface CameraControls {
+  cameraPosition(
+    position?: { x: number; y: number; z: number },
+    lookAt?: { x: number; y: number; z: number } | null,
+    transitionMs?: number
+  ): { x: number; y: number; z: number; lookAt: { x: number; y: number; z: number } };
+  zoomToFit(durationMs?: number, padding?: number): void;
+}
+
+export interface GraphMenuProps {
+  is3D?: boolean;
+  onToggle3D?: () => void;
+  /** ForceGraph3D instance (populated only while the 3D canvas is mounted)
+   * so the view controls drive the 3D camera instead of the 2D transform.
+   * Passed by GraphViewport; optional so standalone renderers still work. */
+  fgRef?: React.MutableRefObject<ForceGraphMethods | undefined>;
+}
+
+export function GraphMenu({ is3D, onToggle3D, fgRef }: GraphMenuProps = {}) {
   const [isOpen, setIsOpen] = useState(false);
-  const { zoomIn, zoomOut, resetView, transform } = useGraphContext();
+  const { graph, zoomIn, zoomOut, resetView, transform } = useGraphContext();
+
+  /** 3D zoom = move the camera along its view axis (z * factor) toward the
+   * point it is currently looking at. The library resets lookAt to the
+   * origin when given null/undefined (three-render-objects: `lookAt ||
+   * {x:0,y:0,z:0}`), so the current lookAt is threaded through explicitly
+   * to keep the zoom anchored in place instead of yanking the view.
+   * Falls back to the 2D transform handlers when not in 3D mode. */
+  const handleZoomIn = () => {
+    if (is3D && fgRef?.current) {
+      const camera = fgRef.current as unknown as CameraControls;
+      const { x, y, z, lookAt } = camera.cameraPosition();
+      camera.cameraPosition({ x, y, z: z * 0.75 }, lookAt, 300);
+    } else {
+      zoomIn();
+    }
+  };
+
+  const handleZoomOut = () => {
+    if (is3D && fgRef?.current) {
+      const camera = fgRef.current as unknown as CameraControls;
+      const { x, y, z, lookAt } = camera.cameraPosition();
+      camera.cameraPosition({ x, y, z: z * 1.25 }, lookAt, 300);
+    } else {
+      zoomOut();
+    }
+  };
+
+  const handleResetView = () => {
+    if (is3D && fgRef?.current) {
+      const camera = fgRef.current as unknown as CameraControls;
+      // zoomToFit needs a non-empty bbox; an empty graph has nothing to fit.
+      if ((graph?.nodes.length ?? 0) > 0) {
+        camera.zoomToFit(400, 20);
+      }
+    } else {
+      resetView();
+    }
+  };
 
   return (
     <>
@@ -101,17 +164,17 @@ export function GraphMenu({ is3D, onToggle3D }: { is3D?: boolean; onToggle3D?: (
                 View controls
               </h3>
               <div className="flex items-center gap-1 rounded-md border p-1">
-                <Button variant="ghost" size="icon-sm" onClick={zoomOut} aria-label="Zoom out">
+                <Button variant="ghost" size="icon-sm" onClick={handleZoomOut} aria-label="Zoom out">
                   <ZoomOut className="h-4 w-4" />
                 </Button>
                 <span className="min-w-[3rem] flex-1 text-center font-mono text-xs text-muted-foreground">
-                  {Math.round(transform.scale * 100)}%
+                  {is3D ? "3D" : `${Math.round(transform.scale * 100)}%`}
                 </span>
-                <Button variant="ghost" size="icon-sm" onClick={zoomIn} aria-label="Zoom in">
+                <Button variant="ghost" size="icon-sm" onClick={handleZoomIn} aria-label="Zoom in">
                   <ZoomIn className="h-4 w-4" />
                 </Button>
                 <div className="mx-1 h-4 w-px bg-border" />
-                <Button variant="ghost" size="icon-sm" onClick={resetView} aria-label="Reset view">
+                <Button variant="ghost" size="icon-sm" onClick={handleResetView} aria-label="Reset view">
                   <Maximize2 className="h-4 w-4" />
                 </Button>
               </div>

--- a/apps/web/components/graph/GraphViewport.tsx
+++ b/apps/web/components/graph/GraphViewport.tsx
@@ -32,10 +32,11 @@ export interface GraphViewportProps {
  * directions; the Explorer content only renders while open. Positioned as
  * a fixed overlay (z-60) over the canvas on ALL viewports — desktop is
  * a 480px right-side sheet, mobile is full-width with a click-to-close
- * backdrop (z-59). Stacking above GraphFocusView (z-20) is deliberate:
- * the drawer must never tuck "under" the impact modal. Folders / external
- * packages have no file source to inspect (FileDetails hits /api/file),
- * so only "file"-type nodes open it.
+ * backdrop (z-59). Single source of truth for file inspection: GraphFocusView
+ * self-hides for "file" nodes (see its type guard), so this drawer and the
+ * central modal can never be open at the same time — no clipping.
+ * Folders / external packages have no file source to inspect (FileDetails
+ * hits /api/file), so only "file"-type nodes open it.
  *
  * Closing the drawer deselects the node (selectNode(null)), which also
  * closes the focus view — consistent with "close = stop inspecting this

--- a/apps/web/components/graph/GraphViewport.tsx
+++ b/apps/web/components/graph/GraphViewport.tsx
@@ -8,7 +8,8 @@
 
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
+import type { ForceGraphMethods } from "react-force-graph-3d";
 
 import { GraphProvider, useGraphContext } from "./GraphProvider";
 import { GraphCanvas } from "./GraphCanvas";
@@ -26,57 +27,70 @@ export interface GraphViewportProps {
 }
 
 /**
- * Right-hand module explorer, mounted when a FILE node is selected. Lives
- * in the flex layout OUTSIDE the canvas column (sibling, not overlay), so
- * GraphFocusView's inset-4 overlay never collides with it — the canvas
- * column just narrows. Folders / external packages have no file source to
- * inspect (FileDetails hits /api/file), so only "file"-type nodes open it.
+ * Right-hand code drawer ("CodeDrawer"), opened when a FILE node is
+ * selected. Always mounted so the slide-in/out transition can run in both
+ * directions; the Explorer content only renders while open. Positioned as
+ * a fixed overlay (z-60) over the canvas on ALL viewports — desktop is
+ * a 480px right-side sheet, mobile is full-width with a click-to-close
+ * backdrop (z-59). Stacking above GraphFocusView (z-20) is deliberate:
+ * the drawer must never tuck "under" the impact modal. Folders / external
+ * packages have no file source to inspect (FileDetails hits /api/file),
+ * so only "file"-type nodes open it.
  *
- * Closing the Explorer deselects the node (selectNode(null)), which also
+ * Closing the drawer deselects the node (selectNode(null)), which also
  * closes the focus view — consistent with "close = stop inspecting this
- * module". Closing the focus view alone (its own X) keeps the Explorer
+ * module". Closing the focus view alone (its own X) keeps the drawer
  * open: the node stays selected, so the deep inspection persists.
  */
 function ExplorerPanel({ repoUrl, branch }: { repoUrl: string; branch?: string }) {
   const { graph, selectedNodeId, selectNode } = useGraphContext();
-  // md+ keeps the Explorer as a 380px flex sibling (canvas column narrows);
-  // below md a 380px sibling would leave the canvas ~0px wide on a phone,
-  // so it becomes a full-screen overlay instead. Safe to branch on the
-  // hook here: the panel only mounts after a client-side node selection.
   const isMdUp = useMediaQuery("(min-width: 48rem)");
 
-  if (!selectedNodeId) return null;
-  const selected = graph?.nodes.find((n) => n.id === selectedNodeId);
-  if (!selected || selected.type !== "file") return null;
+  const selectedNode = selectedNodeId ? graph?.nodes.find((n) => n.id === selectedNodeId) : null;
+  const isOpen = selectedNode?.type === "file";
 
   return (
-    <div
-      className={
-        isMdUp
-          ? "h-full w-[380px] shrink-0"
-          : "fixed inset-0 z-50 shadow-2xl"
-      }
-    >
-      <Explorer
-        repoUrl={repoUrl}
-        moduleId={selectedNodeId}
-        branch={branch}
-        onClose={() => selectNode(null)}
-      />
-    </div>
+    <>
+      {!isMdUp && isOpen && (
+        <div
+          className="fixed inset-0 z-59 bg-black/60"
+          onClick={() => selectNode(null)}
+          aria-hidden="true"
+        />
+      )}
+      <div
+        className={`fixed top-0 right-0 bottom-0 z-60 w-full md:w-120 bg-[#0d1117] border-l border-[#30363d] shadow-2xl overflow-y-auto transition-transform ${
+          isOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+        aria-hidden={!isOpen}
+      >
+        {isOpen && selectedNode && (
+          <Explorer
+            repoUrl={repoUrl}
+            moduleId={selectedNode.id}
+            branch={branch}
+            onClose={() => selectNode(null)}
+          />
+        )}
+      </div>
+    </>
   );
 }
 
 export function GraphViewport({ repoUrl, branch }: GraphViewportProps) {
   const [is3D, setIs3D] = useState(false);
+  // Shared handle to the live ForceGraph3D instance (undefined in 2D mode),
+  // filled by GraphCanvas3D and read by GraphMenu so the view controls
+  // drive the 3D camera instead of the 2D transform when in 3D mode.
+  const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
   return (
     <GraphProvider repoUrl={repoUrl} branch={branch}>
       <div className="flex h-full w-full">
         <div className="relative h-full min-w-0 flex-1">
           <div style={{ position: "relative", width: "100%", height: "100%" }}>
-            {is3D ? <GraphCanvas3D /> : <GraphCanvas />}
+            {is3D ? <GraphCanvas3D fgRef={fgRef} /> : <GraphCanvas />}
           </div>
-          <GraphMenu is3D={is3D} onToggle3D={() => setIs3D((v) => !v)} />
+          <GraphMenu is3D={is3D} onToggle3D={() => setIs3D((v) => !v)} fgRef={fgRef} />
           <GraphSearch />
           <GraphFocusView />
           <GraphContextMenu />


### PR DESCRIPTION
Three graph UX fixes (rebased on origin/ARCLUX.main):

1. **CodeDrawer as fixed overlay** (GraphViewport): right-side drawer z-60 (480px on md+, full-width + click-to-close backdrop z-59 on mobile), slides via translate-x. No longer a flex sibling / z-50 inset.
2. **3D camera view controls** (GraphMenu/GraphCanvas3D): +/- drive the ForceGraph3D camera (cameraPosition z*0.75/1.25, 300ms, lookAt preserved), Fit uses zoomToFit(400, 20); 2D keeps transform handlers. fgRef threaded via GraphViewport.
3. **Node click single-source-of-truth** (GraphFocusView): file nodes open ONLY the code drawer; the central modal self-hides for them (raw type guard), so drawer and modal can never overlap. Non-file nodes (folders) keep the modal (no drawer exists for them).
4. **3D node colors**: effective-type classification applied to base color (routes/hooks/components no longer all blue), merged with the fan-in importance tint from #478.