### PR TITLE
Fix/wire remote analysis

### DIFF
--- a/apps/cli/security.ts
+++ b/apps/cli/security.ts
@@ -17,7 +17,9 @@
 
 import type { Command } from "commander";
 import * as p from "@clack/prompts";
-import { analyzeRepository } from "../../packages/engine/pipeline";
+import { createRemoteSource } from "../../packages/remote/RemoteSource";
+import { createRemoteAnalysisRequest } from "../../packages/remote-analysis/RemoteAnalysisRequest";
+import { analyzeRemoteRequest } from "../../packages/remote-analysis/analyzeRemoteSource";
 import { DiskSourceProvider } from "../../packages/security-analysis";
 import { detectSecretExposure } from "../../packages/security-analysis/source/SecretExposureDetector";
 import { detectUnsafePatterns } from "../../packages/security-analysis/source/UnsafePatternDetector";
@@ -41,7 +43,11 @@ export function registerSecurityCommand(program: Command): void {
       spinner.start(`Running security analysis on ${targetPath}`);
 
       try {
-        const result = await analyzeRepository({ localPath: targetPath });
+        const remoteResult = await analyzeRemoteRequest(createRemoteAnalysisRequest(createRemoteSource(targetPath)));
+        if (!remoteResult.ok || !remoteResult.analysis) {
+          throw new Error(remoteResult.error ?? "Remote analysis did not produce a result.");
+        }
+        const result = remoteResult.analysis;
 
         const sources = new DiskSourceProvider(targetPath);
         const findings = [

--- a/packages/acquisition/ArchiveAcquirer.ts
+++ b/packages/acquisition/ArchiveAcquirer.ts
@@ -8,7 +8,15 @@
 
 import type { AcquisitionPolicy } from "./AcquisitionPolicy";
 import type { AcquisitionResult } from "./AcquisitionResult";
-import { createSourceAcquirer } from "./SourceAcquirer";
+import { assertSourceAllowed, resolveAcquisitionPolicy } from "./AcquisitionPolicy";
+import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { lstat, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, normalize, relative, resolve } from "node:path";
+
+const execFileAsync = promisify(execFile);
 
 export interface ArchiveAcquirer {
   id: string;
@@ -18,6 +26,147 @@ export interface ArchiveAcquirer {
 }
 
 export function createArchiveAcquirer(source?: string): ArchiveAcquirer {
-  const delegate = createSourceAcquirer(source);
-  return { ...delegate, id: delegate.id };
+  return {
+    id: randomUUID(),
+    source,
+    metadata: { kind: "archive" },
+    async acquire(requestedSource = source, policy) {
+      if (!requestedSource || !isArchiveSource(requestedSource)) {
+        return {
+          ok: false,
+          errors: ["Archive acquisition requires a .zip, .tar, .tar.gz, or .tgz source."],
+        };
+      }
+
+      const resolvedPolicy = resolveAcquisitionPolicy(policy);
+      let workspace: string | undefined;
+      try {
+        assertSourceAllowed(requestedSource, resolvedPolicy);
+        workspace = await mkdtemp(join(tmpdir(), "arclux-archive-"));
+        const archivePath = await materializeArchive(requestedSource, workspace, resolvedPolicy);
+        const entries = await listEntries(archivePath, archiveFormat(requestedSource));
+        validateEntries(entries);
+
+        const extractedPath = join(workspace, "source");
+        await extractArchive(archivePath, extractedPath, archiveFormat(requestedSource));
+        const files = await collectSafeFiles(extractedPath, resolvedPolicy.maxBytes);
+        const extractedBytes = files.reduce((total, file) => total + file.sizeBytes, 0);
+        if (extractedBytes > resolvedPolicy.maxBytes) {
+          throw new Error(`Extracted archive exceeds acquisition limit (${extractedBytes} > ${resolvedPolicy.maxBytes} bytes).`);
+        }
+
+        return {
+          ok: true,
+          errors: [],
+          snapshot: {
+            id: randomUUID(),
+            source: requestedSource,
+            createdAt: new Date().toISOString(),
+            files: files.map((file) => file.relativePath).sort(),
+          },
+        };
+      } catch (error) {
+        return { ok: false, errors: [error instanceof Error ? error.message : String(error)] };
+      } finally {
+        if (workspace) await rm(workspace, { recursive: true, force: true }).catch(() => undefined);
+      }
+    },
+  };
+}
+
+function isArchiveSource(source: string): boolean {
+  return /\.(?:zip|tar|tar\.gz|tgz)(?:[?#].*)?$/i.test(source);
+}
+
+type ArchiveFormat = "zip" | "tar";
+
+function archiveFormat(source: string): ArchiveFormat {
+  return /\.zip(?:[?#].*)?$/i.test(source) ? "zip" : "tar";
+}
+
+async function materializeArchive(
+  source: string,
+  workspace: string,
+  policy: AcquisitionPolicy,
+): Promise<string> {
+  const archivePath = join(workspace, `archive${archiveFormat(source) === "zip" ? ".zip" : ".tar"}`);
+  if (!/^https?:\/\//i.test(source)) {
+    const info = await stat(source);
+    if (!info.isFile()) throw new Error("Archive source must be a file.");
+    if (info.size > policy.maxBytes) throw new Error(`Archive exceeds acquisition limit (${info.size} > ${policy.maxBytes} bytes).`);
+    await writeFile(archivePath, await readFile(source));
+    return archivePath;
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), policy.timeoutMs);
+  try {
+    const response = await fetch(source, { signal: controller.signal });
+    if (!response.ok) throw new Error(`Archive download failed with HTTP ${response.status}.`);
+    const contentLength = Number(response.headers.get("content-length") ?? 0);
+    if (contentLength > policy.maxBytes) throw new Error(`Archive exceeds acquisition limit (${contentLength} > ${policy.maxBytes} bytes).`);
+    const data = Buffer.from(await response.arrayBuffer());
+    if (data.byteLength > policy.maxBytes) throw new Error(`Archive exceeds acquisition limit (${data.byteLength} > ${policy.maxBytes} bytes).`);
+    await writeFile(archivePath, data);
+    return archivePath;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function listEntries(archivePath: string, format: ArchiveFormat): Promise<string[]> {
+  const args = format === "zip" ? ["-Z1", archivePath] : ["-tf", archivePath];
+  const { stdout } = await execFileAsync(format === "zip" ? "unzip" : "tar", args, { maxBuffer: 10 * 1024 * 1024 });
+  return stdout.split(/\r?\n/).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function validateEntries(entries: string[]): void {
+  for (const entry of entries) {
+    const normalized = normalize(entry.replaceAll("\\", "/"));
+    if (normalized.startsWith("/") || normalized === ".." || normalized.startsWith(`..${normalize("/")}`)) {
+      throw new Error(`Archive contains unsafe path: ${entry}`);
+    }
+  }
+}
+
+async function extractArchive(archivePath: string, destination: string, format: ArchiveFormat): Promise<void> {
+  await mkdir(destination, { recursive: true });
+  const args = format === "zip"
+    ? ["-q", archivePath, "-d", destination]
+    : ["--no-same-owner", "--no-same-permissions", "-xf", archivePath, "-C", destination];
+  await execFileAsync(format === "zip" ? "unzip" : "tar", args, { maxBuffer: 10 * 1024 * 1024 });
+}
+
+interface AcquiredFile {
+  relativePath: string;
+  sizeBytes: number;
+}
+
+async function collectSafeFiles(root: string, maxBytes: number): Promise<AcquiredFile[]> {
+  const rootPath = resolve(root);
+  const files: AcquiredFile[] = [];
+  let totalBytes = 0;
+
+  async function walk(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const absolutePath = resolve(directory, entry.name);
+      const relativePath = relative(rootPath, absolutePath);
+      if (relativePath === "" || relativePath.startsWith("..")) {
+        throw new Error(`Extracted path escaped archive root: ${entry.name}`);
+      }
+      const info = await lstat(absolutePath);
+      if (info.isSymbolicLink()) throw new Error(`Archive contains a symbolic link: ${relativePath}`);
+      if (info.isDirectory()) {
+        await walk(absolutePath);
+        continue;
+      }
+      if (!info.isFile()) continue;
+      totalBytes += info.size;
+      if (totalBytes > maxBytes) throw new Error(`Extracted archive exceeds acquisition limit (${totalBytes} > ${maxBytes} bytes).`);
+      files.push({ relativePath: relativePath.replaceAll("\\", "/"), sizeBytes: info.size });
+    }
+  }
+
+  await walk(rootPath);
+  return files;
 }

--- a/packages/acquisition/RepositoryAcquirer.ts
+++ b/packages/acquisition/RepositoryAcquirer.ts
@@ -9,6 +9,7 @@
 import type { AcquisitionPolicy } from "./AcquisitionPolicy";
 import type { AcquisitionResult } from "./AcquisitionResult";
 import { createSourceAcquirer } from "./SourceAcquirer";
+import { statSync } from "node:fs";
 
 export interface RepositoryAcquirer {
   id: string;
@@ -19,5 +20,28 @@ export interface RepositoryAcquirer {
 
 export function createRepositoryAcquirer(source?: string): RepositoryAcquirer {
   const delegate = createSourceAcquirer(source);
-  return { ...delegate, id: delegate.id };
+  return {
+    id: delegate.id,
+    source,
+    metadata: { kind: "repository" },
+    async acquire(requestedSource = source, policy) {
+      if (!requestedSource || !isRepositorySource(requestedSource)) {
+        return { ok: false, errors: ["Repository acquisition requires a git URL or local directory."] };
+      }
+      return delegate.acquire(requestedSource, policy);
+    },
+  };
+}
+
+function isRepositorySource(source: string): boolean {
+  try {
+    const url = new URL(source);
+    return ["http:", "https:", "ssh:", "git:"].includes(url.protocol);
+  } catch {
+    try {
+      return statSync(source).isDirectory();
+    } catch {
+      return false;
+    }
+  }
 }

--- a/packages/remote-analysis/RemoteAnalysisRequest.ts
+++ b/packages/remote-analysis/RemoteAnalysisRequest.ts
@@ -19,5 +19,11 @@ export function createRemoteAnalysisRequest(
   source?: RemoteSource | string,
   revision?: string,
 ): RemoteAnalysisRequest {
-  return { id: crypto.randomUUID(), source, revision };
+  if (typeof source === "string" && source.trim() === "") {
+    throw new Error("Remote analysis source cannot be empty.");
+  }
+  if (revision !== undefined && revision.trim() === "") {
+    throw new Error("Remote analysis revision cannot be empty.");
+  }
+  return { id: crypto.randomUUID(), source, revision, metadata: { requestedAt: new Date().toISOString() } };
 }

--- a/packages/remote-analysis/RemoteAnalysisResult.ts
+++ b/packages/remote-analysis/RemoteAnalysisResult.ts
@@ -9,6 +9,9 @@
 import type { AnalyzeRepositoryResult } from "../engine/pipeline";
 import type { SecurityAnalysis } from "../security-analysis/SecurityAnalysis";
 import type { RemoteAnalysisRequest } from "./RemoteAnalysisRequest";
+import type { SourceSnapshot } from "../acquisition/SourceSnapshot";
+import type { RemoteImpactReport } from "./RemoteImpactReport";
+import type { SourceHealthReport } from "./SourceHealthReport";
 
 export interface RemoteAnalysisResult {
   id: string;
@@ -18,6 +21,9 @@ export interface RemoteAnalysisResult {
   completedAt: string;
   analysis?: AnalyzeRepositoryResult;
   security?: SecurityAnalysis;
+  snapshot?: SourceSnapshot;
+  health?: SourceHealthReport;
+  impact?: RemoteImpactReport;
   error?: string;
   metadata?: Record<string, unknown>;
 }

--- a/packages/remote-analysis/RemoteAnalysisSession.ts
+++ b/packages/remote-analysis/RemoteAnalysisSession.ts
@@ -35,5 +35,15 @@ export function updateRemoteAnalysisSession(
   session: RemoteAnalysisSession,
   update: Pick<RemoteAnalysisSession, "status"> & Partial<RemoteAnalysisSession>,
 ): RemoteAnalysisSession {
+  if (!canTransition(session.status, update.status)) {
+    throw new Error(`Invalid remote analysis transition: ${session.status} -> ${update.status}.`);
+  }
   return { ...session, ...update };
+}
+
+function canTransition(from: RemoteAnalysisStatus, to: RemoteAnalysisStatus): boolean {
+  if (from === to) return true;
+  if (from === "pending") return to === "running" || to === "failed";
+  if (from === "running") return to === "completed" || to === "failed";
+  return false;
 }

--- a/packages/remote-analysis/analyzeRemoteSource.ts
+++ b/packages/remote-analysis/analyzeRemoteSource.ts
@@ -1,18 +1,45 @@
 import { RemoteRepository } from "../remote/RemoteRepository";
 import type { RemoteSource } from "../remote/RemoteSource";
+import { createRemoteSource } from "../remote/RemoteSource";
+import { createSourceAcquirer } from "../acquisition/SourceAcquirer";
+import { createSnapshotFromFiles } from "../acquisition/SourceSnapshot";
+import { createRemoteImpactReport } from "./RemoteImpactReport";
+import { createSourceHealthReport } from "./SourceHealthReport";
 import { createRemoteAnalysisResult, type RemoteAnalysisResult } from "./RemoteAnalysisResult";
+import type { RemoteAnalysisRequest } from "./RemoteAnalysisRequest";
+import { createRemoteAnalysisSession, updateRemoteAnalysisSession } from "./RemoteAnalysisSession";
 
 /** Runs the complete ARCLUX pipeline and preserves both core and security output. */
 export async function analyzeRemoteSource(source: RemoteSource): Promise<RemoteAnalysisResult> {
   const startedAt = new Date().toISOString();
   try {
+    const acquisition = source.localPath
+      ? await createSourceAcquirer(source.localPath).acquire()
+      : undefined;
+    if (acquisition && !acquisition.ok) {
+      throw new Error(acquisition.errors.join("; "));
+    }
+    const snapshot = acquisition?.snapshot;
     const analysis = await new RemoteRepository(source).analyze();
+    const analyzedSnapshot = snapshot ?? createSnapshotFromFiles(
+      source.url ?? source.localPath ?? source.id,
+      analysis.repository.getAllModules().map((module) => module.file.relativePath),
+      analysis.meta.defaultBranch,
+    );
     return createRemoteAnalysisResult(source, {
       ok: true,
       startedAt,
       completedAt: new Date().toISOString(),
       analysis,
       security: analysis.securityAnalysis,
+      snapshot: analyzedSnapshot,
+      health: createSourceHealthReport(analyzedSnapshot.source, {
+        ok: true,
+        files: analysis.scanSummary.filesScanned,
+        parsedFiles: analysis.scanSummary.filesParsed,
+        skippedFiles: analysis.scanSummary.filesSkippedNoParser,
+      }),
+      impact: createRemoteImpactReport(analyzedSnapshot.source, analysis.securityAnalysis?.findings ?? []),
     });
   } catch (error) {
     return createRemoteAnalysisResult(source, {
@@ -22,4 +49,20 @@ export async function analyzeRemoteSource(source: RemoteSource): Promise<RemoteA
       error: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+export async function analyzeRemoteRequest(request: RemoteAnalysisRequest): Promise<RemoteAnalysisResult> {
+  if (!request.source) {
+    return createRemoteAnalysisResult(undefined, { ok: false, error: "A remote analysis source is required." });
+  }
+
+  const source = typeof request.source === "string" ? createRemoteSource(request.source) : request.source;
+  let session = createRemoteAnalysisSession(source);
+  session = updateRemoteAnalysisSession(session, { status: "running" });
+  const result = await analyzeRemoteSource(source);
+  session = updateRemoteAnalysisSession(session, { status: result.ok ? "completed" : "failed", result });
+  return {
+    ...result,
+    metadata: { ...result.metadata, requestId: request.id, sessionId: session.id, sessionStatus: session.status },
+  };
 }

--- a/packages/remote/RemoteSource.ts
+++ b/packages/remote/RemoteSource.ts
@@ -10,6 +10,9 @@
 // a bare clone. Mirrors engine/pipeline.ts's AnalyzeRepositoryOptions
 // contract (repoUrl XOR localPath) and adds attack-surface configuration.
 
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+
 export interface RemoteSource {
   /** Stable caller-supplied id, e.g. "repo:gsf-001/arclux". */
   id: string;
@@ -25,4 +28,17 @@ export interface RemoteSource {
    * whose entry convention detectEntryPoints doesn't know).
    */
   extraEntryPaths?: string[];
+}
+
+export function createRemoteSource(
+  source: string,
+  options: Omit<RemoteSource, "id" | "url" | "localPath"> = {},
+): RemoteSource {
+  if (!source.trim()) throw new Error("Remote source cannot be empty.");
+  const remote = /^(?:https?|ssh|git):\/\//i.test(source) || /^(?:git@|github:|gitlab:)/i.test(source);
+  return {
+    id: randomUUID(),
+    ...(remote ? { url: source } : { localPath: resolve(source) }),
+    ...options,
+  };
 }

--- a/tests/remote-layer.test.ts
+++ b/tests/remote-layer.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { createSourceAcquirer } from "../packages/acquisition";
+import { createArchiveAcquirer, createRepositoryAcquirer, createSourceAcquirer } from "../packages/acquisition";
 import { createRemoteAccess, createRemoteLocator, createRemoteProvider, createRemoteRevision } from "../packages/remote";
 import { createRemoteImpactReport, createSourceHealthReport } from "../packages/remote-analysis";
+import { analyzeRemoteRequest } from "../packages/remote-analysis/analyzeRemoteSource";
+import { createRemoteAnalysisRequest } from "../packages/remote-analysis/RemoteAnalysisRequest";
 
 describe("remote acquisition contracts", () => {
   it("rejects remote sources when policy disallows them", async () => {
@@ -14,6 +16,11 @@ describe("remote acquisition contracts", () => {
     const result = await createSourceAcquirer("tests/fixtures/security-leaks").acquire();
     expect(result.ok).toBe(true);
     expect(result.snapshot?.files).toEqual(["app.ts", "safe.ts"]);
+  });
+
+  it("keeps repository and archive acquirers honest about their inputs", async () => {
+    expect((await createRepositoryAcquirer().acquire("not-a-repository")).ok).toBe(false);
+    expect((await createArchiveAcquirer().acquire("not-an-archive" as string)).ok).toBe(false);
   });
 });
 
@@ -35,5 +42,11 @@ describe("remote reports", () => {
     expect(createSourceHealthReport("local", { ok: true, files: 2, parsedFiles: 2 }).skippedFiles).toBe(0);
     expect(createRemoteImpactReport("local").affectedFiles).toEqual([]);
     expect(createRemoteImpactReport("local").severity).toBe("none");
+  });
+
+  it("returns a correlated failure for a missing analysis source", async () => {
+    const result = await analyzeRemoteRequest(createRemoteAnalysisRequest());
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("source is required");
   });
 });


### PR DESCRIPTION
## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
