### PR TITLE
feat: route daemon re-analysis through JobScheduler (workqueue max_active pattern)

### DIFF
--- a/packages/daemon/DaemonRepositoryWatcher.ts
+++ b/packages/daemon/DaemonRepositoryWatcher.ts
@@ -11,16 +11,54 @@
 // decisions entry). Does not change watchRepository.ts's behavior --
 // wraps it, calling getAnalysis() once per flushed change batch so
 // consumers (daemon, future IDE bridge) can subscribe instead of polling.
+//
+// Every analysis trigger runs through a JobScheduler (packages/scheduler,
+// pattern-ported from Linux kernel/workqueue.c) instead of firing
+// directly:
+//
+//   - Coalescing ("already pending work is not requeued" -- queue_work()
+//     in workqueue.c): a change batch that arrives while an analysis job
+//     is already waiting does NOT schedule a second one. getAnalysis()
+//     is state-based (revision token in watchRepository.ts), so the
+//     pending job reads the newest state when it actually runs -- N
+//     change batches collapse into one re-analysis.
+//   - max_active=1 (workqueue's max_active): at most one full re-index
+//     runs at a time. Without this, a change batch arriving mid-analysis
+//     (or a GET /analysis poll during a re-index) starts a SECOND,
+//     overlapping buildIndex() -- duplicate work on the hot path.
+//   - ordered (workqueue's "ordered" attrs): queued analyses run in
+//     FIFO order, so a re-analysis triggered during an in-flight one
+//     always sees the newest state rather than racing it.
+//
+// The Linux concepts deliberately NOT ported: per-CPU worker pools, NUMA
+// affinity, work_struct bit packing -- single-process Node scheduler has
+// none of those problems (see JobScheduler.ts's header for the same call).
 
 import { EventEmitter } from "node:events";
 import { watchRepository, type RepositoryWatcher } from "../watcher/watchRepository";
 import { watchFilesystem, type FilesystemWatcher } from "../watcher/watchFilesystem";
 import { createChangeQueue, type ChangeQueue } from "../watcher/changeQueue";
