### PR TITLE
fix: implement remote acquisition and analysis layer

### DIFF
--- a/packages/acquisition/AcquisitionPolicy.ts
+++ b/packages/acquisition/AcquisitionPolicy.ts
@@ -19,3 +19,33 @@ export const defaultAcquisitionPolicy: AcquisitionPolicy = {
   maxBytes: 100 * 1024 * 1024,
   timeoutMs: 30_000,
 };
+
+export function resolveAcquisitionPolicy(
+  policy: Partial<AcquisitionPolicy> = {},
+): AcquisitionPolicy {
+  const resolved = { ...defaultAcquisitionPolicy, ...policy };
+  if (!Number.isFinite(resolved.maxBytes) || resolved.maxBytes <= 0) {
+    throw new Error("Acquisition policy maxBytes must be greater than zero.");
+  }
+  if (!Number.isFinite(resolved.timeoutMs) || resolved.timeoutMs <= 0) {
+    throw new Error("Acquisition policy timeoutMs must be greater than zero.");
+  }
+  return { ...resolved, allowedHosts: [...resolved.allowedHosts] };
+}
+
+export function assertSourceAllowed(source: string, policy: AcquisitionPolicy): void {
+  let url: URL;
+  try {
+    url = new URL(source);
+  } catch {
+    return;
+  }
+
+  if (!policy.allowRemote) throw new Error("Remote acquisition is disabled by policy.");
+  if (!["http:", "https:", "ssh:", "git:", "ftp:"].includes(url.protocol)) {
+    throw new Error(`Remote protocol is not allowed: ${url.protocol}`);
+  }
+  if (policy.allowedHosts.length > 0 && !policy.allowedHosts.includes(url.hostname)) {
+    throw new Error(`Remote host is not allowed: ${url.hostname}`);
+  }
+}

--- a/packages/acquisition/ArchiveAcquirer.ts
+++ b/packages/acquisition/ArchiveAcquirer.ts
@@ -6,12 +6,18 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { AcquisitionPolicy } from "./AcquisitionPolicy";
+import type { AcquisitionResult } from "./AcquisitionResult";
+import { createSourceAcquirer } from "./SourceAcquirer";
+
 export interface ArchiveAcquirer {
   id: string;
   source?: string;
   metadata?: Record<string, unknown>;
+  acquire(source?: string, policy?: Partial<AcquisitionPolicy>): Promise<AcquisitionResult>;
 }
 
 export function createArchiveAcquirer(source?: string): ArchiveAcquirer {
-  return { id: crypto.randomUUID(), source };
+  const delegate = createSourceAcquirer(source);
+  return { ...delegate, id: delegate.id };
 }

--- a/packages/acquisition/RepositoryAcquirer.ts
+++ b/packages/acquisition/RepositoryAcquirer.ts
@@ -6,12 +6,18 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { AcquisitionPolicy } from "./AcquisitionPolicy";
+import type { AcquisitionResult } from "./AcquisitionResult";
+import { createSourceAcquirer } from "./SourceAcquirer";
+
 export interface RepositoryAcquirer {
   id: string;
   source?: string;
   metadata?: Record<string, unknown>;
+  acquire(source?: string, policy?: Partial<AcquisitionPolicy>): Promise<AcquisitionResult>;
 }
 
 export function createRepositoryAcquirer(source?: string): RepositoryAcquirer {
-  return { id: crypto.randomUUID(), source };
+  const delegate = createSourceAcquirer(source);
+  return { ...delegate, id: delegate.id };
 }

