### PR TITLE
Scaffold remote acquisition + security analysis packages

### DIFF
--- a/packages/acquisition/AcquisitionPolicy.ts
+++ b/packages/acquisition/AcquisitionPolicy.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: acquisition/AcquisitionPolicy — not yet implemented.

--- a/packages/acquisition/AcquisitionResult.ts
+++ b/packages/acquisition/AcquisitionResult.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: acquisition/AcquisitionResult — not yet implemented.

--- a/packages/acquisition/ArchiveAcquirer.ts
+++ b/packages/acquisition/ArchiveAcquirer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: acquisition/ArchiveAcquirer — not yet implemented.

--- a/packages/acquisition/RepositoryAcquirer.ts
+++ b/packages/acquisition/RepositoryAcquirer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: acquisition/RepositoryAcquirer — not yet implemented.

--- a/packages/acquisition/SourceAcquirer.ts
+++ b/packages/acquisition/SourceAcquirer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: acquisition/SourceAcquirer — not yet implemented.

--- a/packages/acquisition/SourceSnapshot.ts
+++ b/packages/acquisition/SourceSnapshot.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: acquisition/SourceSnapshot — not yet implemented.

--- a/packages/adapters/ArchiveSourceAdapter.ts
+++ b/packages/adapters/ArchiveSourceAdapter.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: adapters/ArchiveSourceAdapter — not yet implemented.

--- a/packages/adapters/GitHubSourceAdapter.ts
+++ b/packages/adapters/GitHubSourceAdapter.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: adapters/GitHubSourceAdapter — not yet implemented.

--- a/packages/adapters/GitLabSourceAdapter.ts
+++ b/packages/adapters/GitLabSourceAdapter.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: adapters/GitLabSourceAdapter — not yet implemented.

--- a/packages/adapters/LocalSourceAdapter.ts
+++ b/packages/adapters/LocalSourceAdapter.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: adapters/LocalSourceAdapter — not yet implemented.

--- a/packages/boundaries/AnalysisBoundary.ts
+++ b/packages/boundaries/AnalysisBoundary.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: boundaries/AnalysisBoundary — not yet implemented.

--- a/packages/boundaries/EvidenceBoundary.ts
+++ b/packages/boundaries/EvidenceBoundary.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: boundaries/EvidenceBoundary — not yet implemented.

--- a/packages/boundaries/RemoteAccessPolicy.ts
+++ b/packages/boundaries/RemoteAccessPolicy.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: boundaries/RemoteAccessPolicy — not yet implemented.

--- a/packages/boundaries/SourceBoundaryPolicy.ts
+++ b/packages/boundaries/SourceBoundaryPolicy.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: boundaries/SourceBoundaryPolicy — not yet implemented.

--- a/packages/diagnostics/DiagnosticEvidence.ts
+++ b/packages/diagnostics/DiagnosticEvidence.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: diagnostics/DiagnosticEvidence — not yet implemented.

--- a/packages/diagnostics/DiagnosticOrigin.ts
+++ b/packages/diagnostics/DiagnosticOrigin.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: diagnostics/DiagnosticOrigin — not yet implemented.

--- a/packages/diagnostics/RemoteDiagnostic.ts
+++ b/packages/diagnostics/RemoteDiagnostic.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: diagnostics/RemoteDiagnostic — not yet implemented.

--- a/packages/diagnostics/RuntimeDiagnostic.ts
+++ b/packages/diagnostics/RuntimeDiagnostic.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: diagnostics/RuntimeDiagnostic — not yet implemented.

--- a/packages/diagnostics/SourceDiagnostic.ts
+++ b/packages/diagnostics/SourceDiagnostic.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: diagnostics/SourceDiagnostic — not yet implemented.

--- a/packages/observation/NetworkObservation.ts
+++ b/packages/observation/NetworkObservation.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: observation/NetworkObservation — not yet implemented.

--- a/packages/observation/ObservationRecord.ts
+++ b/packages/observation/ObservationRecord.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: observation/ObservationRecord — not yet implemented.

