### PR TITLE
fix(ci): force-add gitignored package-lock.json fixture (CI test failure)

### DIFF
--- a/tests/fixtures/dependency-vuln/package-lock.json
+++ b/tests/fixtures/dependency-vuln/package-lock.json
@@ -1,0 +1,37 @@
+{
+  "name": "dependency-vuln",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dependency-vuln",
+      "version": "1.0.0",
+      "dependencies": {
+        "axios": "1.7.0",
+        "express": "4.18.2",
+        "lodash": "4.17.20"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.0.tgz",
+      "integrity": "sha512-test"
+    },
+    "node_modules/express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-test"
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-test"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-test"
+    }
+  }
+}


### PR DESCRIPTION
## Problem
CI on ARCLUX.main fails: `pnpm run test` → tests/dependency-security.test.ts fails (vulnerable-dependency missing, totalDirect=0).

Root cause: `.gitignore` line 10 ignores `package-lock.json`, so the fixture file `tests/fixtures/dependency-vuln/package-lock.json` was never committed in #486. Locally the tests passed because the file exists on disk; CI (fresh checkout) has no lockfile → parseLockfiles returns nothing.

## Fix
Force-add the fixture (git add -f) — a targeted exception for test data, the `.gitignore` rule itself is untouched. Once tracked, gitignore no longer applies.

## Verification
- Locally: npx vitest run = 566/566 (this branch contains the fixture + main)
- The failing CI assertions (vulnerable-dependency present, totalDirect=3) pass