--- a/packages/acquisition/SourceAcquirer.ts
+++ b/packages/acquisition/SourceAcquirer.ts
@@ -6,12 +6,79 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import { randomUUID } from "node:crypto";
+import { statSync } from "node:fs";
+import { scanFiles } from "../parser/core/scanFiles";
+import { RemoteRepository } from "../remote/RemoteRepository";
+import type { AcquisitionPolicy } from "./AcquisitionPolicy";
+import { assertSourceAllowed, defaultAcquisitionPolicy, resolveAcquisitionPolicy } from "./AcquisitionPolicy";
+import type { AcquisitionResult } from "./AcquisitionResult";
+import { createSnapshotFromFiles } from "./SourceSnapshot";
+
 export interface SourceAcquirer {
   id: string;
   source?: string;
   metadata?: Record<string, unknown>;
+  acquire(source?: string, policy?: Partial<AcquisitionPolicy>): Promise<AcquisitionResult>;
 }
 
 export function createSourceAcquirer(source?: string): SourceAcquirer {
-  return { id: crypto.randomUUID(), source };
+  const acquirer: SourceAcquirer = {
+    id: randomUUID(),
+    source,
+    async acquire(requestedSource = source, policy = defaultAcquisitionPolicy): Promise<AcquisitionResult> {
+      if (!requestedSource) return { ok: false, errors: ["A source is required."] };
+
+      try {
+        const resolvedPolicy = resolveAcquisitionPolicy(policy);
+        assertSourceAllowed(requestedSource, resolvedPolicy);
+        const remote = isRemoteSource(requestedSource);
+
+        if (remote) {
+          const result = await withTimeout(
+            new RemoteRepository({ id: acquirer.id, url: requestedSource }).analyze(),
+            resolvedPolicy.timeoutMs,
+          );
+          const files = result.repository.getAllModules().map((module) => module.file.relativePath);
+          return { ok: true, errors: [], snapshot: createSnapshotFromFiles(requestedSource, files, result.meta.defaultBranch) };
+        }
+
+        if (!statSync(requestedSource).isDirectory()) {
+          throw new Error("Local acquisition source must be a directory.");
+        }
+        const fileInfo = scanFiles(requestedSource);
+        const totalBytes = fileInfo.reduce((sum, file) => sum + file.sizeBytes, 0);
+        if (totalBytes > resolvedPolicy.maxBytes) {
+          throw new Error(`Source exceeds acquisition limit (${totalBytes} > ${resolvedPolicy.maxBytes} bytes).`);
+        }
+        return {
+          ok: true,
+          errors: [],
+          snapshot: createSnapshotFromFiles(requestedSource, fileInfo.map((file) => file.relativePath)),
+        };
+      } catch (error) {
+        return { ok: false, errors: [error instanceof Error ? error.message : String(error)] };
+      }
+    },
+  };
+  return acquirer;
+}
+
+function isRemoteSource(source: string): boolean {
+  try {
+    const url = new URL(source);
+    return ["http:", "https:", "ssh:", "git:"].includes(url.protocol);
+  } catch { return false; }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Acquisition timed out after ${timeoutMs}ms.`)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/packages/acquisition/SourceSnapshot.ts
+++ b/packages/acquisition/SourceSnapshot.ts
@@ -27,3 +27,11 @@ export function createSourceSnapshot(
     files: [...files],
   };
 }
+
+export function createSnapshotFromFiles(
+  source: string,
+  files: readonly string[],
+  revision?: string,
+): SourceSnapshot {
+  return createSourceSnapshot(source, [...new Set(files)].sort(), revision);
+}

--- a/packages/remote-analysis/RemoteAnalysisRequest.ts
+++ b/packages/remote-analysis/RemoteAnalysisRequest.ts
@@ -6,12 +6,18 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { RemoteSource } from "../remote/RemoteSource";
+
 export interface RemoteAnalysisRequest {
   id: string;
-  source?: string;
+  source?: RemoteSource | string;
+  revision?: string;
   metadata?: Record<string, unknown>;
 }
 
-export function createRemoteAnalysisRequest(source?: string): RemoteAnalysisRequest {
-  return { id: crypto.randomUUID(), source };
+export function createRemoteAnalysisRequest(
+  source?: RemoteSource | string,
+  revision?: string,
+): RemoteAnalysisRequest {
+  return { id: crypto.randomUUID(), source, revision };
 }

--- a/packages/remote-analysis/RemoteAnalysisResult.ts
+++ b/packages/remote-analysis/RemoteAnalysisResult.ts
@@ -6,12 +6,33 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { AnalyzeRepositoryResult } from "../engine/pipeline";
+import type { SecurityAnalysis } from "../security-analysis/SecurityAnalysis";
+import type { RemoteAnalysisRequest } from "./RemoteAnalysisRequest";
+
 export interface RemoteAnalysisResult {
   id: string;
-  source?: string;
+  source?: RemoteAnalysisRequest["source"];
+  ok: boolean;
+  startedAt: string;
+  completedAt: string;
+  analysis?: AnalyzeRepositoryResult;
+  security?: SecurityAnalysis;
+  error?: string;
   metadata?: Record<string, unknown>;
 }
 
-export function createRemoteAnalysisResult(source?: string): RemoteAnalysisResult {
-  return { id: crypto.randomUUID(), source };
+export function createRemoteAnalysisResult(
+  source?: RemoteAnalysisRequest["source"],
+  values: Partial<Omit<RemoteAnalysisResult, "id" | "source">> = {},
+): RemoteAnalysisResult {
+  const now = new Date().toISOString();
+  return {
+    id: crypto.randomUUID(),
+    source,
+    ok: values.ok ?? false,
+    startedAt: values.startedAt ?? now,
+    completedAt: values.completedAt ?? now,
+    ...values,
+  };
 }

--- a/packages/remote-analysis/RemoteAnalysisSession.ts
+++ b/packages/remote-analysis/RemoteAnalysisSession.ts
@@ -6,12 +6,34 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { RemoteAnalysisResult } from "./RemoteAnalysisResult";
+import type { RemoteSource } from "../remote/RemoteSource";
+
+export type RemoteAnalysisStatus = "pending" | "running" | "completed" | "failed";
+
 export interface RemoteAnalysisSession {
   id: string;
-  source?: string;
+  source?: RemoteSource | string;
+  status: RemoteAnalysisStatus;
+  startedAt: string;
+  completedAt?: string;
+  result?: RemoteAnalysisResult;
+  error?: string;
   metadata?: Record<string, unknown>;
 }
 
-export function createRemoteAnalysisSession(source?: string): RemoteAnalysisSession {
-  return { id: crypto.randomUUID(), source };
+export function createRemoteAnalysisSession(source?: RemoteSource | string): RemoteAnalysisSession {
+  return {
+    id: crypto.randomUUID(),
+    source,
+    status: "pending",
+    startedAt: new Date().toISOString(),
+  };
+}
+
+export function updateRemoteAnalysisSession(
+  session: RemoteAnalysisSession,
+  update: Pick<RemoteAnalysisSession, "status"> & Partial<RemoteAnalysisSession>,
+): RemoteAnalysisSession {
+  return { ...session, ...update };
 }

--- a/packages/remote-analysis/RemoteImpactReport.ts
+++ b/packages/remote-analysis/RemoteImpactReport.ts
@@ -6,12 +6,28 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
+import type { SecurityFinding } from "../security-analysis/SecurityFinding";
+
 export interface RemoteImpactReport {
   id: string;
   source?: string;
+  findings: SecurityFinding[];
+  affectedFiles: string[];
+  severity: "none" | "low" | "medium" | "high" | "critical";
   metadata?: Record<string, unknown>;
 }
 
-export function createRemoteImpactReport(source?: string): RemoteImpactReport {
-  return { id: crypto.randomUUID(), source };
+export function createRemoteImpactReport(
+  source?: string,
+  findings: SecurityFinding[] = [],
+): RemoteImpactReport {
+  const affectedFiles = [...new Set(findings.map((finding) => finding.location.filePath))].sort();
+  const severity = findings.reduce<RemoteImpactReport["severity"]>((current, finding) =>
+    severityRank(finding.severity) > severityRank(current) ? finding.severity : current,
+  "none");
+  return { id: crypto.randomUUID(), source, findings: [...findings], affectedFiles, severity };
+}
+
+function severityRank(severity: RemoteImpactReport["severity"]): number {
+  return { none: 0, low: 1, medium: 2, high: 3, critical: 4 }[severity];
 }

--- a/packages/remote-analysis/SourceHealthReport.ts
+++ b/packages/remote-analysis/SourceHealthReport.ts
@@ -9,9 +9,26 @@
 export interface SourceHealthReport {
   id: string;
   source?: string;
+  ok: boolean;
+  files: number;
+  parsedFiles: number;
+  skippedFiles: number;
+  errors: string[];
   metadata?: Record<string, unknown>;
 }
 
-export function createSourceHealthReport(source?: string): SourceHealthReport {
-  return { id: crypto.randomUUID(), source };
+export function createSourceHealthReport(
+  source?: string,
+  values: Partial<Omit<SourceHealthReport, "id" | "source">> = {},
+): SourceHealthReport {
+  return {
+    id: crypto.randomUUID(),
+    source,
+    ok: values.ok ?? false,
+    files: values.files ?? 0,
+    parsedFiles: values.parsedFiles ?? 0,
+    skippedFiles: values.skippedFiles ?? 0,
+    errors: values.errors ?? [],
+    ...values,
+  };
 }

--- a/packages/remote-analysis/analyzeRemoteSource.ts
+++ b/packages/remote-analysis/analyzeRemoteSource.ts
@@ -1,0 +1,25 @@
+import { RemoteRepository } from "../remote/RemoteRepository";
+import type { RemoteSource } from "../remote/RemoteSource";
+import { createRemoteAnalysisResult, type RemoteAnalysisResult } from "./RemoteAnalysisResult";
+
+/** Runs the complete ARCLUX pipeline and preserves both core and security output. */
+export async function analyzeRemoteSource(source: RemoteSource): Promise<RemoteAnalysisResult> {
+  const startedAt = new Date().toISOString();
+  try {
+    const analysis = await new RemoteRepository(source).analyze();
+    return createRemoteAnalysisResult(source, {
+      ok: true,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      analysis,
+      security: analysis.securityAnalysis,
+    });
+  } catch (error) {
+    return createRemoteAnalysisResult(source, {
+      ok: false,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/remote-analysis/index.ts
+++ b/packages/remote-analysis/index.ts
@@ -3,3 +3,4 @@ export * from "./RemoteAnalysisResult";
 export * from "./RemoteAnalysisSession";
 export * from "./RemoteImpactReport";
 export * from "./SourceHealthReport";
+export * from "./analyzeRemoteSource";

--- a/packages/remote/RemoteAccess.ts
+++ b/packages/remote/RemoteAccess.ts
@@ -9,9 +9,23 @@
 export interface RemoteAccess {
   id: string;
   source?: string;
+  allowed: boolean;
+  reason?: string;
   metadata?: Record<string, unknown>;
 }
 
-export function createRemoteAccess(source?: string): RemoteAccess {
-  return { id: crypto.randomUUID(), source };
+export function createRemoteAccess(source?: string, allowedHosts: string[] = []): RemoteAccess {
+  if (!source) return { id: crypto.randomUUID(), source, allowed: false, reason: "A source is required." };
+  try {
+    const host = new URL(source).hostname;
+    const allowed = allowedHosts.length === 0 || allowedHosts.includes(host);
+    return {
+      id: crypto.randomUUID(),
+      source,
+      allowed,
+      reason: allowed ? undefined : `Remote host is not allowed: ${host}`,
+    };
+  } catch {
+    return { id: crypto.randomUUID(), source, allowed: false, reason: "Source is not a valid URL." };
+  }
 }

--- a/packages/remote/RemoteLocator.ts
+++ b/packages/remote/RemoteLocator.ts
@@ -9,9 +9,19 @@
 export interface RemoteLocator {
   id: string;
   source?: string;
+  protocol?: string;
+  host?: string;
+  path?: string;
+  revision?: string;
   metadata?: Record<string, unknown>;
 }
 
-export function createRemoteLocator(source?: string): RemoteLocator {
-  return { id: crypto.randomUUID(), source };
+export function createRemoteLocator(source?: string, revision?: string): RemoteLocator {
+  if (!source) return { id: crypto.randomUUID(), source, revision };
+  try {
+    const url = new URL(source);
+    return { id: crypto.randomUUID(), source, revision, protocol: url.protocol, host: url.hostname, path: url.pathname };
+  } catch {
+    return { id: crypto.randomUUID(), source, revision, path: source };
+  }
 }

--- a/packages/remote/RemoteProvider.ts
+++ b/packages/remote/RemoteProvider.ts
@@ -9,9 +9,26 @@
 export interface RemoteProvider {
   id: string;
   source?: string;
+  name: "github" | "gitlab" | "archive" | "local" | "unknown";
+  supports(source: string): boolean;
   metadata?: Record<string, unknown>;
 }
 
 export function createRemoteProvider(source?: string): RemoteProvider {
-  return { id: crypto.randomUUID(), source };
+  const name = identifyProvider(source);
+  return {
+    id: crypto.randomUUID(),
+    source,
+    name,
+    supports: (candidate) => identifyProvider(candidate) === name,
+  };
+}
+
+function identifyProvider(source?: string): RemoteProvider["name"] {
+  if (!source) return "unknown";
+  if (/github\.com/i.test(source)) return "github";
+  if (/gitlab\.com/i.test(source)) return "gitlab";
+  if (/\.(?:zip|tar|tar\.gz|tgz)(?:$|\?)/i.test(source)) return "archive";
+  if (!/^\w+:\/\//.test(source)) return "local";
+  return "unknown";
 }

--- a/packages/remote/RemoteRevision.ts
+++ b/packages/remote/RemoteRevision.ts
@@ -9,9 +9,16 @@
 export interface RemoteRevision {
   id: string;
   source?: string;
+  value?: string;
+  immutable: boolean;
   metadata?: Record<string, unknown>;
 }
 
-export function createRemoteRevision(source?: string): RemoteRevision {
-  return { id: crypto.randomUUID(), source };
+export function createRemoteRevision(value?: string, source?: string): RemoteRevision {
+  return {
+    id: crypto.randomUUID(),
+    source,
+    value,
+    immutable: value ? /^[0-9a-f]{7,64}$/i.test(value) : false,
+  };
 }

--- a/packages/remote/index.ts
+++ b/packages/remote/index.ts
@@ -11,6 +11,10 @@
 
 export type { RemoteSource } from "./RemoteSource";
 export { RemoteRepository } from "./RemoteRepository";
+export * from "./RemoteAccess";
+export * from "./RemoteLocator";
+export * from "./RemoteProvider";
+export * from "./RemoteRevision";
 export {
   createRemoteSnapshot,
   type RemoteSnapshot,

--- a/tests/remote-layer.test.ts
+++ b/tests/remote-layer.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createSourceAcquirer } from "../packages/acquisition";
+import { createRemoteAccess, createRemoteLocator, createRemoteProvider, createRemoteRevision } from "../packages/remote";
+import { createRemoteImpactReport, createSourceHealthReport } from "../packages/remote-analysis";
+
+describe("remote acquisition contracts", () => {
+  it("rejects remote sources when policy disallows them", async () => {
+    const result = await createSourceAcquirer().acquire("https://github.com/example/repo.git", { allowRemote: false });
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toContain("disabled");
+  });
+
+  it("creates a deterministic, sorted local snapshot", async () => {
+    const result = await createSourceAcquirer("tests/fixtures/security-leaks").acquire();
+    expect(result.ok).toBe(true);
+    expect(result.snapshot?.files).toEqual(["app.ts", "safe.ts"]);
+  });
+});
+
+describe("remote metadata", () => {
+  it("classifies providers and immutable revisions", () => {
+    expect(createRemoteProvider("https://github.com/GSF-001/ARCLUX").name).toBe("github");
+    expect(createRemoteRevision("a1b2c3d").immutable).toBe(true);
+    expect(createRemoteRevision("main").immutable).toBe(false);
+    expect(createRemoteLocator("https://github.com/GSF-001/ARCLUX").host).toBe("github.com");
+  });
+
+  it("enforces host allowlists", () => {
+    expect(createRemoteAccess("https://github.com/GSF-001/ARCLUX", ["gitlab.com"]).allowed).toBe(false);
+  });
+});
+
+describe("remote reports", () => {
+  it("summarizes source health and empty impact safely", () => {
+    expect(createSourceHealthReport("local", { ok: true, files: 2, parsedFiles: 2 }).skippedFiles).toBe(0);
+    expect(createRemoteImpactReport("local").affectedFiles).toEqual([]);
+    expect(createRemoteImpactReport("local").severity).toBe("none");
+  });
+});


### PR DESCRIPTION
## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