+import { JobScheduler } from "../scheduler/JobScheduler";
+import { createJob } from "../scheduler/Job";
+import { JobStatus } from "../scheduler/JobState";
 import type { AnalyzeRepositoryResult } from "../engine/pipeline";
 
 export interface DaemonRepositoryEvents {
   "analysis:updated": [AnalyzeRepositoryResult];
   "analysis:error": [Error];
+}
+
+export interface DaemonRepositoryWatcherOptions {
+  /**
+   * Injectable for tests; defaults to watchRepository(rootPath). The
+   * scheduler wrapping is identical either way.
+   */
+  inner?: RepositoryWatcher;
+  /**
+   * Cap on concurrent analyses, mirrors workqueue's max_active. Defaults
+   * to 1 -- full re-indexes must never overlap.
+   */
+  maxActive?: number;
 }
 
 /**
@@ -29,22 +67,22 @@ export interface DaemonRepositoryEvents {
  * requiring the caller to poll getAnalysis(). Runs a SECOND watcher on the
  * same rootPath rather than modifying watchRepository.ts itself, keeping
  * that module's pull-only contract intact for existing callers (e.g. the
- * `work` command) while this one adds push on top.
+ * `work` command) while this one adds push on top. All analysis work is
+ * serialized + coalesced through a JobScheduler -- see the header comment.
  */
 export class DaemonRepositoryWatcher extends EventEmitter {
   private readonly inner: RepositoryWatcher;
+  private readonly scheduler: JobScheduler;
   private readonly pushFsWatcher: FilesystemWatcher;
   private readonly pushQueue: ChangeQueue;
 
-  constructor(private readonly rootPath: string) {
+  constructor(private readonly rootPath: string, options: DaemonRepositoryWatcherOptions = {}) {
     super();
-    this.inner = watchRepository(rootPath);
+    this.inner = options.inner ?? watchRepository(rootPath);
+    this.scheduler = new JobScheduler({ maxActive: options.maxActive ?? 1, ordered: true });
 
     this.pushQueue = createChangeQueue(() => {
-      this.inner
-        .getAnalysis()
-        .then((result) => this.emit("analysis:updated", result))
-        .catch((err) => this.emit("analysis:error", err instanceof Error ? err : new Error(String(err))));
+      this.scheduleAnalysis();
     });
 
     this.pushFsWatcher = watchFilesystem(rootPath, (event) => {
@@ -52,9 +90,58 @@ export class DaemonRepositoryWatcher extends EventEmitter {
     });
   }
 
-  /** Same as RepositoryWatcher.getAnalysis() -- for a caller that wants an immediate read without waiting for the next push event. */
+  /**
+   * Coalesced re-analysis, one per change burst (workqueue pattern:
+   * queue_work() returns false when the work item is already pending).
+   * If an analysis job is already waiting in the scheduler, a new change
+   * batch does NOT schedule another one -- the pending job picks up the
+   * newest state when it runs. Public so callers (the daemon bridge, a
+   * future "re-analyze now" endpoint) can trigger the same coalesced path
+   * programmatically instead of hand-subscribing to the scheduler.
+   */
+  scheduleAnalysis(): void {
+    const states = this.scheduler.list();
+    const alreadyPending = states.some(
+      (s) => s.status === JobStatus.PENDING || s.status === JobStatus.DELAYED
+    );
+    if (alreadyPending) return;
+
+    const job = createJob({
+      name: `re-analyze:${this.rootPath}`,
+      run: async () => {
+        try {
+          const result = await this.inner.getAnalysis();
+          this.emit("analysis:updated", result);
+        } catch (err) {
+          this.emit("analysis:error", err instanceof Error ? err : new Error(String(err)));
+        }
+      },
+    });
+    this.scheduler.schedule(job);
+  }
+
+  /**
+   * Same as RepositoryWatcher.getAnalysis() -- returns the current
+   * analysis, running it only if the tree changed. Routed through the
+   * scheduler so the max_active=1 cap is actually enforced: a poll that
+   * arrives mid-re-index waits for the in-flight analysis instead of
+   * starting an overlapping second one.
+   */
   getAnalysis(): Promise<AnalyzeRepositoryResult> {
-    return this.inner.getAnalysis();
+    return new Promise((resolve, reject) => {
+      this.scheduler.schedule(
+        createJob({
+          name: `get-analysis:${this.rootPath}`,
+          run: async () => {
+            try {
+              resolve(await this.inner.getAnalysis());
+            } catch (err) {
+              reject(err instanceof Error ? err : new Error(String(err)));
+            }
+          },
+        })
+      );
+    });
   }
 
   async close(): Promise<void> {

--- a/packages/scheduler/JobScheduler.ts
+++ b/packages/scheduler/JobScheduler.ts
@@ -26,6 +26,7 @@ export class JobScheduler {
   private readonly maxActive: number;
   private states = new Map<string, JobStateEntry>();
   private runningCount = 0;
+  private drainTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(options: JobSchedulerOptions = {}) {
     this.queue = new JobQueue({ ordered: options.ordered });
@@ -47,12 +48,37 @@ export class JobScheduler {
     return [...this.states.values()];
   }
 
-  /** Pulls runnable jobs off the queue until maxActive is reached or the queue is empty. */
+  /**
+   * Pulls runnable jobs off the queue until maxActive is reached or the
+   * queue is empty. Mirrors workqueue's worker pool waking: schedule() and
+   * job completion both call this, and — the piece that was missing — if
+   * only DELAYED jobs remain (notBefore in the future), a timer is armed
+   * for the earliest notBefore so drain() runs again the moment that job
+   * becomes runnable. Without it, a delayed job queued while no slot was
+   * free would sit in the queue forever: nothing ever re-triggers drain()
+   * once its delay expires (delayed_work in workqueue.h has the same
+   * "wake at expiry" contract, via the timer wheel instead of setTimeout).
+   */
   private drain(): void {
+    if (this.drainTimer) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = undefined;
+    }
+
     while (this.runningCount < this.maxActive) {
       const job = this.queue.dequeue();
       if (!job) break;
       this.runJob(job);
+    }
+
+    const now = Date.now();
+    const nextWake = this.queue
+      .peekAll()
+      .map((j) => j.notBefore ?? 0)
+      .filter((t) => t > now)
+      .sort((a, b) => a - b)[0];
+    if (nextWake !== undefined) {
+      this.drainTimer = setTimeout(() => this.drain(), nextWake - now);
     }
   }
 

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -812,3 +812,9 @@ NetworkRegistry.ts (lists all registered daemon endpoints from ~/.arclux/endpoin
 **Status:** Done
 
 New extension packages per approved plan (docs/SECURITY_ANALYSIS_PLAN.md): packages/provenance (SourceOrigin/EvidenceOrigin/ProvenanceRecord), packages/remote (RemoteSource/RemoteRepository/RemoteSnapshot), packages/security-analysis (source/ detectors: secrets gitleaks-model, unsafe patterns Semgrep-model, sensitive-data-flow CodeQL-inspired; architecture/: trust boundary, cross-boundary, impact; reporting/: SecurityReport + SARIF 2.1.0 export + remediation templates), packages/correlation (AttackSurfaceMapper BFS validated by experiment, Finding/Evidence/ImpactCorrelator, ImpactSnapshot). Core engine untouched; consumes Repository/DependencyGraph via analyzeRepository. suite 551/551.
+
+## 2026-08-18 — Daemon re-analysis routed through JobScheduler (workqueue max_active pattern)
+
+**Status:** Done
+
+DaemonRepositoryWatcher now routes every analysis trigger through packages/scheduler's JobScheduler (maxActive=1, ordered): change bursts coalesce (already-pending work is not requeued, mirroring kernel/workqueue.c queue_work), analyses never overlap, and direct getAnalysis() polls serialize behind an in-flight re-index. Also fixed a latent JobScheduler gap found while wiring: a delayed job (notBefore/delayMs) sat in the queue forever because nothing re-triggered drain() after its delay expired -- drain() now arms a timer for the earliest notBefore. First production consumer for packages/scheduler. Tests: tests/daemon-scheduler.test.ts (7 cases), full suite 580/580 green, typecheck clean.

--- a/tests/daemon-scheduler.test.ts
+++ b/tests/daemon-scheduler.test.ts
@@ -1,0 +1,278 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for the scheduler→daemon wiring (issue: daemon re-analysis hammer).
+// Covers the two halves of the change:
+//   1. JobScheduler's delayed-drain gap fix — a delayed job (delayMs /
+//      notBefore) now actually runs once its delay expires, instead of
+//      sitting in the queue forever because nothing re-triggers drain().
+//   2. DaemonRepositoryWatcher routing every analysis trigger through the
+//      scheduler: change bursts coalesce (workqueue "already pending"),
+//      analyses never overlap (max_active=1), and direct getAnalysis()
+//      polls serialize behind an in-flight re-index instead of duplicating
+//      it.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { EventEmitter } from "node:events";
+import { JobScheduler } from "../packages/scheduler/JobScheduler";
+import { createJob } from "../packages/scheduler/Job";
+import { JobStatus } from "../packages/scheduler/JobState";
+import { DaemonRepositoryWatcher } from "../packages/daemon/DaemonRepositoryWatcher";
+import type { RepositoryWatcher } from "../packages/watcher/watchRepository";
+import type { AnalyzeRepositoryResult } from "../packages/engine/pipeline";
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+const RESULT = { moduleCount: 1, meta: { id: "fake" } } as unknown as AnalyzeRepositoryResult;
+
+interface FakeInner extends RepositoryWatcher {
+  calls(): number;
+  maxOverlap(): number;
+  parkedCount(): number;
+  releaseNext(): void;
+  releaseAll(): void;
+  close: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Controllable stand-in for watchRepository(). In auto mode (gated:
+ * false) every getAnalysis() resolves immediately; in gated mode each
+ * call parks on a promise the test releases, so tests can hold an
+ * analysis in-flight and observe what happens while it runs.
+ */
+function createFakeInner(gated = false): FakeInner {
+  let callCount = 0;
+  let inFlight = 0;
+  let peakOverlap = 0;
+  const parked: Array<() => void> = [];
+
+  return {
+    getAnalysis(): Promise<AnalyzeRepositoryResult> {
+      callCount += 1;
+      inFlight += 1;
+      peakOverlap = Math.max(peakOverlap, inFlight);
+      return new Promise((resolve) => {
+        const finish = () => {
+          inFlight -= 1;
+          resolve(RESULT);
+        };
+        if (gated) parked.push(finish);
+        else finish();
+      });
+    },
+    calls: () => callCount,
+    maxOverlap: () => peakOverlap,
+    parkedCount: () => parked.length,
+    releaseNext: () => parked.shift()?.(),
+    releaseAll: () => {
+      while (parked.length) parked.shift()!();
+    },
+    close: vi.fn(async () => {}),
+  };
+}
+
+/**
+ * Releases every parked analysis as it appears until none remain. Needed
+ * because gated analyses chain: releasing job N lets the scheduler start
+ * job N+1, which parks again — so "release what is parked right now" must
+ * loop with microtask yields in between.
+ */
+async function releaseUntilIdle(inner: FakeInner): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    if (inner.parkedCount() === 0) break;
+    inner.releaseAll();
+    await new Promise((r) => setImmediate(r));
+  }
+}
+
+function waitForEvents(emitter: EventEmitter, event: string, count: number, timeoutMs = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let seen = 0;
+    const timer = setTimeout(
+      () => reject(new Error(`timed out waiting for ${count} "${event}" event(s)`)),
+      timeoutMs
+    );
+    emitter.on(event, () => {
+      seen += 1;
+      if (seen === count) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  });
+}
+
+// ── JobScheduler: delayed jobs must eventually run ───────────────────
+
+describe("JobScheduler delayed-drain gap", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("runs a delayed job once its notBefore passes, without any other schedule() call", async () => {
+    const scheduler = new JobScheduler({ maxActive: 1 });
+    const runs: string[] = [];
+
+    const job = createJob({
+      name: "deferred",
+      delayMs: 500,
+      run: async () => {
+        runs.push("deferred");
+      },
+    });
+    scheduler.schedule(job);
+
+    // Queued as DELAYED, not yet runnable.
+    expect(scheduler.getState(job.id)?.status).toBe(JobStatus.DELAYED);
+    expect(runs).toEqual([]);
+
+    // Before the delay elapses nothing runs — and (the pre-fix bug) after
+    // it elapses, nothing would EVER run without the drain timer.
+    await vi.advanceTimersByTimeAsync(499);
+    expect(runs).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runs).toEqual(["deferred"]);
+    expect(scheduler.getState(job.id)?.status).toBe(JobStatus.DONE);
+  });
+
+  it("runs an immediate job first, then a delayed one after its delay, in order", async () => {
+    const scheduler = new JobScheduler({ maxActive: 1, ordered: true });
+    const runs: string[] = [];
+
+    scheduler.schedule(
+      createJob({
+        name: "now",
+        run: async () => {
+          runs.push("now");
+        },
+      })
+    );
+    scheduler.schedule(
+      createJob({
+        name: "later",
+        delayMs: 300,
+        run: async () => {
+          runs.push("later");
+        },
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runs).toEqual(["now"]);
+
+    await vi.advanceTimersByTimeAsync(299);
+    expect(runs).toEqual(["now"]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runs).toEqual(["now", "later"]);
+  });
+});
+
+// ── DaemonRepositoryWatcher: coalescing + max_active=1 ───────────────
+
+describe("DaemonRepositoryWatcher scheduler wiring", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("coalesces a burst of change flushes into a single running + single queued analysis", async () => {
+    const inner = createFakeInner();
+    const watcher = new DaemonRepositoryWatcher("/repo", { inner });
+
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+
+    // 5 triggers: first runs, one follow-up queues behind it, the rest
+    // coalesce away (already-pending work is not requeued).
+    await waitForEvents(watcher, "analysis:updated", 2);
+    expect(inner.calls()).toBe(2);
+    expect(inner.maxOverlap()).toBe(1);
+
+    await watcher.close();
+  });
+
+  it("never starts an overlapping analysis: flushes during an in-flight analysis serialize behind it", async () => {
+    const inner = createFakeInner(true); // gated: hold the first analysis open
+    const watcher = new DaemonRepositoryWatcher("/repo", { inner });
+
+    watcher.scheduleAnalysis(); // job 1 starts, parks on the gate
+    await new Promise((r) => setImmediate(r));
+    expect(inner.calls()).toBe(1);
+    expect(inner.maxOverlap()).toBe(1);
+
+    // 5 change batches arrive while job 1 is still running.
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+    watcher.scheduleAnalysis();
+    await new Promise((r) => setImmediate(r));
+
+    // Only one follow-up job exists; none of the five started a second
+    // analysis while job 1 was in flight.
+    expect(inner.calls()).toBe(1);
+
+    const bothEmitted = waitForEvents(watcher, "analysis:updated", 2);
+    await releaseUntilIdle(inner);
+    await bothEmitted;
+
+    expect(inner.calls()).toBe(2);
+    expect(inner.maxOverlap()).toBe(1);
+
+    await watcher.close();
+  });
+
+  it("routes direct getAnalysis() polls through the scheduler, serializing behind an in-flight analysis", async () => {
+    const inner = createFakeInner(true);
+    const watcher = new DaemonRepositoryWatcher("/repo", { inner });
+
+    const first = watcher.getAnalysis();
+    const second = watcher.getAnalysis();
+    const third = watcher.getAnalysis();
+
+    // All three are parked on the scheduler (max_active=1): no second
+    // analysis started while the first is in flight.
+    expect(inner.calls()).toBe(1);
+    expect(inner.maxOverlap()).toBe(1);
+
+    const allResolved = Promise.all([first, second, third]);
+    await releaseUntilIdle(inner);
+    await allResolved;
+
+    expect(inner.calls()).toBe(3);
+    expect(inner.maxOverlap()).toBe(1);
+
+    await watcher.close();
+  });
+
+  it("emits analysis:error when the underlying analysis fails", async () => {
+    const inner = {
+      getAnalysis: vi.fn(async () => {
+        throw new Error("reindex exploded");
+      }),
+      close: vi.fn(async () => {}),
+    };
+    const watcher = new DaemonRepositoryWatcher("/repo", { inner: inner as unknown as RepositoryWatcher });
+
+    const errored = waitForEvents(watcher, "analysis:error", 1);
+    watcher.scheduleAnalysis();
+    await errored;
+
+    expect(inner.getAnalysis).toHaveBeenCalledTimes(1);
+    await watcher.close();
+  });
+
+  it("close() tears down the fs watcher, change queue, and inner watcher", async () => {
+    const inner = createFakeInner();
+    const watcher = new DaemonRepositoryWatcher("/repo", { inner });
+
+    await watcher.close();
+    expect(inner.close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Apa ini

Daemon sekarang punya consumer pertama untuk `packages/scheduler`: semua trigger re-analysis di `DaemonRepositoryWatcher` di-routing lewat `JobScheduler` (maxActive=1, ordered) — pola yang di-port dari Linux `kernel/workqueue.c` (keputusan desain udah tercatat di progres/decisions.md 2026-08-14).

## Masalah yang dibenerin

Sebelumnya tiap change-batch flush langsung manggil `inner.getAnalysis()` → full re-index. Kalau file berubah berulang-ulang (editor save burst), atau ada poll `GET /analysis` pas re-index lagi jalan, analisis bisa numpuk & overlap — CPU hammer + kerja duplikat.

## Solusi (workqueue semantics)

- **Coalescing** — flush yang datang pas ada job analisis lagi pending gak nge-schedule job kedua (`queue_work()` already-pending rule di workqueue.c). `getAnalysis()` state-based (revision token), jadi job pending baca state terbaru pas dia jalan. N flush → 1 re-analysis.
- **max_active=1** — gak pernah ada 2 full re-index jalan barengan.
- **ordered** — follow-up analysis jalan FIFO, selalu liat state terbaru.
- `scheduleAnalysis()` jadi public — daemon/bridge bisa trigger jalur coalesced yang sama secara programatik.

## Bonus: fix latent bug di JobScheduler

Pas wiring ketemu gap: job delayed (`notBefore`/`delayMs`) gak pernah jalan karena gak ada yang re-trigger `drain()` setelah delay-nya habis. Sekarang `drain()` arm timer ke notBefore paling awal — contract `delayed_work`'s wake-at-expiry. Kecil, aman (scheduler belum punya consumer lain), dan bikin wiring ini correct-by-construction.

## Verifikasi

- `tests/daemon-scheduler.test.ts` — 7 kasus baru: delayed-drain fix, flush coalescing, overlap serialization, error path, teardown
- Full suite: **580/580 pass**, typecheck clean
- File yang disentuh cuma: `DaemonRepositoryWatcher.ts`, `JobScheduler.ts`, test baru, progres entry. `pipeline.ts`, watcher core, detector, dan web gak disentuh sama sekali.