### PR TITLE
fix(acquisition): allowedHosts empty must deny-all, not skip host check

### DIFF
--- a/packages/acquisition/AcquisitionPolicy.ts
+++ b/packages/acquisition/AcquisitionPolicy.ts
@@ -60,7 +60,10 @@ export function assertSourceAllowed(source: string, policy: AcquisitionPolicy): 
   if (!["http:", "https:", "ssh:", "git:", "ftp:"].includes(url.protocol)) {
     throw new Error(`Remote protocol is not allowed: ${url.protocol}`);
   }
-  if (policy.allowedHosts.length > 0 && !policy.allowedHosts.includes(url.hostname)) {
+  // allowedHosts empty by default = deny-all for remote hosts, NOT
+  // unrestricted. Callers MUST explicitly populate allowedHosts before
+  // any remote acquisition is permitted.
+  if (!policy.allowedHosts.includes(url.hostname)) {
     throw new Error(`Remote host is not allowed: ${url.hostname}`);
   }
 }


### PR DESCRIPTION
Previously, an empty allowedHosts array caused assertSourceAllowed() to skip the host check entirely, allowing remote acquisition from ANY host. This is an SSRF-class risk: a user running arclux security against a URL with no explicit allowedHosts configured could have requests directed at internal network services or cloud metadata endpoints without their awareness. Empty allowedHosts now correctly means deny-all for remote sources — callers must explicitly populate the whitelist before any remote host is permitted.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
