### PR TITLE
fix(security): drop eval/shell FPs on string literals and .eval() methods

### DIFF
--- a/packages/security-analysis/source/UnsafePatternDetector.ts
+++ b/packages/security-analysis/source/UnsafePatternDetector.ts
@@ -52,7 +52,9 @@ export interface UnsafePatternOptions {
 export const DEFAULT_UNSAFE_PATTERN_RULES: UnsafePatternRule[] = [
   {
     id: "unsafe-eval",
-    regex: /\beval\s*\(/,
+    // Lookbehind matches Bandit B307 (ast.Call with a bare `eval` name):
+    // `model.eval()` / `regex.eval()` are attribute calls, not the builtin.
+    regex: /(?<![.\w])eval\s*\(/,
     keywords: ["eval("],
     notInside: ["//", "/*"],
     severity: "high",
@@ -127,6 +129,35 @@ export const DEFAULT_UNSAFE_PATTERN_RULES: UnsafePatternRule[] = [
   },
 ];
 
+/**
+ * True when the match at `matchIndex` sits inside a string literal or a
+ * comment on that line. Line-based heuristic (quote parity + `#`-comments):
+ * - an odd number of unescaped `"` or `'` before the match -> inside a string
+ * - an unquoted `#` before the match -> inside a (#) comment (Python etc.)
+ *
+ * Purpose: a pattern inside a string is a denylist constant / doc text, not
+ * a real call — flagging it is a false positive (e.g. MSCodeBase
+ * `BLOCKED_STR_PATTERNS = {"eval(", "exec(", ...}` and `model.eval()` in
+ * comments, EXPERIMENTS_LOG 2026-08-18). Limitations: multiline strings and
+ * JS template literals (backticks) are not tracked — accepted for a line
+ * scanner.
+ */
+export function isInsideStringOrComment(line: string, matchIndex: number): boolean {
+  let inDouble = false;
+  let inSingle = false;
+  for (let i = 0; i < matchIndex; i++) {
+    const c = line[i];
+    if (c === "\\") {
+      i += 1; // skip the escaped character
+      continue;
+    }
+    if (c === '"') inDouble = !inDouble;
+    else if (c === "'") inSingle = !inSingle;
+    else if (c === "#" && !inDouble && !inSingle) return true; // Python-style comment
+  }
+  return inDouble || inSingle;
+}
+
 export function detectUnsafePatterns(
   repository: Repository,
   sources: SourceProvider,
@@ -148,7 +179,11 @@ export function detectUnsafePatterns(
       for (const rule of rules) {
         if (rule.keywords && rule.keywords.length > 0 && !rule.keywords.some((k) => line.includes(k))) continue;
         if (rule.notInside && rule.notInside.some((n) => line.includes(n))) continue;
-        if (!rule.regex.test(line)) continue;
+        const match = rule.regex.exec(line);
+        if (!match) continue;
+        // FP guard: a pattern inside a string literal or comment is a denylist
+        // constant / doc text, not a real call (MSCodeBase audit 2026-08-18).
+        if (isInsideStringOrComment(line, match.index)) continue;
 
         findings.push({
           id: `${rule.id}:${relativePath}:${i + 1}`,

--- a/tests/security-analysis.test.ts
+++ b/tests/security-analysis.test.ts
@@ -34,6 +34,7 @@ import {
 import {
   detectUnsafePatterns,
   DEFAULT_UNSAFE_PATTERN_RULES,
+  isInsideStringOrComment,
 } from "../packages/security-analysis/source/UnsafePatternDetector";
 import { detectSensitiveDataFlow } from "../packages/security-analysis/source/SensitiveDataFlowDetector";
 
@@ -235,6 +236,59 @@ describe("detectUnsafePatterns (unit, in-memory)", () => {
     const ids = findings.map((f) => f.ruleId);
     expect(ids).toContain("innerhtml-assignment");
     expect(ids).toContain("dangerously-set-innerhtml");
+  });
+
+  // FP regression: MSCodeBase audit 2026-08-18 (all 12 high were FPs)
+  it("does not flag .eval() method calls (model.eval())", () => {
+    const repo = makeRepository(["model.py"]);
+    const sources = new MapSourceProvider({ "model.py": "model.eval()\n" });
+    const findings = detectUnsafePatterns(repo, sources);
+    expect(findings.filter((f) => f.ruleId === "unsafe-eval")).toHaveLength(0);
+  });
+
+  it("does not flag denylist string constants", () => {
+    const repo = makeRepository(["denylist.py"]);
+    const sources = new MapSourceProvider({
+      "denylist.py": 'BLOCKED = {"eval(", "exec(", "compile(", "subprocess"}\n',
+    });
+    const findings = detectUnsafePatterns(repo, sources);
+    expect(findings.filter((f) => f.ruleId === "unsafe-eval")).toHaveLength(0);
+    expect(findings.filter((f) => f.ruleId === "shell-exec")).toHaveLength(0);
+  });
+
+  it("does not flag Python comments mentioning eval", () => {
+    const repo = makeRepository(["c.py"]);
+    const sources = new MapSourceProvider({ "c.py": "# model.eval() switches to inference mode\n" });
+    const findings = detectUnsafePatterns(repo, sources);
+    expect(findings.filter((f) => f.ruleId === "unsafe-eval")).toHaveLength(0);
+  });
+
+  it("still flags a bare eval() call next to a string literal", () => {
+    const repo = makeRepository(["x.ts"]);
+    const sources = new MapSourceProvider({
+      "x.ts": 'const label = "eval( is fine in text";\nconst y = eval(code);\n',
+    });
+    const findings = detectUnsafePatterns(repo, sources);
+    expect(findings.filter((f) => f.ruleId === "unsafe-eval")).toHaveLength(1);
+    expect(findings.filter((f) => f.ruleId === "unsafe-eval")[0].location.line).toBe(2);
+  });
+});
+
+describe("isInsideStringOrComment (unit)", () => {
+  it("detects matches inside double-quoted strings", () => {
+    expect(isInsideStringOrComment('BLOCKED = {"eval(", x', 12)).toBe(true);
+  });
+  it("detects matches inside single-quoted strings", () => {
+    expect(isInsideStringOrComment("x = 'eval( text'", 5)).toBe(true);
+  });
+  it("detects matches after a Python # comment", () => {
+    expect(isInsideStringOrComment("# model.eval()", 5)).toBe(true);
+  });
+  it("returns false for a bare call", () => {
+    expect(isInsideStringOrComment("const y = eval(code);", 10)).toBe(false);
+  });
+  it("does not treat a # inside a string as a comment", () => {
+    expect(isInsideStringOrComment('x = "# not a comment" eval(', 22)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
MSCodeBase audit (2026-08-18): all 12 high findings from `arclux security` were false positives — the line-regex scanner flagged denylist constants (`BLOCKED_STR_PATTERNS = {"eval(", "exec(", ...}`), comments mentioning `model.eval()`, and the PyTorch method `model.eval()` as `unsafe-eval`/`shell-exec`. Bandit B307 (the Python reference) detects eval via `ast.Call` and never flags string literals.

## Changes
- `unsafe-eval` rule: `\beval\s*\(` → `(?<![.\w])eval\s*\(` — attribute calls (`.eval()`) are no longer flagged (Bandit-equivalent)
- new exported `isInsideStringOrComment(line, matchIndex)` — quote-parity + `#`-comment heuristic: a pattern inside a string literal or comment is a denylist constant / doc text, not a real call
- 8 new tests (detector FP regressions + helper unit tests)

## Verified
- `tests/security-analysis.test.ts`: 29/29
- full suite: 603/603 (on current main after rebase)
- package tsc: clean
- E1 re-run on the repro stand: 6-7 findings → 1 (only the real `eval()` remains)

## Known limitation
Line-based scanner still misses obfuscated calls (`getattr(__builtins__, "ev"+"al")`) and does not track multiline strings / JS template literals — documented in code comments.