### PR TITLE
feat(security-analysis): dependency layer — lockfile analysis, vulnerable deps, transitive risk

### DIFF
--- a/apps/cli/security.ts
+++ b/apps/cli/security.ts
@@ -25,6 +25,7 @@ import { detectSensitiveDataFlow } from "../../packages/security-analysis/source
 import { detectTrustBoundaryViolations } from "../../packages/security-analysis/architecture/TrustBoundaryAnalyzer";
 import { detectCrossBoundaryCalls } from "../../packages/security-analysis/architecture/CrossBoundaryAnalyzer";
 import { mapAttackSurface } from "../../packages/correlation/AttackSurfaceMapper";
+import { analyzeDependencyRisk } from "../../packages/security-analysis/dependency/DependencyRiskAnalyzer";
 import { buildSecurityReport } from "../../packages/security-analysis/reporting/SecurityReport";
 
 export function registerSecurityCommand(program: Command): void {
@@ -49,6 +50,7 @@ export function registerSecurityCommand(program: Command): void {
           ...detectSensitiveDataFlow(result.repository, sources),
           ...detectTrustBoundaryViolations(result.repository, sources),
           ...detectCrossBoundaryCalls(result.repository, sources),
+          ...analyzeDependencyRisk({ manifestDependencies: result.dependencies, sources }).findings,
         ];
         const attackSurface = mapAttackSurface(result.repository, result.graph);
 

--- a/packages/security-analysis/dependency/DependencyRiskAnalyzer.ts
+++ b/packages/security-analysis/dependency/DependencyRiskAnalyzer.ts
@@ -5,5 +5,84 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Dependency risk analysis — the aggregate entry point of the dependency
+// layer. Consumes the core engine's ManifestDependency[] (already part of
+// AnalyzeRepositoryResult — nothing new to scan for manifests) plus the
+// SourceProvider content channel for LOCKFILES (exact versions), and
+// produces SecurityFinding[]:
+//
+//   1. vulnerable-dependency   — pinned version < fixedVersion in the
+//                                known-vulnerability database (A03:2025)
+//   2. unpinned-dependency     — runtime dependency declared with a range
+//                                (^, ~, >=, *, latest) instead of an exact
+//                                version — supply-chain risk heuristic
+//
+// The known-vulnerability database is deliberately small; an external
+// advisory feed is a documented deferral (see VulnerableDependencyDetector).
 
-// Scaffold: security-analysis/dependency/DependencyRiskAnalyzer — not yet implemented.
+import type { SourceProvider } from "../SourceProvider";
+import type { SecuritySeverity } from "../SecuritySeverity";
+import type { SecurityFinding } from "../SecurityFinding";
+import type { ManifestDependency } from "../../parser/core/ManifestParserInterface";
+import { parseLockfiles, type LockedDependency } from "./LockfileAnalyzer";
+import {
+  detectVulnerableDependencies,
+  toSecurityFindings,
+  type KnownVulnerability,
+} from "./VulnerableDependencyDetector";
+import { analyzeTransitiveRisk, type TransitiveRiskReport } from "./TransitiveRiskAnalyzer";
+
+export interface DependencyRiskInput {
+  /** Manifest-declared dependencies from the core pipeline (AnalyzeRepositoryResult.dependencies). */
+  manifestDependencies: ManifestDependency[];
+  sources: SourceProvider;
+  /** Custom vulnerability database — replaces the default when provided. */
+  vulnerabilities?: KnownVulnerability[];
+}
+
+export interface DependencyRiskResult {
+  findings: SecurityFinding[];
+  locked: LockedDependency[];
+  transitiveRisk: TransitiveRiskReport;
+}
+
+/** True when the manifest spec is not an exact pinned version (^, ~, >=, *, latest, ...). */
+export function isUnpinnedRange(versionRange: string | undefined): boolean {
+  if (!versionRange || versionRange.trim() === "") return false;
+  const trimmed = versionRange.trim();
+  if (/^\d+\.\d+\.\d+$/.test(trimmed)) return false; // exact "1.2.3"
+  if (/^v\d+\.\d+\.\d+$/.test(trimmed)) return false; // exact "v1.2.3"
+  if (/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(trimmed)) return false; // exact with prerelease
+  return true;
+}
+
+export function analyzeDependencyRisk(input: DependencyRiskInput): DependencyRiskResult {
+  const locked = parseLockfiles(input.sources).dependencies;
+  const vulnerabilityHits = detectVulnerableDependencies(locked, input.vulnerabilities);
+  const transitiveRisk = analyzeTransitiveRisk(locked, vulnerabilityHits);
+
+  const findings: SecurityFinding[] = [...toSecurityFindings(vulnerabilityHits)];
+
+  // Heuristic: runtime deps declared with a range are a supply-chain risk
+  // (the exact version is decided by the resolver, not the developer).
+  for (const dep of input.manifestDependencies) {
+    if (dep.kind !== "runtime") continue;
+    if (!isUnpinnedRange(dep.versionRange)) continue;
+
+    findings.push({
+      id: `unpinned-dependency:${dep.name}`,
+      ruleId: "unpinned-dependency",
+      title: `Runtime dependency "${dep.name}" is not pinned to an exact version`,
+      description: `Declared as "${dep.versionRange}" — the exact installed version is decided by the resolver. Pin to an exact version and use a lockfile.`,
+      severity: "low" as SecuritySeverity,
+      confidence: "high",
+      location: { moduleId: "manifest", filePath: "manifest" },
+      cwe: ["CWE-1104"], // Use of Unmaintained Third Party Components (supply-chain hygiene)
+      owasp: ["A03:2025"],
+    });
+  }
+
+  findings.sort((a, b) => a.ruleId.localeCompare(b.ruleId) || a.id.localeCompare(b.id));
+  return { findings, locked, transitiveRisk };
+}

--- a/packages/security-analysis/dependency/LockfileAnalyzer.ts
+++ b/packages/security-analysis/dependency/LockfileAnalyzer.ts
@@ -5,5 +5,197 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Lockfile analysis: extracts PINNED (exact) versions from lockfiles,
+// complementing the core engine's ManifestDependency[] which only carries
+// manifest version RANGES (e.g. "^1.2.0"). A vulnerability check needs the
+// exact installed version, so this is where the security layer gets it.
+//
+// Honest scope: parsing is regex/JSON-minimal per format, not a full
+// spec implementation. Supported: package-lock.json (npm v1/v2/v3),
+// pnpm-lock.yaml, yarn.lock, go.sum, Cargo.lock, composer.lock.
+// Unsupported formats are skipped (returned in `skipped`).
 
-// Scaffold: security-analysis/dependency/LockfileAnalyzer — not yet implemented.
+import type { SourceProvider } from "../SourceProvider";
+
+export interface LockedDependency {
+  name: string;
+  /** Exact pinned version, normalized (leading "v" stripped). */
+  version: string;
+  manager: "npm" | "pnpm" | "yarn" | "go" | "cargo" | "composer";
+  lockfilePath: string;
+  /** 1 = direct (declared in a manifest), 2+ = transitive (nested). npm only; others are all 1. */
+  depth: number;
+}
+
+export interface LockfileParseResult {
+  dependencies: LockedDependency[];
+  lockfilesFound: string[];
+  /** Files that exist but whose format is unsupported. */
+  skipped: string[];
+}
+
+export const LOCKFILE_NAMES = [
+  "package-lock.json",
+  "pnpm-lock.yaml",
+  "yarn.lock",
+  "go.sum",
+  "Cargo.lock",
+  "composer.lock",
+] as const;
+
+export type LockfileName = (typeof LOCKFILE_NAMES)[number];
+
+/** Strip a leading "v"/"=" and whitespace so semver comparison works. */
+export function normalizeVersion(raw: string): string {
+  return raw.trim().replace(/^[v=]\s*/, "");
+}
+
+export function parseLockfiles(sources: SourceProvider, filenames: readonly string[] = LOCKFILE_NAMES): LockfileParseResult {
+  const dependencies: LockedDependency[] = [];
+  const lockfilesFound: string[] = [];
+  const skipped: string[] = [];
+
+  for (const filename of filenames) {
+    const content = sources.read(filename);
+    if (content === null) continue;
+    lockfilesFound.push(filename);
+
+    switch (filename) {
+      case "package-lock.json":
+        dependencies.push(...parsePackageLock(content, filename));
+        break;
+      case "pnpm-lock.yaml":
+        dependencies.push(...parsePnpmLock(content, filename));
+        break;
+      case "yarn.lock":
+        dependencies.push(...parseYarnLock(content, filename));
+        break;
+      case "go.sum":
+        dependencies.push(...parseGoSum(content, filename));
+        break;
+      case "Cargo.lock":
+        dependencies.push(...parseCargoLock(content, filename));
+        break;
+      case "composer.lock":
+        dependencies.push(...parseComposerLock(content, filename));
+        break;
+      default:
+        skipped.push(filename);
+    }
+  }
+
+  return { dependencies, lockfilesFound, skipped };
+}
+
+function parsePackageLock(content: string, lockfilePath: string): LockedDependency[] {
+  let json: unknown;
+  try {
+    json = JSON.parse(content);
+  } catch {
+    return [];
+  }
+  const out: LockedDependency[] = [];
+
+  interface NpmDep {
+    version?: string;
+    dependencies?: Record<string, NpmDep>;
+  }
+  const root = json as { packages?: Record<string, { version?: string }>; dependencies?: Record<string, NpmDep> };
+
+  // npm v7+ (lockfileVersion 2/3): flat "packages" — direct = path without nested node_modules
+  if (root.packages) {
+    for (const [pkgPath, info] of Object.entries(root.packages)) {
+      if (pkgPath === "") continue;
+      const version = info.version;
+      if (!version) continue;
+      const isTransitive = pkgPath.split("node_modules/").length > 2;
+      // name = last path segment (scoped: @scope/name keeps its slash)
+      const segments = pkgPath.split("node_modules/");
+      const name = segments[segments.length - 1] ?? pkgPath;
+      out.push({
+        name,
+        version: normalizeVersion(version),
+        manager: "npm",
+        lockfilePath,
+        // "node_modules/x" = direct (depth 1); "node_modules/a/node_modules/b" = transitive
+        depth: segments.length - 1,
+      });
+    }
+  }
+
+  if (root.dependencies) {
+    const walk = (deps: Record<string, NpmDep>, depth: number) => {
+      for (const [name, info] of Object.entries(deps)) {
+        if (info.version) {
+          out.push({ name, version: normalizeVersion(info.version), manager: "npm", lockfilePath, depth });
+        }
+        if (info.dependencies) walk(info.dependencies, depth + 1);
+      }
+    };
+    walk(root.dependencies, 1);
+  }
+
+  return out;
+}
+
+function parsePnpmLock(content: string, lockfilePath: string): LockedDependency[] {
+  const out: LockedDependency[] = [];
+  // Blocks: "  /pkg@1.2.3:" (scoped: "/@scope/pkg@1.2.3") or "  pkg@1.2.3:"
+  const re = /^\s{2}\/?((?:@[^/]+\/)?[^/@\s]+)@(\d+\.\d+\.\d+):/gm;
+  for (const match of content.matchAll(re)) {
+    out.push({ name: match[1]!, version: match[2]!, manager: "pnpm", lockfilePath, depth: 1 });
+  }
+  return out;
+}
+
+function parseYarnLock(content: string, lockfilePath: string): LockedDependency[] {
+  const out: LockedDependency[] = [];
+  // Blocks: 'name@range:' then '  version "1.2.3"'
+  const blockRe = /^([^\n]+):\n((?:[ \t]+.*\n?)*)/gm;
+  for (const block of content.matchAll(blockRe)) {
+    const header = block[1] ?? "";
+    const body = block[2] ?? "";
+    const versionMatch = body.match(/^\s+version\s+"([^"]+)"/m);
+    if (!versionMatch) continue;
+    // header may be "name@^1.0.0, name@^1.1.0" — take the first quoted piece
+    const nameMatch = header.match(/"((?:@[^/]+\/)?[^@"]+)@/);
+    const name = nameMatch?.[1] ?? header.split("@")[0];
+    out.push({ name, version: normalizeVersion(versionMatch[1]!), manager: "yarn", lockfilePath, depth: 1 });
+  }
+  return out;
+}
+
+function parseGoSum(content: string, lockfilePath: string): LockedDependency[] {
+  const out: LockedDependency[] = [];
+  const re = /^([^\s]+)\s+(v\d+\.\d+\.\d+(?:[^\s]*)?)\s+h1:/gm;
+  for (const match of content.matchAll(re)) {
+    out.push({ name: match[1]!, version: normalizeVersion(match[2]!), manager: "go", lockfilePath, depth: 1 });
+  }
+  return out;
+}
+
+function parseCargoLock(content: string, lockfilePath: string): LockedDependency[] {
+  const out: LockedDependency[] = [];
+  const re = /name\s*=\s*"([^"]+)"\s*\n\s*version\s*=\s*"([^"]+)"/g;
+  for (const match of content.matchAll(re)) {
+    out.push({ name: match[1]!, version: normalizeVersion(match[2]!), manager: "cargo", lockfilePath, depth: 1 });
+  }
+  return out;
+}
+
+function parseComposerLock(content: string, lockfilePath: string): LockedDependency[] {
+  let json: unknown;
+  try {
+    json = JSON.parse(content);
+  } catch {
+    return [];
+  }
+  const packages = (json as { packages?: Array<{ name?: string; version?: string }> }).packages ?? [];
+  const out: LockedDependency[] = [];
+  for (const pkg of packages) {
+    if (!pkg.name || !pkg.version) continue;
+    out.push({ name: pkg.name, version: normalizeVersion(pkg.version), manager: "composer", lockfilePath, depth: 1 });
+  }
+  return out;
+}

--- a/packages/security-analysis/dependency/TransitiveRiskAnalyzer.ts
+++ b/packages/security-analysis/dependency/TransitiveRiskAnalyzer.ts
@@ -5,5 +5,57 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Transitive-risk analysis over pinned dependencies. For npm lockfiles
+// the LockfileAnalyzer already marks depth (1 = direct, 2+ = transitive);
+// other managers report everything at depth 1 (no graph in the lockfile
+// format — documented limitation). This analyzer computes the aggregate
+// picture: how much of the dependency tree is transitive, and which
+// vulnerable hits are direct (developer-controlled, higher risk) vs
+// transitive (indirect, harder to fix).
 
-// Scaffold: security-analysis/dependency/TransitiveRiskAnalyzer — not yet implemented.
+import type { LockedDependency } from "./LockfileAnalyzer";
+import type { VulnerableDependencyFinding } from "./VulnerableDependencyDetector";
+
+export interface TransitiveRiskReport {
+  totalDirect: number;
+  totalTransitive: number;
+  /** 1 for lockfiles without nesting (non-npm), max nesting depth otherwise. */
+  maxDepth: number;
+  /** Vulnerable hits that are direct dependencies (depth 1). */
+  vulnerableDirect: VulnerableDependencyFinding[];
+  /** Vulnerable hits that are transitive (depth 2+). */
+  vulnerableTransitive: VulnerableDependencyFinding[];
+  /**
+   * Heuristic 0..1: fraction of the tree that is transitive. Higher means
+   * more of the supply chain is outside the developer's direct control.
+   */
+  transitiveRatio: number;
+}
+
+export function analyzeTransitiveRisk(
+  locked: LockedDependency[],
+  vulnerable: VulnerableDependencyFinding[]
+): TransitiveRiskReport {
+  const totalDirect = locked.filter((d) => d.depth === 1).length;
+  const totalTransitive = locked.filter((d) => d.depth > 1).length;
+  const maxDepth = locked.reduce((max, d) => Math.max(max, d.depth), locked.length > 0 ? 1 : 0);
+
+  const vulnIds = new Set(vulnerable.map((v) => `${v.dependency.name}@${v.dependency.version}`));
+  const vulnerableDirect = vulnerable.filter((v) => v.dependency.depth === 1);
+  const vulnerableTransitive = vulnerable.filter((v) => v.dependency.depth > 1);
+
+  return {
+    totalDirect,
+    totalTransitive,
+    maxDepth,
+    vulnerableDirect,
+    vulnerableTransitive,
+    transitiveRatio: totalDirect + totalTransitive > 0 ? totalTransitive / (totalDirect + totalTransitive) : 0,
+  };
+}
+
+/** Convenience: find the vulnerable dependency records a report references. */
+export function vulnerableNames(report: TransitiveRiskReport): string[] {
+  return [...new Set([...report.vulnerableDirect, ...report.vulnerableTransitive].map((v) => v.dependency.name))].sort();
+}

--- a/packages/security-analysis/dependency/VulnerableDependencyDetector.ts
+++ b/packages/security-analysis/dependency/VulnerableDependencyDetector.ts
@@ -5,5 +5,152 @@
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Vulnerable-dependency detection: pinned (lockfile) versions are compared
+// against a known-vulnerability database using a small dependency-free
+// semver comparator.
+//
+// The built-in database (DEFAULT_KNOWN_VULNERABILITIES) is a deliberately
+// SMALL, hand-maintained subset of well-known advisories. It is NOT a
+// substitute for an external advisory feed (OSV/NVD/GitHub Advisory DB) —
+// wiring one is a documented deferral. Entries are marked with their
+// advisory id and must be verified before relying on them for gating.
 
-// Scaffold: security-analysis/dependency/VulnerableDependencyDetector — not yet implemented.
+import type { SecuritySeverity } from "../SecuritySeverity";
+import type { SecurityFinding } from "../SecurityFinding";
+import type { LockedDependency } from "./LockfileAnalyzer";
+
+export interface KnownVulnerability {
+  /** Package name as it appears in the lockfile (e.g. "lodash"). */
+  name: string;
+  /** Vulnerable when locked version < fixedVersion (semver). */
+  fixedVersion: string;
+  severity: SecuritySeverity;
+  description: string;
+  /** Advisory id, e.g. "CVE-2021-23337". */
+  reference: string;
+  cwe?: string[];
+  owasp?: string[];
+}
+
+export interface VulnerableDependencyFinding {
+  dependency: LockedDependency;
+  vulnerability: KnownVulnerability;
+}
+
+/**
+ * Minimal semver comparator (major.minor.patch, optional prerelease
+ * ignored). Returns -1 | 0 | 1. Not a full semver implementation —
+ * build metadata ("+...") is stripped, prerelease ordering is not
+ * implemented (documented limitation).
+ */
+export function compareSemver(aRaw: string, bRaw: string): -1 | 0 | 1 {
+  const a = aRaw.split("+")[0]!.split("-")[0]!;
+  const b = bRaw.split("+")[0]!.split("-")[0]!;
+  const aParts = a.split(".").map((p) => parseInt(p, 10) || 0);
+  const bParts = b.split(".").map((p) => parseInt(p, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const av = aParts[i] ?? 0;
+    const bv = bParts[i] ?? 0;
+    if (av < bv) return -1;
+    if (av > bv) return 1;
+  }
+  return 0;
+}
+
+export function isVulnerable(lockedVersion: string, vulnerability: KnownVulnerability): boolean {
+  return compareSemver(lockedVersion, vulnerability.fixedVersion) < 0;
+}
+
+/**
+ * Built-in advisory subset — verify each entry against its advisory before
+ * relying on it in a gate. Full advisory feed = documented deferral.
+ */
+export const DEFAULT_KNOWN_VULNERABILITIES: KnownVulnerability[] = [
+  {
+    name: "lodash",
+    fixedVersion: "4.17.21",
+    severity: "high",
+    description: "Prototype pollution via zipObjectDeep / set / defaultToDeep (fixed in 4.17.21).",
+    reference: "CVE-2021-23337",
+    cwe: ["CWE-1321"],
+    owasp: ["A03:2025"],
+  },
+  {
+    name: "minimist",
+    fixedVersion: "1.2.6",
+    severity: "high",
+    description: "Prototype pollution via constructor payload (fixed in 1.2.6).",
+    reference: "CVE-2021-44906",
+    cwe: ["CWE-1321"],
+    owasp: ["A03:2025"],
+  },
+  {
+    name: "ws",
+    fixedVersion: "8.17.1",
+    severity: "medium",
+    description: "DoS via uncaught error on malformed close frame (fixed in 8.17.1).",
+    reference: "CVE-2024-37890",
+    cwe: ["CWE-400"],
+    owasp: ["A03:2025"],
+  },
+  {
+    name: "jsonwebtoken",
+    fixedVersion: "9.0.0",
+    severity: "high",
+    description: "Unrestricted key type can lead to forged tokens (fixed in 9.0.0).",
+    reference: "CVE-2022-23529",
+    cwe: ["CWE-347"],
+    owasp: ["A07:2025"],
+  },
+  {
+    name: "next",
+    fixedVersion: "12.0.9",
+    severity: "high",
+    description: "Improper input validation in i18n routing (fixed in 12.0.9).",
+    reference: "CVE-2022-23649",
+    cwe: ["CWE-20"],
+    owasp: ["A05:2025"],
+  },
+];
+
+export function detectVulnerableDependencies(
+  locked: LockedDependency[],
+  database: KnownVulnerability[] = DEFAULT_KNOWN_VULNERABILITIES
+): VulnerableDependencyFinding[] {
+  const byName = new Map<string, KnownVulnerability[]>();
+  for (const vuln of database) {
+    const list = byName.get(vuln.name) ?? [];
+    list.push(vuln);
+    byName.set(vuln.name, list);
+  }
+
+  const findings: VulnerableDependencyFinding[] = [];
+  for (const dep of locked) {
+    for (const vuln of byName.get(dep.name) ?? []) {
+      if (isVulnerable(dep.version, vuln)) {
+        findings.push({ dependency: dep, vulnerability: vuln });
+        break; // one finding per dependency instance
+      }
+    }
+  }
+  return findings;
+}
+
+/** Converts vulnerable-dependency hits into the standard SecurityFinding shape. */
+export function toSecurityFindings(hits: VulnerableDependencyFinding[]): SecurityFinding[] {
+  return hits.map((hit) => {
+    const { dependency, vulnerability } = hit;
+    return {
+      id: `vulnerable-dependency:${dependency.name}:${dependency.version}`,
+      ruleId: "vulnerable-dependency",
+      title: `Vulnerable dependency "${dependency.name}@${dependency.version}"`,
+      description: `${vulnerability.description} (${vulnerability.reference}; fixed in ${vulnerability.fixedVersion}; depth ${dependency.depth}; ${dependency.manager} via ${dependency.lockfilePath}).`,
+      severity: vulnerability.severity,
+      confidence: "medium",
+      location: { moduleId: dependency.lockfilePath, filePath: dependency.lockfilePath },
+      cwe: vulnerability.cwe,
+      owasp: vulnerability.owasp,
+    };
+  });
+}

--- a/packages/security-analysis/index.ts
+++ b/packages/security-analysis/index.ts
@@ -75,3 +75,34 @@ export {
   type ReportAttackSurface,
   type BuildSecurityReportInput,
 } from "./reporting/SecurityReport";
+
+export {
+  parseLockfiles,
+  normalizeVersion,
+  LOCKFILE_NAMES,
+  type LockedDependency,
+  type LockfileParseResult,
+} from "./dependency/LockfileAnalyzer";
+
+export {
+  compareSemver,
+  isVulnerable,
+  detectVulnerableDependencies,
+  toSecurityFindings,
+  DEFAULT_KNOWN_VULNERABILITIES,
+  type KnownVulnerability,
+  type VulnerableDependencyFinding,
+} from "./dependency/VulnerableDependencyDetector";
+
+export {
+  analyzeTransitiveRisk,
+  vulnerableNames,
+  type TransitiveRiskReport,
+} from "./dependency/TransitiveRiskAnalyzer";
+
+export {
+  analyzeDependencyRisk,
+  isUnpinnedRange,
+  type DependencyRiskInput,
+  type DependencyRiskResult,
+} from "./dependency/DependencyRiskAnalyzer";

--- a/tests/dependency-security.test.ts
+++ b/tests/dependency-security.test.ts
@@ -1,0 +1,232 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for packages/security-analysis/dependency: lockfile parsing
+// (unit, inline content per format), semver comparison, vulnerable
+// dependency detection, transitive risk, and the aggregate analyzer over
+// the tests/fixtures/dependency-vuln fixture (real files, real path).
+
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { DiskSourceProvider, type SourceProvider } from "../packages/security-analysis";
+import { parseLockfiles, normalizeVersion, type LockedDependency } from "../packages/security-analysis/dependency/LockfileAnalyzer";
+import { compareSemver, isVulnerable, detectVulnerableDependencies, DEFAULT_KNOWN_VULNERABILITIES, type KnownVulnerability } from "../packages/security-analysis/dependency/VulnerableDependencyDetector";
+import { analyzeTransitiveRisk } from "../packages/security-analysis/dependency/TransitiveRiskAnalyzer";
+import { analyzeDependencyRisk, isUnpinnedRange } from "../packages/security-analysis/dependency/DependencyRiskAnalyzer";
+
+class MapSourceProvider implements SourceProvider {
+  private contents: Map<string, string>;
+  constructor(contents: Record<string, string>) {
+    this.contents = new Map(Object.entries(contents));
+  }
+  read(relativePath: string): string | null {
+    return this.contents.get(relativePath) ?? null;
+  }
+}
+
+// ─────────────────────────────────────────────
+// normalizeVersion / compareSemver
+// ─────────────────────────────────────────────
+
+describe("normalizeVersion + compareSemver", () => {
+  it("normalizes leading v and whitespace", () => {
+    expect(normalizeVersion("v1.2.3")).toBe("1.2.3");
+    expect(normalizeVersion(" 1.2.3 ")).toBe("1.2.3");
+    expect(normalizeVersion("=1.2.3")).toBe("1.2.3");
+  });
+
+  it("compares patch/minor/major", () => {
+    expect(compareSemver("4.17.20", "4.17.21")).toBe(-1);
+    expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+    expect(compareSemver("2.0.0", "1.9.9")).toBe(1);
+  });
+
+  it("ignores prerelease/build metadata (documented limitation)", () => {
+    expect(compareSemver("1.2.3-alpha", "1.2.3")).toBe(0);
+    expect(compareSemver("1.2.3+build5", "1.2.3")).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Lockfile parsing — unit per format
+// ─────────────────────────────────────────────
+
+describe("parseLockfiles (unit)", () => {
+  it("parses package-lock.json v3 (packages) with direct/transitive depth", () => {
+    const sources = new MapSourceProvider({
+      "package-lock.json": JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          "": { name: "x", version: "1.0.0" },
+          "node_modules/lodash": { version: "4.17.20" },
+          "node_modules/express/node_modules/qs": { version: "6.11.0" },
+        },
+      }),
+    });
+    const { dependencies } = parseLockfiles(sources, ["package-lock.json"]);
+    const lodash = dependencies.find((d) => d.name === "lodash")!;
+    expect(lodash.version).toBe("4.17.20");
+    expect(lodash.depth).toBe(1); // direct
+    const qs = dependencies.find((d) => d.name === "qs")!;
+    expect(qs.depth).toBe(2); // transitive
+  });
+
+  it("parses yarn.lock blocks", () => {
+    const sources = new MapSourceProvider({
+      "yarn.lock": '"lodash@^4.17.0":\n  version "4.17.20"\n  resolved "https://x/y.tgz"\n\n"express@~4.18.0":\n  version "4.18.2"\n',
+    });
+    const { dependencies } = parseLockfiles(sources, ["yarn.lock"]);
+    expect(dependencies.find((d) => d.name === "lodash")!.version).toBe("4.17.20");
+    expect(dependencies.find((d) => d.name === "express")!.version).toBe("4.18.2");
+  });
+
+  it("parses go.sum and Cargo.lock", () => {
+    const sources = new MapSourceProvider({
+      "go.sum": "github.com/foo/bar v1.2.3 h1:abc\n",
+      "Cargo.lock": '[[package]]\nname = "serde"\nversion = "1.0.200"\n',
+    });
+    const { dependencies } = parseLockfiles(sources, ["go.sum", "Cargo.lock"]);
+    expect(dependencies.find((d) => d.name === "github.com/foo/bar")!.version).toBe("1.2.3");
+    expect(dependencies.find((d) => d.name === "serde")!.version).toBe("1.0.200");
+  });
+
+  it("reports missing lockfiles as skipped and tolerates malformed JSON", () => {
+    const sources = new MapSourceProvider({ "package-lock.json": "not-json{{" });
+    const { dependencies, lockfilesFound, skipped } = parseLockfiles(sources);
+    expect(lockfilesFound).toEqual(["package-lock.json"]);
+    expect(dependencies).toEqual([]);
+    expect(skipped).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Vulnerable dependency detection
+// ─────────────────────────────────────────────
+
+describe("detectVulnerableDependencies", () => {
+  const locked: LockedDependency[] = [
+    { name: "lodash", version: "4.17.20", manager: "npm", lockfilePath: "package-lock.json", depth: 1 },
+    { name: "express", version: "4.18.2", manager: "npm", lockfilePath: "package-lock.json", depth: 1 },
+  ];
+
+  it("flags versions below fixedVersion", () => {
+    const hits = detectVulnerableDependencies(locked);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.dependency.name).toBe("lodash");
+    expect(hits[0]!.vulnerability.reference).toBe("CVE-2021-23337");
+  });
+
+  it("isVulnerable respects the boundary (equal is NOT vulnerable)", () => {
+    const vuln = DEFAULT_KNOWN_VULNERABILITIES.find((v) => v.name === "lodash")!;
+    expect(isVulnerable("4.17.21", vuln)).toBe(false);
+    expect(isVulnerable("4.17.22", vuln)).toBe(false);
+    expect(isVulnerable("4.17.20", vuln)).toBe(true);
+  });
+
+  it("respects a custom database", () => {
+    const custom: KnownVulnerability[] = [
+      { name: "express", fixedVersion: "4.19.0", severity: "high", description: "t", reference: "TEST-1" },
+    ];
+    const hits = detectVulnerableDependencies(locked, custom);
+    expect(hits.map((h) => h.dependency.name)).toEqual(["express"]);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Transitive risk
+// ─────────────────────────────────────────────
+
+describe("analyzeTransitiveRisk", () => {
+  it("splits vulnerable hits into direct vs transitive", () => {
+    const locked: LockedDependency[] = [
+      { name: "lodash", version: "4.17.20", manager: "npm", lockfilePath: "p", depth: 1 },
+      { name: "qs", version: "6.11.0", manager: "npm", lockfilePath: "p", depth: 2 },
+    ];
+    const hits = detectVulnerableDependencies(locked);
+    const report = analyzeTransitiveRisk(locked, hits);
+    expect(report.totalDirect).toBe(1);
+    expect(report.totalTransitive).toBe(1);
+    expect(report.maxDepth).toBe(2);
+    expect(report.vulnerableDirect).toHaveLength(1);
+    expect(report.transitiveRatio).toBe(0.5);
+  });
+
+  it("handles empty input", () => {
+    const report = analyzeTransitiveRisk([], []);
+    expect(report.totalDirect).toBe(0);
+    expect(report.totalTransitive).toBe(0);
+    expect(report.transitiveRatio).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Aggregate analyzer over the real fixture
+// ─────────────────────────────────────────────
+
+describe("analyzeDependencyRisk over tests/fixtures/dependency-vuln", () => {
+  const root = path.join(__dirname, "fixtures", "dependency-vuln");
+
+  it("flags the vulnerable pinned lodash and the unpinned ranges", () => {
+    const result = analyzeDependencyRisk({
+      manifestDependencies: [
+        { name: "axios", versionRange: "1.7.0", kind: "runtime" },
+        { name: "express", versionRange: "~4.18.0", kind: "runtime" },
+        { name: "lodash", versionRange: "^4.17.0", kind: "runtime" },
+      ],
+      sources: new DiskSourceProvider(root),
+    });
+
+    const ruleIds = result.findings.map((f) => f.ruleId);
+    expect(ruleIds).toContain("vulnerable-dependency");
+    expect(ruleIds).toContain("unpinned-dependency");
+
+    const lodashVuln = result.findings.find((f) => f.ruleId === "vulnerable-dependency")!;
+    expect(lodashVuln.title).toContain("lodash@4.17.20");
+    expect(lodashVuln.severity).toBe("high");
+    expect(lodashVuln.owasp).toContain("A03:2025");
+
+    const unpinned = result.findings.filter((f) => f.ruleId === "unpinned-dependency");
+    expect(unpinned.map((f) => f.title)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("express"),
+        expect.stringContaining("lodash"),
+      ])
+    );
+    // axios is pinned exactly -> NOT flagged
+    expect(unpinned.some((f) => f.title.includes("axios"))).toBe(false);
+  });
+
+  it("reports transitive structure", () => {
+    const result = analyzeDependencyRisk({
+      manifestDependencies: [],
+      sources: new DiskSourceProvider(root),
+    });
+    // fixture: lodash/express/axios direct, qs transitive under express
+    expect(result.transitiveRisk.totalDirect).toBe(3);
+    expect(result.transitiveRisk.totalTransitive).toBe(1);
+    expect(result.transitiveRisk.vulnerableDirect.map((v) => v.dependency.name)).toEqual(["lodash"]);
+  });
+});
+
+// ─────────────────────────────────────────────
+// isUnpinnedRange
+// ─────────────────────────────────────────────
+
+describe("isUnpinnedRange", () => {
+  it("distinguishes exact versions from ranges", () => {
+    expect(isUnpinnedRange("1.2.3")).toBe(false);
+    expect(isUnpinnedRange("v1.2.3")).toBe(false);
+    expect(isUnpinnedRange("1.2.3-alpha.1")).toBe(false);
+    expect(isUnpinnedRange("^1.2.3")).toBe(true);
+    expect(isUnpinnedRange("~1.2.3")).toBe(true);
+    expect(isUnpinnedRange(">=1.2.3")).toBe(true);
+    expect(isUnpinnedRange("*")).toBe(true);
+    expect(isUnpinnedRange("latest")).toBe(true);
+    expect(isUnpinnedRange(undefined)).toBe(false);
+  });
+});

--- a/tests/fixtures/dependency-vuln/package.json
+++ b/tests/fixtures/dependency-vuln/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dependency-vuln",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "axios": "1.7.0",
+    "express": "~4.18.0",
+    "lodash": "^4.17.0"
+  }
+}


### PR DESCRIPTION
## Summary
Implements the dependency risk layer of the security-analysis scaffold (packages/security-analysis/dependency/), wired into `arclux security`.

> [!IMPORTANT]
> **Depends on #485** (type-unification fix) — this branch is based on fix/security-analysis-completeness. Will rebase onto ARCLUX.main once #485 merges.

## What's included
- LockfileAnalyzer — pinned versions from package-lock.json (v1/v2/v3), pnpm-lock.yaml, yarn.lock, go.sum, Cargo.lock, composer.lock via SourceProvider (content channel)
- VulnerableDependencyDetector — dependency-free semver comparator + built-in advisory subset (lodash CVE-2021-23337, minimist CVE-2021-44906, ws CVE-2024-37890, jsonwebtoken CVE-2022-23529, next CVE-2022-23649) — external advisory feed documented as deferral
- TransitiveRiskAnalyzer — direct vs transitive depth split (npm nesting), transitiveRatio heuristic
- DependencyRiskAnalyzer — aggregate: vulnerable-dependency findings + unpinned-dependency supply-chain heuristic (A03:2025), consumes core ManifestDependency[] (no new manifest scanning)
- CLI: `arclux security` now includes dependency findings
- Tests: 15 new (566/566 total), fixture tests/fixtures/dependency-vuln (lodash 4.17.20 pinned, express/lodash unpinned)

## Verified
- npx vitest run: 566/566
- npx tsc --noEmit: 0 errors in new files
- arclux security tests/fixtures/dependency-vuln: lodash@4.17.20 flagged high, express/lodash flagged unpinned, axios (pinned) not flagged