### PR TITLE
feat: glowing planet-style nodes + tilted importance rings in 3D view

### DIFF
--- a/apps/web/components/graph/GraphCanvas3D.tsx
+++ b/apps/web/components/graph/GraphCanvas3D.tsx
@@ -10,6 +10,7 @@
 
 import { useMemo, useState, useRef, useEffect } from "react";
 import dynamic from "next/dynamic";
+import * as THREE from "three";
 import { useGraphContext } from "./GraphProvider";
 
 const ForceGraph3D = dynamic(() => import("react-force-graph-3d"), { ssr: false });
@@ -23,18 +24,13 @@ const NODE_COLORS: Record<string, string> = {
   hook: "#E5484D",
 };
 
-// Same fan-in tiers as GraphNode.tsx's impact halo (IMPACT_HIGH_THRESHOLD /
-// IMPACT_MEDIUM_THRESHOLD) -- kept in sync manually since 2D reads these
-// from GraphNode.tsx's own module scope, not a shared export yet.
+// Same fan-in tiers as GraphNode.tsx's 2D impact halo -- kept manually in
+// sync since 2D reads these from its own module scope, not a shared export.
 const IMPACT_HIGH_THRESHOLD = 100;
 const IMPACT_MEDIUM_THRESHOLD = 20;
 
-// Warm colors that get MORE intense as importance rises, applied as a tint
-// over the node's base type-color rather than replacing it -- so you can
-// still tell "this is a route" vs "this is a hook" AND "this is critical"
-// at the same time, instead of importance fully overriding type identity.
-const IMPACT_TINT_HIGH = "#FF3B30"; // hot red -- 100+ files depend on this
-const IMPACT_TINT_MEDIUM = "#FFB224"; // amber -- 20-99 files depend on this
+const IMPACT_TINT_HIGH = "#FF3B30";
+const IMPACT_TINT_MEDIUM = "#FFB224";
 
 function hexToRgb(hex: string) {
   const n = parseInt(hex.slice(1), 16);
@@ -50,13 +46,86 @@ function mixColor(baseHex: string, tintHex: string, amount: number): string {
   return `rgb(${r},${g},${b})`;
 }
 
-/** Blends the node's type color toward a warning tint based on fan-in
- * (importCount), same thresholds as GraphNode.tsx's halo tiers. Low
- * importance = pure type color. High importance = strongly tinted red. */
 function getImportanceColor(baseColor: string, importCount: number): string {
   if (importCount > IMPACT_HIGH_THRESHOLD) return mixColor(baseColor, IMPACT_TINT_HIGH, 0.75);
   if (importCount >= IMPACT_MEDIUM_THRESHOLD) return mixColor(baseColor, IMPACT_TINT_MEDIUM, 0.55);
   return baseColor;
+}
+
+function getImpactTier(importCount: number): "high" | "medium" | "none" {
+  if (importCount > IMPACT_HIGH_THRESHOLD) return "high";
+  if (importCount >= IMPACT_MEDIUM_THRESHOLD) return "medium";
+  return "none";
+}
+
+// Geometries are expensive to recreate per node -- cache once, reuse across
+// all nodes (materials are cheap enough to create per-node for per-node color).
+const CORE_GEOMETRY = new THREE.SphereGeometry(4, 16, 16);
+const GLOW_GEOMETRY = new THREE.SphereGeometry(4, 16, 16);
+const RING_GEOMETRY = new THREE.RingGeometry(7, 9, 32);
+
+type NodeDatum = {
+  id: string;
+  name: string;
+  color: string;
+  importCount: number;
+  isSelected: boolean;
+};
+
+function buildNodeObject(node: NodeDatum): THREE.Object3D {
+  const group = new THREE.Group();
+  const displayColor = node.isSelected ? "#ffffff" : node.color;
+
+  // Core "planet" -- MeshBasicMaterial ignores scene lighting so it always
+  // renders at full brightness, giving a glowing/emissive look without
+  // needing a real light source or postprocessing bloom pass.
+  const core = new THREE.Mesh(
+    CORE_GEOMETRY,
+    new THREE.MeshBasicMaterial({ color: displayColor })
+  );
+  group.add(core);
+
+  // Glow halo -- a larger, transparent, additively-blended sphere behind
+  // the core. This is a common "fake bloom" trick in three.js: no real
+  // postprocessing needed, just an oversized soft sphere.
+  const glowScale = node.isSelected ? 1.9 : 1.5;
+  const glow = new THREE.Mesh(
+    GLOW_GEOMETRY,
+    new THREE.MeshBasicMaterial({
+      color: displayColor,
+      transparent: true,
+      opacity: node.isSelected ? 0.35 : 0.18,
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    })
+  );
+  glow.scale.setScalar(glowScale);
+  group.add(glow);
+
+  // Saturn-style ring, only for medium/high importance tiers -- matches
+  // the 2D impact halo's two tiers (GraphNode.tsx IMPACT_HIGH/MEDIUM_THRESHOLD).
+  const tier = getImpactTier(node.importCount);
+  if (tier !== "none") {
+    const ringColor = tier === "high" ? IMPACT_TINT_HIGH : IMPACT_TINT_MEDIUM;
+    const ring = new THREE.Mesh(
+      RING_GEOMETRY,
+      new THREE.MeshBasicMaterial({
+        color: ringColor,
+        transparent: true,
+        opacity: tier === "high" ? 0.85 : 0.6,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+      })
+    );
+    // Tilt like Saturn's rings instead of a flat equatorial disc -- purely
+    // aesthetic, makes it read as a "ring" from most camera angles instead
+    // of disappearing edge-on when viewed from directly above/below.
+    ring.rotation.x = Math.PI / 2.6;
+    if (tier === "high") ring.scale.setScalar(1.3);
+    group.add(ring);
+  }
+
+  return group;
 }
 
 export function GraphCanvas3D() {
@@ -87,6 +156,7 @@ export function GraphCanvas3D() {
           name: n.label,
           val: 1,
           color: getImportanceColor(baseColor, importCount),
+          importCount,
         };
       }),
       links: graph.edges.map((e) => ({
@@ -106,10 +176,11 @@ export function GraphCanvas3D() {
           height={dimensions.height}
           graphData={graphData}
           nodeLabel="name"
-          nodeColor={(node) => {
-            const n = node as { id: string; color: string };
-            return n.id === selectedNodeId ? "#ffffff" : n.color;
+          nodeThreeObject={(node) => {
+            const n = node as unknown as NodeDatum;
+            return buildNodeObject({ ...n, isSelected: n.id === selectedNodeId });
           }}
+          nodeThreeObjectExtend={false}
           onNodeClick={(node) => selectNode((node as { id: string }).id)}
           backgroundColor="#000000"
           linkColor={() => "rgba(255,255,255,0.2)"}


### PR DESCRIPTION
## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
