### PR TITLE
fix: Windows drive-letter paths in security CLI + Python package-manager detection

### DIFF
--- a/packages/acquisition/AcquisitionPolicy.ts
+++ b/packages/acquisition/AcquisitionPolicy.ts
@@ -33,7 +33,22 @@ export function resolveAcquisitionPolicy(
   return { ...resolved, allowedHosts: [...resolved.allowedHosts] };
 }
 
+const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
+const POSIX_ABSOLUTE_RE = /^\//;
+const UNC_RE = /^\\\\/;
+
+/**
+ * True для абсолютных локальных путей (C:\…, /home/…, \\\\server\share).
+ * Node's `new URL("D:/foo")` парсит "D:" как схему БЕЗ исключения — такие пути
+ * нельзя доверять URL-парсеру при классификации source (см. RepositoryAcquirer).
+ */
+export function isAbsoluteLocalPath(source: string): boolean {
+  return WINDOWS_DRIVE_RE.test(source) || POSIX_ABSOLUTE_RE.test(source) || UNC_RE.test(source);
+}
+
 export function assertSourceAllowed(source: string, policy: AcquisitionPolicy): void {
+  // Локальный источник — политика remote (allowRemote/hosts) не применима.
+  if (isAbsoluteLocalPath(source)) return;
   let url: URL;
   try {
     url = new URL(source);

--- a/packages/acquisition/RepositoryAcquirer.ts
+++ b/packages/acquisition/RepositoryAcquirer.ts
@@ -7,6 +7,7 @@
 //     http://www.apache.org/licenses/LICENSE-2.0
 
 import type { AcquisitionPolicy } from "./AcquisitionPolicy";
+import { isAbsoluteLocalPath } from "./AcquisitionPolicy";
 import type { AcquisitionResult } from "./AcquisitionResult";
 import { createSourceAcquirer } from "./SourceAcquirer";
 import { statSync } from "node:fs";
@@ -34,14 +35,23 @@ export function createRepositoryAcquirer(source?: string): RepositoryAcquirer {
 }
 
 function isRepositorySource(source: string): boolean {
+  // Node's URL parser accepts "D:/foo" WITHOUT throwing (protocol === "d:"),
+  // so Windows drive-letter paths never reach the statSync fallback below.
+  if (isAbsoluteLocalPath(source)) {
+    return isLocalDirectory(source);
+  }
   try {
     const url = new URL(source);
     return ["http:", "https:", "ssh:", "git:"].includes(url.protocol);
   } catch {
-    try {
-      return statSync(source).isDirectory();
-    } catch {
-      return false;
-    }
+    return isLocalDirectory(source);
+  }
+}
+
+function isLocalDirectory(source: string): boolean {
+  try {
+    return statSync(source).isDirectory();
+  } catch {
+    return false;
   }
 }

--- a/packages/acquisition/SourceAcquirer.ts
+++ b/packages/acquisition/SourceAcquirer.ts
@@ -11,7 +11,7 @@ import { statSync } from "node:fs";
 import { scanFiles } from "../parser/core/scanFiles";
 import { RemoteRepository } from "../remote/RemoteRepository";
 import type { AcquisitionPolicy } from "./AcquisitionPolicy";
-import { assertSourceAllowed, defaultAcquisitionPolicy, resolveAcquisitionPolicy } from "./AcquisitionPolicy";
+import { assertSourceAllowed, defaultAcquisitionPolicy, isAbsoluteLocalPath, resolveAcquisitionPolicy } from "./AcquisitionPolicy";
 import type { AcquisitionResult } from "./AcquisitionResult";
 import { createSnapshotFromFiles } from "./SourceSnapshot";
 
@@ -65,6 +65,7 @@ export function createSourceAcquirer(source?: string): SourceAcquirer {
 }
 
 function isRemoteSource(source: string): boolean {
+  if (isAbsoluteLocalPath(source)) return false;
   try {
     const url = new URL(source);
     return ["http:", "https:", "ssh:", "git:"].includes(url.protocol);

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -28,7 +28,7 @@ export interface RepoRecord {
   defaultBranch: string;
   rootPath: string;
   detectedFrameworks: string[];
-  packageManager: "npm" | "pnpm" | "yarn" | "unknown";
+  packageManager: "npm" | "pnpm" | "yarn" | "poetry" | "uv" | "pipenv" | "pdm" | "pip" | "unknown";
   analyzedAt: string;
 }
 

--- a/packages/engine/detectRepositoryMeta.ts
+++ b/packages/engine/detectRepositoryMeta.ts
@@ -35,7 +35,14 @@ const LOCKFILE_MARKERS: Array<{ filename: string; packageManager: RepositoryMeta
   { filename: "pnpm-lock.yaml", packageManager: "pnpm" },
   { filename: "yarn.lock", packageManager: "yarn" },
   { filename: "package-lock.json", packageManager: "npm" },
+  { filename: "poetry.lock", packageManager: "poetry" },
+  { filename: "uv.lock", packageManager: "uv" },
+  { filename: "Pipfile.lock", packageManager: "pipenv" },
+  { filename: "pdm.lock", packageManager: "pdm" },
 ];
+
+// Python-манифесты без lockfile — признак pip-установки (requirements/pyproject).
+const PYTHON_MANIFEST_FALLBACKS = ["requirements.txt", "pyproject.toml"] as const;
 
 interface PackageJsonShape {
   dependencies?: Record<string, string>;
@@ -125,15 +132,20 @@ export function detectFrameworks(rootPath: string): string[] {
 
 /**
  * Detects the package manager a repo uses by checking for its lockfile at the
- * repo root. Checked in order pnpm -> yarn -> npm since a repo might have a
- * stray lockfile left over from switching tools; the first match wins.
- * Returns "unknown" if no recognized lockfile is present.
+ * repo root. Checked in order pnpm -> yarn -> npm -> poetry -> uv -> pipenv -> pdm
+ * since a repo might have a stray lockfile left over from switching tools; the
+ * first match wins. Python repos without a lockfile fall back to "pip" when
+ * requirements.txt or pyproject.toml is present. Returns "unknown" otherwise.
  */
 export function detectPackageManager(rootPath: string): RepositoryMeta["packageManager"] {
   for (const marker of LOCKFILE_MARKERS) {
     if (existsSync(join(rootPath, marker.filename))) {
       return marker.packageManager;
     }
+  }
+
+  if (PYTHON_MANIFEST_FALLBACKS.some((filename) => existsSync(join(rootPath, filename)))) {
+    return "pip";
   }
 
   return "unknown";

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -160,7 +160,7 @@ export interface RepositoryMeta {
   defaultBranch: string;
   rootPath: string;
   detectedFrameworks: string[]; // e.g. ["nextjs", "react"]
-  packageManager: "npm" | "pnpm" | "yarn" | "unknown";
+  packageManager: "npm" | "pnpm" | "yarn" | "poetry" | "uv" | "pipenv" | "pdm" | "pip" | "unknown";
   analyzedAt: string; // ISO timestamp
 }
 

--- a/tests/detect-repository-meta.test.ts
+++ b/tests/detect-repository-meta.test.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 ARCLUX
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { detectPackageManager } from "../packages/engine/detectRepositoryMeta";
+
+function repoWith(files: string[]): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "arclux-pm-"));
+  for (const f of files) {
+    const p = path.join(dir, f);
+    mkdirSync(path.dirname(p), { recursive: true });
+    writeFileSync(p, "");
+  }
+  return dir;
+}
+
+describe("detectPackageManager", () => {
+  it("detects JS/TS lockfiles", () => {
+    expect(detectPackageManager(repoWith(["pnpm-lock.yaml"]))).toBe("pnpm");
+    expect(detectPackageManager(repoWith(["yarn.lock"]))).toBe("yarn");
+    expect(detectPackageManager(repoWith(["package-lock.json"]))).toBe("npm");
+  });
+
+  it("detects Python lockfiles", () => {
+    expect(detectPackageManager(repoWith(["poetry.lock"]))).toBe("poetry");
+    expect(detectPackageManager(repoWith(["uv.lock"]))).toBe("uv");
+    expect(detectPackageManager(repoWith(["Pipfile.lock"]))).toBe("pipenv");
+    expect(detectPackageManager(repoWith(["pdm.lock"]))).toBe("pdm");
+  });
+
+  it("falls back to pip for Python manifests without a lockfile", () => {
+    expect(detectPackageManager(repoWith(["requirements.txt"]))).toBe("pip");
+    expect(detectPackageManager(repoWith(["pyproject.toml"]))).toBe("pip");
+  });
+
+  it("prefers pnpm over a stray Python lockfile", () => {
+    expect(detectPackageManager(repoWith(["pnpm-lock.yaml", "poetry.lock"]))).toBe("pnpm");
+  });
+
+  it("returns unknown for a bare repo", () => {
+    expect(detectPackageManager(repoWith([]))).toBe("unknown");
+  });
+});

--- a/tests/remote-layer.test.ts
+++ b/tests/remote-layer.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { createArchiveAcquirer, createRepositoryAcquirer, createSourceAcquirer } from "../packages/acquisition";
 import { createRemoteAccess, createRemoteLocator, createRemoteProvider, createRemoteRevision } from "../packages/remote";
 import { createRemoteImpactReport, createSourceHealthReport } from "../packages/remote-analysis";
@@ -21,6 +24,20 @@ describe("remote acquisition contracts", () => {
   it("keeps repository and archive acquirers honest about their inputs", async () => {
     expect((await createRepositoryAcquirer().acquire("not-a-repository")).ok).toBe(false);
     expect((await createArchiveAcquirer().acquire("not-an-archive" as string)).ok).toBe(false);
+  });
+
+  it("accepts an absolute local directory path (Windows drive-letter form included)", async () => {
+    // Regression: Node's `new URL("D:/...")` yields protocol "d:" without throwing,
+    // so Windows drive-letter paths never hit the statSync fallback — the
+    // `security` CLI command rejected every local Windows path. On POSIX the
+    // tmp path has no scheme and falls back to statSync as before.
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "arclux-acq-"));
+    try {
+      const result = await createRepositoryAcquirer().acquire(tmpDir);
+      expect(result.ok).toBe(true);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Fixes: security CLI on Windows drive-letter paths (KI-064) + Python package-manager detection (poetry/uv/pipenv/pdm/pip) in config/analyze. Tests: 579/579, typecheck 0, lint 0. See commits bbbe90e, 7d7cefa.