### PR TITLE
fix(tests): triage 27 ThreatCrush findings — eliminate false positives, document expected noise

### DIFF
--- a/packages/security-analysis/source/UnsafePatternDetector.ts
+++ b/packages/security-analysis/source/UnsafePatternDetector.ts
@@ -41,6 +41,14 @@ export interface UnsafePatternOptions {
   allowlistPaths?: RegExp[];
 }
 
+// The patterns below ARE the detection definitions: they describe attacks
+// (eval/Function/exec calls, XSS sinks) so the scanner can find them in
+// OTHER repos. They are matched, never executed, by this detector —
+// ThreatCrush flags the literal strings as js-dynamic-code-execution /
+// js-unescaped-html-sink, which is a false positive by the repo guard
+// "check the execution path, not the presence of the string"
+// (AGENT_DIARY 2026-08-13 ThreatCrush entry). Kept as readable regexes on
+// purpose — the pattern is the product's documentation.
 export const DEFAULT_UNSAFE_PATTERN_RULES: UnsafePatternRule[] = [
   {
     id: "unsafe-eval",

--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -461,3 +461,9 @@ impact.test.ts fix). CI on ARCLUX.main confirmed green after merge.
 parseMaven matched `<dependency>` blocks with a blanket regex in ANY context — probe: 2 false positives out of 4 (`maven-shared-utils` from `<plugin><dependencies>` — plugin's own classpath; `guava` from `<dependencyManagement>` — version management only). Fix: strip `<plugin>…</plugin>` and `<dependencyManagement>…</dependencyManagement>` before block matching (neither nests itself nor the other; profile deps KEPT — conditional but real). Also: FIRST tests ever for the manifest package (tests/manifest.test.ts, 8: parsePom kinds/scopes/plugin/dependencyManagement/profile/malformed, parseGradle_ patterns) + wiring proven e2e (status-core's «not wired to analyzeRepository» was outdated — detectDependencies IS called by both local/remote paths; fixture java-basic with pom.xml + Main.java asserts dependencies = 3 project deps only). suite 359/359.
 ARCLUX.main
 
+
+## 2026-08-16 — ThreatCrush false positives in security packages — 27 findings triaged
+
+**Status:** Done
+
+ThreatCrush scan (run 31964856937 comment) found 27: (1) insecure-temp-file x9 — /tmp paths in in-memory test fixtures (never written) — FIXED in source per repo convention: rootPath 'in-memory' + os.tmpdir() for validation paths (remote.test.ts, architecture-security.test.ts, security-analysis.test.ts); (2) js-dynamic-code-execution x4 in UnsafePatternDetector regex patterns — patterns are detection data, never executed — documented in-file (guard: check execution path, not string presence, AGENT_DIARY 2026-08-13); (3) remaining 14 (test-content strings eval/innerHTML + intentional fake secrets in fixtures/tests) are deliberate positive controls for the security detectors — cannot remove without breaking tests; ThreatCrush 0.11.0 has NO ignore mechanism (verified in package source); documented as expected noise.

--- a/tests/architecture-security.test.ts
+++ b/tests/architecture-security.test.ts
@@ -122,7 +122,7 @@ describe("detectCrossBoundaryCalls", () => {
       org: "local",
       name: "unit",
       defaultBranch: "main",
-      rootPath: "/tmp/unit",
+      rootPath: "in-memory",
       detectedFrameworks: [],
       packageManager: "unknown",
       analyzedAt: new Date().toISOString(),
@@ -136,7 +136,7 @@ describe("detectCrossBoundaryCalls", () => {
     return {
       id,
       file: {
-        absolutePath: `/tmp/unit/${path2}`,
+        absolutePath: `in-memory/${path2}`,
         relativePath: path2,
         language: "typescript",
         extension: ".ts",
@@ -159,7 +159,7 @@ describe("detectCrossBoundaryCalls", () => {
       module("handlers/login.ts", "handlers/login.ts", [{ moduleId: "services/auth.service.ts", calleeName: "verifyToken", line: 7 }]),
       module("services/auth.service.ts", "services/auth.service.ts", []),
     ]);
-    const findings = detectCrossBoundaryCalls(repo, new DiskSourceProvider("/tmp/unit"));
+    const findings = detectCrossBoundaryCalls(repo, new DiskSourceProvider("in-memory"));
     expect(findings).toHaveLength(1);
     expect(findings[0].ruleId).toBe("cross-boundary-call");
     expect(findings[0].location.line).toBe(7);
@@ -171,7 +171,7 @@ describe("detectCrossBoundaryCalls", () => {
       module("handlers/login.ts", "handlers/login.ts", [{ moduleId: "utils/format.ts", calleeName: "format", line: 2 }]),
       module("utils/format.ts", "utils/format.ts", []),
     ]);
-    expect(detectCrossBoundaryCalls(repo, new DiskSourceProvider("/tmp/unit"))).toHaveLength(0);
+    expect(detectCrossBoundaryCalls(repo, new DiskSourceProvider("in-memory"))).toHaveLength(0);
   });
 });
 

--- a/tests/remote.test.ts
+++ b/tests/remote.test.ts
@@ -14,18 +14,23 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import path from "node:path";
+import os from "node:os";
 import { RemoteRepository } from "../packages/remote";
 import { createRemoteSnapshot, type RemoteSnapshot } from "../packages/remote";
 import type { AnalyzeRepositoryResult } from "../packages/engine/pipeline";
 
 const NEXTJS_DEMO = path.join(__dirname, "..", "playground", "nextjs-demo");
+// Validation tests use a path that exists as a directory but is never
+// analyzed (analyze() throws before any I/O) — os.tmpdir()-based per the
+// repo convention for non-analyzed test paths (avoids ThreatCrush noise).
+const NON_ANALYZED_PATH = path.join(os.tmpdir(), "arclux-remote-test");
 
 describe("RemoteRepository argument validation", () => {
   it("throws when both url and localPath are set", async () => {
     const repo = new RemoteRepository({
       id: "both",
       url: "https://github.com/GSF-001/ARCLUX.git",
-      localPath: "/tmp/x",
+      localPath: NON_ANALYZED_PATH,
     });
     await expect(repo.analyze()).rejects.toThrow(/not both/);
   });
@@ -36,8 +41,8 @@ describe("RemoteRepository argument validation", () => {
   });
 
   it("exposes the source unchanged", () => {
-    const repo = new RemoteRepository({ id: "r1", localPath: "/tmp/x", branch: "main" });
-    expect(repo.source).toEqual({ id: "r1", localPath: "/tmp/x", branch: "main" });
+    const repo = new RemoteRepository({ id: "r1", localPath: NON_ANALYZED_PATH, branch: "main" });
+    expect(repo.source).toEqual({ id: "r1", localPath: NON_ANALYZED_PATH, branch: "main" });
   });
 });
 

--- a/tests/security-analysis.test.ts
+++ b/tests/security-analysis.test.ts
@@ -65,7 +65,9 @@ function makeRepository(relativePaths: string[]): Repository {
     org: "local",
     name: "unit",
     defaultBranch: "main",
-    rootPath: "/tmp/unit",
+    // In-memory fixture: no files are written, so this is a marker value,
+    // not a real path (avoids ThreatCrush insecure-temp-file noise).
+    rootPath: "in-memory",
     detectedFrameworks: [],
     packageManager: "unknown",
     analyzedAt: new Date().toISOString(),
@@ -75,7 +77,7 @@ function makeRepository(relativePaths: string[]): Repository {
     repo.addModule({
       id: relativePath,
       file: {
-        absolutePath: `/tmp/unit/${relativePath}`,
+        absolutePath: `in-memory/${relativePath}`,
         relativePath,
         language: "typescript",
         extension: ".ts",
@@ -221,7 +223,7 @@ describe("detectSensitiveDataFlow (unit, in-memory)", () => {
       org: "local",
       name: "unit",
       defaultBranch: "main",
-      rootPath: "/tmp/unit",
+      rootPath: "in-memory",
       detectedFrameworks: [],
       packageManager: "unknown",
       analyzedAt: new Date().toISOString(),
@@ -229,7 +231,7 @@ describe("detectSensitiveDataFlow (unit, in-memory)", () => {
     repo.addModule({
       id: "logger.ts",
       file: {
-        absolutePath: "/tmp/unit/logger.ts",
+        absolutePath: "in-memory/logger.ts",
         relativePath: "logger.ts",
         language: "typescript",
         extension: ".ts",


### PR DESCRIPTION
## Triage of ThreatCrush scan (27 findings)

All 27 were triaged against the repo guard (AGENT_DIARY 2026-08-13): *check the execution path, not the presence of the string*.

| Class | Count | Disposition |
|---|---|---|
| `insecure-temp-file` — /tmp paths in in-memory test fixtures | 9 | **Fixed in source** (repo convention): in-memory repositories never write → rootPath `"in-memory"`; RemoteRepository validation paths → `os.tmpdir()`-based |
| `js-dynamic-code-execution` — UnsafePatternDetector regex patterns | 4 | **False positive by guard**: the regexes are detection *data* (matched, never executed). Kept readable (they are the product's documentation) + in-file rationale comment |
| Test-content strings (eval/innerHTML) + intentional fake secrets in fixtures/tests | 14 | **Deliberate positive controls** for the security detectors — cannot be removed without breaking tests. ThreatCrush 0.11.0 has no ignore/allowlist mechanism (verified in package source) → documented as expected noise in progres/bugs.md |

## Verification
- npx vitest run: 566/566
- No `/tmp` paths left in packages/security-analysis|remote|correlation|provenance or the touched test files
- Full ThreatCrush re-scan happens in CI on this PR