--- a/packages/observation/ObservationScope.ts
+++ b/packages/observation/ObservationScope.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: observation/ObservationScope — not yet implemented.

--- a/packages/observation/RuntimeObservation.ts
+++ b/packages/observation/RuntimeObservation.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: observation/RuntimeObservation — not yet implemented.

--- a/packages/observation/SourceObservation.ts
+++ b/packages/observation/SourceObservation.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: observation/SourceObservation — not yet implemented.

--- a/packages/provenance/EvidenceOrigin.ts
+++ b/packages/provenance/EvidenceOrigin.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: provenance/EvidenceOrigin — not yet implemented.

--- a/packages/provenance/ProvenanceRecord.ts
+++ b/packages/provenance/ProvenanceRecord.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: provenance/ProvenanceRecord — not yet implemented.

--- a/packages/provenance/RevisionIdentity.ts
+++ b/packages/provenance/RevisionIdentity.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: provenance/RevisionIdentity — not yet implemented.

--- a/packages/provenance/SnapshotIdentity.ts
+++ b/packages/provenance/SnapshotIdentity.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: provenance/SnapshotIdentity — not yet implemented.

--- a/packages/provenance/SourceOrigin.ts
+++ b/packages/provenance/SourceOrigin.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: provenance/SourceOrigin — not yet implemented.

--- a/packages/remote-analysis/RemoteAnalysisRequest.ts
+++ b/packages/remote-analysis/RemoteAnalysisRequest.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote-analysis/RemoteAnalysisRequest — not yet implemented.

--- a/packages/remote-analysis/RemoteAnalysisResult.ts
+++ b/packages/remote-analysis/RemoteAnalysisResult.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote-analysis/RemoteAnalysisResult — not yet implemented.

--- a/packages/remote-analysis/RemoteAnalysisSession.ts
+++ b/packages/remote-analysis/RemoteAnalysisSession.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote-analysis/RemoteAnalysisSession — not yet implemented.

--- a/packages/remote-analysis/RemoteImpactReport.ts
+++ b/packages/remote-analysis/RemoteImpactReport.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote-analysis/RemoteImpactReport — not yet implemented.

--- a/packages/remote-analysis/SourceHealthReport.ts
+++ b/packages/remote-analysis/SourceHealthReport.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote-analysis/SourceHealthReport — not yet implemented.

--- a/packages/remote/RemoteAccess.ts
+++ b/packages/remote/RemoteAccess.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote/RemoteAccess — not yet implemented.

--- a/packages/remote/RemoteLocator.ts
+++ b/packages/remote/RemoteLocator.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote/RemoteLocator — not yet implemented.

--- a/packages/remote/RemoteProvider.ts
+++ b/packages/remote/RemoteProvider.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote/RemoteProvider — not yet implemented.

--- a/packages/remote/RemoteRepository.ts
+++ b/packages/remote/RemoteRepository.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote/RemoteRepository — not yet implemented.

--- a/packages/remote/RemoteRevision.ts
+++ b/packages/remote/RemoteRevision.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote/RemoteRevision — not yet implemented.

--- a/packages/remote/RemoteSnapshot.ts
+++ b/packages/remote/RemoteSnapshot.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote/RemoteSnapshot — not yet implemented.

--- a/packages/remote/RemoteSource.ts
+++ b/packages/remote/RemoteSource.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: remote/RemoteSource — not yet implemented.

--- a/packages/security-analysis/SecurityAnalysis.ts
+++ b/packages/security-analysis/SecurityAnalysis.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/SecurityAnalysis — not yet implemented.

--- a/packages/security-analysis/SecurityCategory.ts
+++ b/packages/security-analysis/SecurityCategory.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/SecurityCategory — not yet implemented.

--- a/packages/security-analysis/SecurityEvidence.ts
+++ b/packages/security-analysis/SecurityEvidence.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/SecurityEvidence — not yet implemented.

