### PR TITLE
fix(security-analysis): completeness of type unification merged in #484

### DIFF
--- a/packages/correlation/EvidenceCorrelator.ts
+++ b/packages/correlation/EvidenceCorrelator.ts
@@ -11,7 +11,7 @@
 // on a finding lets consumers answer "where did this finding come from and
 // can I reproduce it" — the analysis-provenance analogue of SLSA's idea.
 
-import type { SecurityFinding } from "../security-analysis/types";
+import type { SecurityFinding } from "../security-analysis/SecurityFinding";
 import { createProvenanceRecord } from "../provenance/ProvenanceRecord";
 import type { SourceOrigin } from "../provenance/SourceOrigin";
 import type { EvidenceOrigin } from "../provenance/EvidenceOrigin";

--- a/packages/correlation/FindingCorrelator.ts
+++ b/packages/correlation/FindingCorrelator.ts
@@ -11,7 +11,8 @@
 // runs, so duplicate reports merge naturally) and severity/file grouping
 // for reports.
 
-import type { SecurityFinding, SecuritySeverity } from "../security-analysis/types";
+import type { SecuritySeverity } from "../security-analysis/SecuritySeverity";
+import type { SecurityFinding } from "../security-analysis/SecurityFinding";
 
 export function dedupeFindings(findings: SecurityFinding[]): SecurityFinding[] {
   const seen = new Set<string>();

--- a/packages/correlation/ImpactCorrelation.ts
+++ b/packages/correlation/ImpactCorrelation.ts
@@ -16,7 +16,8 @@
 // Larger = fix first. Deterministic — same inputs, same score.
 
 import type { Repository } from "../repository/Repository";
-import type { SecurityFinding, SecuritySeverity } from "../security-analysis/types";
+import type { SecuritySeverity } from "../security-analysis/SecuritySeverity";
+import type { SecurityFinding } from "../security-analysis/SecurityFinding";
 import {
   attachImpactToFindings,
   type SecurityImpactReport,

--- a/packages/correlation/SecurityCorrelationInput.ts
+++ b/packages/correlation/SecurityCorrelationInput.ts
@@ -15,7 +15,7 @@
 
 import type { Repository } from "../repository/Repository";
 import type { DependencyGraph } from "../shared/types";
-import type { SecurityFinding } from "../security-analysis/types";
+import type { SecurityFinding } from "../security-analysis/SecurityFinding";
 import type { ProvenanceRecord } from "../provenance/ProvenanceRecord";
 import type { ImpactSnapshot } from "./ImpactSnapshot";
 

--- a/packages/remote/RemoteSnapshot.ts
+++ b/packages/remote/RemoteSnapshot.ts
@@ -10,7 +10,7 @@ import { hashObject } from "../shared/hash";
 import type { Repository } from "../repository/Repository";
 import type { DependencyGraph } from "../shared/types";
 import type { AnalyzeRepositoryResult } from "../engine/pipeline";
-import type { SecurityFinding } from "../security-analysis/types";
+import type { SecurityFinding } from "../security-analysis/SecurityFinding";
 import type { ProvenanceRecord } from "../provenance/ProvenanceRecord";
 import type { RemoteSource } from "./RemoteSource";
 

--- a/packages/security-analysis/SecurityFinding.ts
+++ b/packages/security-analysis/SecurityFinding.ts
@@ -5,5 +5,59 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// The security finding contract: one normalized security finding plus its
+// location and remediation hint. Shape is intentionally richer than the
+// core engine's Issue (engine/contract.ts) — the core contract stays
+// untouched; this is the security pipeline's own extension type.
 
-// Scaffold: security-analysis/SecurityFinding — not yet implemented.
+import type { SecuritySeverity, SecurityConfidence } from "./SecuritySeverity";
+
+/** A position in the analyzed repository. Line/column are 1-based, optional (file-level findings). */
+export interface SecurityLocation {
+  /** ModuleInfo id — usually the relative path. */
+  moduleId: string;
+  /** Relative path, POSIX-style. */
+  filePath: string;
+  /** 1-based line number. Absent for file-level findings. */
+  line?: number;
+  /** 1-based column number. Absent when unknown. */
+  column?: number;
+}
+
+/** Fix guidance attached to a finding (Semgrep fix-style, but never auto-applied). */
+export interface RemediationSuggestion {
+  /** One-line actionable summary, e.g. "Move the secret to an environment variable." */
+  summary: string;
+  /** Longer explanation of why this fixes the weakness. */
+  detail?: string;
+  /** A literal replacement hint for the matched code region. */
+  fixHint?: string;
+}
+
+/**
+ * One normalized security finding.
+ */
+export interface SecurityFinding {
+  /**
+   * Deterministic fingerprint: `${ruleId}:${filePath}:${line ?? "file"}`.
+   * Stable across runs — the key for dedup (FindingCorrelator) and for
+   * baselines (like gitleaks' fingerprint, verified 2026-08-16).
+   */
+  id: string;
+  /** Stable rule identifier, e.g. "hardcoded-api-key" or "unsafe-eval". */
+  ruleId: string;
+  title: string;
+  description: string;
+  severity: SecuritySeverity;
+  confidence: SecurityConfidence;
+  location: SecurityLocation;
+  /** MITRE CWE identifiers, e.g. ["CWE-798"]. */
+  cwe?: string[];
+  /** OWASP Top 10:2025 identifiers, e.g. ["A03:2025"]. */
+  owasp?: string[];
+  /** How to fix it. Populated by reporting/RemediationSuggestion templates. */
+  remediation?: RemediationSuggestion;
+  /** Links this finding to a ProvenanceRecord (packages/provenance). */
+  provenanceId?: string;
+}

--- a/packages/security-analysis/SecuritySeverity.ts
+++ b/packages/security-analysis/SecuritySeverity.ts
@@ -5,5 +5,13 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Severity taxonomy follows the Semgrep model (LOW/MEDIUM/HIGH/CRITICAL),
+// verified against Semgrep's rule-syntax docs (2026-08-16). Maps to SARIF
+// level as: critical/high -> error, medium -> warning, low -> note.
 
-// Scaffold: security-analysis/SecuritySeverity — not yet implemented.
+/** Security severity of a finding. */
+export type SecuritySeverity = "critical" | "high" | "medium" | "low";
+
+/** How sure the detector is that the finding is a real vulnerability, not a false positive. */
+export type SecurityConfidence = "high" | "medium" | "low";

--- a/packages/security-analysis/SourceProvider.ts
+++ b/packages/security-analysis/SourceProvider.ts
@@ -8,7 +8,20 @@
 
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { SourceProvider } from "./types";
+
+/**
+ * Content channel for content-based detectors (secrets, unsafe patterns).
+ *
+ * ARCLUX's Repository deliberately does NOT carry file contents (verified
+ * in buildIndex.ts: content is read, used for resolveSameScopeDependencies,
+ * then discarded). Detectors that need the raw text take a SourceProvider
+ * as an explicit extension input — the file LIST still comes from the
+ * Repository, so detectors never re-scan the filesystem themselves.
+ */
+export interface SourceProvider {
+  /** Returns the file content, or null when the path is unknown/unreadable. */
+  read(relativePath: string): string | null;
+}
 
 /**
  * Default SourceProvider backed by the filesystem. Reads relative paths

--- a/packages/security-analysis/architecture/CrossBoundaryAnalyzer.ts
+++ b/packages/security-analysis/architecture/CrossBoundaryAnalyzer.ts
@@ -18,7 +18,8 @@
 // detector reports what the core model actually sees, nothing more.
 
 import type { Repository } from "../../repository/Repository";
-import type { SecurityFinding, SourceProvider } from "../types";
+import type { SecurityFinding } from "../SecurityFinding";
+import type { SourceProvider } from "../SourceProvider";
 import {
   classifyTrustZone,
   DEFAULT_TRUST_ZONES,

--- a/packages/security-analysis/architecture/SecurityImpactAnalyzer.ts
+++ b/packages/security-analysis/architecture/SecurityImpactAnalyzer.ts
@@ -15,7 +15,7 @@
 import type { Repository } from "../../repository/Repository";
 import { buildImpactTree, type ImpactTreeNode } from "../../impact/buildImpactTree";
 import { calculateAffectedFiles } from "../../impact/calculateAffectedFiles";
-import type { SecurityFinding } from "../types";
+import type { SecurityFinding } from "../SecurityFinding";
 
 export interface SecurityImpactReport {
   moduleId: string;

--- a/packages/security-analysis/architecture/TrustBoundaryAnalyzer.ts
+++ b/packages/security-analysis/architecture/TrustBoundaryAnalyzer.ts
@@ -30,7 +30,9 @@
 
 import type { Repository } from "../../repository/Repository";
 import type { ModuleInfo } from "../../shared/types";
-import type { SecurityFinding, SecuritySeverity, SourceProvider } from "../types";
+import type { SecuritySeverity } from "../SecuritySeverity";
+import type { SecurityFinding } from "../SecurityFinding";
+import type { SourceProvider } from "../SourceProvider";
 
 export interface TrustZoneDefinition {
   /** Exact path-segment names (case-insensitive) that put a module in this zone. */

--- a/packages/security-analysis/index.ts
+++ b/packages/security-analysis/index.ts
@@ -13,13 +13,14 @@
 export type {
   SecuritySeverity,
   SecurityConfidence,
+} from "./SecuritySeverity";
+export type {
   SecurityLocation,
   SecurityFinding,
   RemediationSuggestion,
-  SourceProvider,
-} from "./types";
+} from "./SecurityFinding";
 
-export { DiskSourceProvider } from "./SourceProvider";
+export { DiskSourceProvider, type SourceProvider } from "./SourceProvider";
 
 export {
   detectSecretExposure,

--- a/packages/security-analysis/reporting/RemediationSuggestion.ts
+++ b/packages/security-analysis/reporting/RemediationSuggestion.ts
@@ -11,7 +11,9 @@
 // always advisory). Unknown rule ids yield null so callers can fall back
 // to their own text.
 
-import type { RemediationSuggestion, SecurityFinding } from "../types";
+import type { RemediationSuggestion, SecurityFinding } from "../SecurityFinding";
+
+export type { RemediationSuggestion } from "../SecurityFinding";
 
 const TEMPLATES: Record<string, Omit<RemediationSuggestion, "summary"> & { summary: string }> = {
   "aws-access-key": {

--- a/packages/security-analysis/reporting/SecurityReport.ts
+++ b/packages/security-analysis/reporting/SecurityReport.ts
@@ -21,7 +21,8 @@
 // never imports packages/correlation (which imports security-analysis —
 // that would be a cycle).
 
-import type { SecurityFinding, SecuritySeverity } from "../types";
+import type { SecuritySeverity } from "../SecuritySeverity";
+import type { SecurityFinding } from "../SecurityFinding";
 import type { ProvenanceRecord } from "../../provenance/ProvenanceRecord";
 import { attachRemediations } from "./RemediationSuggestion";
 

--- a/packages/security-analysis/source/SecretExposureDetector.ts
+++ b/packages/security-analysis/source/SecretExposureDetector.ts
@@ -23,7 +23,9 @@
 
 import type { Repository } from "../../repository/Repository";
 import type { ModuleInfo } from "../../shared/types";
-import type { SecurityFinding, SecuritySeverity, SourceProvider } from "../types";
+import type { SecuritySeverity } from "../SecuritySeverity";
+import type { SecurityFinding } from "../SecurityFinding";
+import type { SourceProvider } from "../SourceProvider";
 
 export interface SecretRule {
   /** Stable rule id, e.g. "aws-access-key". */

--- a/packages/security-analysis/source/SensitiveDataFlowDetector.ts
+++ b/packages/security-analysis/source/SensitiveDataFlowDetector.ts
@@ -26,7 +26,9 @@
 
 import type { Repository } from "../../repository/Repository";
 import type { ModuleInfo, ResolvedImport } from "../../shared/types";
-import type { SecurityFinding, SecuritySeverity, SourceProvider } from "../types";
+import type { SecuritySeverity } from "../SecuritySeverity";
+import type { SecurityFinding } from "../SecurityFinding";
+import type { SourceProvider } from "../SourceProvider";
 
 export interface DataFlowRule {
   /** Import specifier fragments that mark a module as a data SOURCE. */

--- a/packages/security-analysis/source/UnsafePatternDetector.ts
+++ b/packages/security-analysis/source/UnsafePatternDetector.ts
@@ -15,7 +15,9 @@
 // SensitiveDataFlowDetector.ts.
 
 import type { Repository } from "../../repository/Repository";
-import type { SecurityFinding, SecuritySeverity, SourceProvider } from "../types";
+import type { SecuritySeverity } from "../SecuritySeverity";
+import type { SecurityFinding } from "../SecurityFinding";
+import type { SourceProvider } from "../SourceProvider";
 
 export interface UnsafePatternRule {
   id: string;

--- a/tests/attack-surface.test.ts
+++ b/tests/attack-surface.test.ts
@@ -37,7 +37,7 @@ import {
 import { correlateFindingsWithImpact, scoreFinding } from "../packages/correlation/ImpactCorrelation";
 import { linkFindingsToProvenance } from "../packages/correlation/EvidenceCorrelator";
 import { buildImpactSnapshot } from "../packages/correlation/ImpactSnapshot";
-import type { SecurityFinding } from "../packages/security-analysis/types";
+import type { SecurityFinding } from "../packages/security-analysis/SecurityFinding";
 
 parserRegistry.register(parseTs);
 parserRegistry.register(parsePython);

--- a/tests/sarif-export.test.ts
+++ b/tests/sarif-export.test.ts
@@ -17,7 +17,7 @@ import {
   type ReportAttackSurface,
 } from "../packages/security-analysis/reporting/SecurityReport";
 import { remediateRule, attachRemediations } from "../packages/security-analysis/reporting/RemediationSuggestion";
-import type { SecurityFinding } from "../packages/security-analysis/types";
+import type { SecurityFinding } from "../packages/security-analysis/SecurityFinding";
 
 function finding(id: string, severity: SecurityFinding["severity"], ruleId: string, filePath: string, line?: number): SecurityFinding {
   return {


### PR DESCRIPTION
## Problem
PR #484 was merged with an incomplete merge commit (f32ceab): type-unification edits made AFTER git add during the scaffold-merge stayed unstaged, so the pushed HEAD still had the author's stub files for SecuritySeverity.ts / SecurityFinding.ts while types.ts was deleted. Result: security-analysis on ARCLUX.main does not compile (imports reference types that only exist in the working tree, not in git history).

Local tests passed because vitest reads the working tree, not HEAD — a merge-discipline gap, now fixed.

## Fix
This branch = origin/ARCLUX.main + cherry-pick of 9fc1e11 (the 19-file commit that stages the real type-unification): SecuritySeverity.ts / SecurityFinding.ts / SourceProvider.ts carry the real types, all import sites updated, reporting/RemediationSuggestion.ts re-exports the type.

## Verification
- npx vitest run: 551/551
- npx tsc --noEmit: 0 errors in security packages
- arclux security smoke test on tests/fixtures/security-leaks: 4 findings