### PR TITLE
fix(ci): post-merge-guard — install deps before typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+      # KI-049 follow-up: the guard typechecks the merged tree but never
+      # installed dependencies, so every push failed with "Cannot find
+      # module 'react'" across all apps/web files. Mirrors the checks job.
+      - run: pnpm install --frozen-lockfile
       - name: Reject merge-conflict junk markers
         run: |
           if grep -rnE "fix/graph-menu-3d-toggle|^ ARCLUX\\.main" \


### PR DESCRIPTION
KI-049's guard typechecks the merged tree but never installed dependencies, so tsc ran against an empty node_modules: every push to main fails with `Cannot find module 'react'` / `react/jsx-runtime` across ALL apps/web files (192 errors). Reproduced on the #478, #479 and #480 merges — pre-existing, not caused by the graph PRs.\n\nFix: add `pnpm install --frozen-lockfile` to the post-merge-guard job, mirroring the green `checks` job.