--- a/packages/security-analysis/SecurityFinding.ts
+++ b/packages/security-analysis/SecurityFinding.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/SecurityFinding — not yet implemented.

--- a/packages/security-analysis/SecuritySeverity.ts
+++ b/packages/security-analysis/SecuritySeverity.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/SecuritySeverity — not yet implemented.

--- a/packages/security-analysis/architecture/CrossBoundaryAnalyzer.ts
+++ b/packages/security-analysis/architecture/CrossBoundaryAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/architecture/CrossBoundaryAnalyzer — not yet implemented.

--- a/packages/security-analysis/architecture/PrivilegeFlowAnalyzer.ts
+++ b/packages/security-analysis/architecture/PrivilegeFlowAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/architecture/PrivilegeFlowAnalyzer — not yet implemented.

--- a/packages/security-analysis/architecture/SecurityImpactAnalyzer.ts
+++ b/packages/security-analysis/architecture/SecurityImpactAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/architecture/SecurityImpactAnalyzer — not yet implemented.

--- a/packages/security-analysis/architecture/SensitivePathAnalyzer.ts
+++ b/packages/security-analysis/architecture/SensitivePathAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/architecture/SensitivePathAnalyzer — not yet implemented.

--- a/packages/security-analysis/architecture/TrustBoundaryAnalyzer.ts
+++ b/packages/security-analysis/architecture/TrustBoundaryAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/architecture/TrustBoundaryAnalyzer — not yet implemented.

--- a/packages/security-analysis/configuration/EnvironmentConfigAnalyzer.ts
+++ b/packages/security-analysis/configuration/EnvironmentConfigAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/configuration/EnvironmentConfigAnalyzer — not yet implemented.

--- a/packages/security-analysis/configuration/ExposureDetector.ts
+++ b/packages/security-analysis/configuration/ExposureDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/configuration/ExposureDetector — not yet implemented.

--- a/packages/security-analysis/configuration/PermissionAnalyzer.ts
+++ b/packages/security-analysis/configuration/PermissionAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/configuration/PermissionAnalyzer — not yet implemented.

--- a/packages/security-analysis/configuration/SecurityConfigDetector.ts
+++ b/packages/security-analysis/configuration/SecurityConfigDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/configuration/SecurityConfigDetector — not yet implemented.

--- a/packages/security-analysis/correlation/AttackSurfaceMapper.ts
+++ b/packages/security-analysis/correlation/AttackSurfaceMapper.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/correlation/AttackSurfaceMapper — not yet implemented.

--- a/packages/security-analysis/correlation/EvidenceCorrelator.ts
+++ b/packages/security-analysis/correlation/EvidenceCorrelator.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/correlation/EvidenceCorrelator — not yet implemented.

--- a/packages/security-analysis/correlation/FindingCorrelator.ts
+++ b/packages/security-analysis/correlation/FindingCorrelator.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/correlation/FindingCorrelator — not yet implemented.

--- a/packages/security-analysis/correlation/ImpactCorrelation.ts
+++ b/packages/security-analysis/correlation/ImpactCorrelation.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/correlation/ImpactCorrelation — not yet implemented.

--- a/packages/security-analysis/dependency/DependencyRiskAnalyzer.ts
+++ b/packages/security-analysis/dependency/DependencyRiskAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/dependency/DependencyRiskAnalyzer — not yet implemented.

--- a/packages/security-analysis/dependency/LockfileAnalyzer.ts
+++ b/packages/security-analysis/dependency/LockfileAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/dependency/LockfileAnalyzer — not yet implemented.

--- a/packages/security-analysis/dependency/TransitiveRiskAnalyzer.ts
+++ b/packages/security-analysis/dependency/TransitiveRiskAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/dependency/TransitiveRiskAnalyzer — not yet implemented.

--- a/packages/security-analysis/dependency/VulnerableDependencyDetector.ts
+++ b/packages/security-analysis/dependency/VulnerableDependencyDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/dependency/VulnerableDependencyDetector — not yet implemented.

--- a/packages/security-analysis/reporting/FindingSummary.ts
+++ b/packages/security-analysis/reporting/FindingSummary.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/reporting/FindingSummary — not yet implemented.

--- a/packages/security-analysis/reporting/RemediationSuggestion.ts
+++ b/packages/security-analysis/reporting/RemediationSuggestion.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/reporting/RemediationSuggestion — not yet implemented.

--- a/packages/security-analysis/reporting/SecurityReport.ts
+++ b/packages/security-analysis/reporting/SecurityReport.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/reporting/SecurityReport — not yet implemented.

--- a/packages/security-analysis/reporting/SecurityTimeline.ts
+++ b/packages/security-analysis/reporting/SecurityTimeline.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/reporting/SecurityTimeline — not yet implemented.

--- a/packages/security-analysis/source/DangerousApiDetector.ts
+++ b/packages/security-analysis/source/DangerousApiDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/source/DangerousApiDetector — not yet implemented.

--- a/packages/security-analysis/source/InputValidationDetector.ts
+++ b/packages/security-analysis/source/InputValidationDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/source/InputValidationDetector — not yet implemented.

--- a/packages/security-analysis/source/SecretExposureDetector.ts
+++ b/packages/security-analysis/source/SecretExposureDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/source/SecretExposureDetector — not yet implemented.

--- a/packages/security-analysis/source/SensitiveDataFlowDetector.ts
+++ b/packages/security-analysis/source/SensitiveDataFlowDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/source/SensitiveDataFlowDetector — not yet implemented.

--- a/packages/security-analysis/source/UnsafePatternDetector.ts
+++ b/packages/security-analysis/source/UnsafePatternDetector.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/source/UnsafePatternDetector — not yet implemented.

--- a/packages/security-analysis/web/AssetExposureAnalyzer.ts
+++ b/packages/security-analysis/web/AssetExposureAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/web/AssetExposureAnalyzer — not yet implemented.

--- a/packages/security-analysis/web/ClientExposureAnalyzer.ts
+++ b/packages/security-analysis/web/ClientExposureAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/web/ClientExposureAnalyzer — not yet implemented.

--- a/packages/security-analysis/web/SecurityHeaderAnalyzer.ts
+++ b/packages/security-analysis/web/SecurityHeaderAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/web/SecurityHeaderAnalyzer — not yet implemented.

--- a/packages/security-analysis/web/SourceMapExposureAnalyzer.ts
+++ b/packages/security-analysis/web/SourceMapExposureAnalyzer.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: security-analysis/web/SourceMapExposureAnalyzer — not yet implemented.

--- a/packages/web-intake/AssetReference.ts
+++ b/packages/web-intake/AssetReference.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: web-intake/AssetReference — not yet implemented.

--- a/packages/web-intake/IntakeResult.ts
+++ b/packages/web-intake/IntakeResult.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: web-intake/IntakeResult — not yet implemented.

--- a/packages/web-intake/SourceBoundary.ts
+++ b/packages/web-intake/SourceBoundary.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: web-intake/SourceBoundary — not yet implemented.

--- a/packages/web-intake/WebsiteLocator.ts
+++ b/packages/web-intake/WebsiteLocator.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: web-intake/WebsiteLocator — not yet implemented.

--- a/packages/web-intake/WebsiteManifest.ts
+++ b/packages/web-intake/WebsiteManifest.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: web-intake/WebsiteManifest — not yet implemented.

--- a/packages/web-intake/WebsiteSource.ts
+++ b/packages/web-intake/WebsiteSource.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Scaffold: web-intake/WebsiteSource — not yet implemented.


### PR DESCRIPTION
Stub-only scaffold: remote/, acquisition/, web-intake/, provenance/, diagnostics/ (new remote-specific files, existing wired diagnostics untouched), observation/, adapters/, boundaries/, remote-analysis/, security-analysis/ (+ 7 subfolders). No logic yet.