### PR TITLE
feat: arclux shell — in-memory session + user-space plugins

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -28,6 +28,7 @@ import { registerWorkspaceCommand } from "./workspace";
 import { registerSystemCommand } from "./commands/system";
 import { registerLanguageCommand } from "./language";
 import { registerSecurityCommand } from "./security";
+import { registerShellCommand } from "./shell";
 
 const program = new Command();
 program.name("arclux").description("Repository intelligence CLI").version("0.1.0");
@@ -52,5 +53,6 @@ registerWorkspaceCommand(program);
 registerSystemCommand(program);
 registerLanguageCommand(program);
 registerSecurityCommand(program);
+registerShellCommand(program);
 
 program.parse();

--- a/apps/cli/shell.ts
+++ b/apps/cli/shell.ts
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * `arclux shell [path]` — start the interactive ARCLUX session. The
+ * Repository stays in memory between commands, so queries are instant.
+ * The REPL itself uses node:repl (history, tab-completion, .exit) with
+ * ArcluxShell as the command engine.
+ */
+
+import type { Command } from "commander";
+import repl from "node:repl";
+import { resolve } from "node:path";
+import { ArcluxShell } from "../../packages/shell/ArcluxShell";
+
+export function registerShellCommand(program: Command): void {
+  program
+    .command("shell [path]")
+    .description("Start an interactive ARCLUX session (repo stays in memory between commands)")
+    .action(async (pathArg?: string) => {
+      const shell = new ArcluxShell();
+
+      if (pathArg) {
+        try {
+          const result = await shell.analyze(resolve(pathArg));
+          for (const line of result.output) console.log(`  ${line}`);
+        } catch (err) {
+          console.error(`analyze failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+
+      // With piped stdin (scripts/tests), node:repl fires eval for every
+      // buffered line without waiting for the previous callback, which
+      // would run queries before `analyze` finishes. Serialize commands
+      // explicitly through a promise chain.
+      let queue: Promise<void> = Promise.resolve();
+
+      const rl = repl.start({
+        prompt: `${shell.promptLabel}> `,
+        useGlobal: false,
+        ignoreUndefined: true,
+        // Custom eval: every line goes to ArcluxShell.handleCommand as a
+        // command, never parsed as JavaScript. Without this, node:repl's
+        // default eval tries to evaluate "~/flask" / "impact file.ts" as
+        // JS and spams the session with SyntaxErrors.
+        eval: async (
+          cmd: string,
+          _ctx: unknown,
+          _file: string,
+          cb: (err: Error | null, result?: unknown) => void
+        ) => {
+          queue = queue.then(async () => {
+            try {
+              const result = await shell.handleCommand(cmd);
+              for (const out of result.output) rl.outputStream.write(`  ${out}\n`);
+              if (result.exit) rl.close();
+            } catch (err) {
+              rl.outputStream.write(`  [error] ${err instanceof Error ? err.message : String(err)}\n`);
+            }
+          });
+          try {
+            await queue;
+            cb(null, undefined);
+          } catch (err) {
+            cb(err instanceof Error ? err : new Error(String(err)));
+          }
+          rl.setPrompt(`${shell.promptLabel}> `);
+          rl.prompt();
+        },
+      });
+
+      // Keep the prompt label fresh after switching repos inside the session.
+      rl.prompt();
+    });
+}

--- a/packages/shell/ArcluxShell.ts
+++ b/packages/shell/ArcluxShell.ts
@@ -1,0 +1,262 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * The ARCLUX interactive session: analyze a repo ONCE, then answer
+ * questions about it instantly — no re-index per query (local-path CLI
+ * commands re-run analyzeRepository() every invocation; the shell keeps
+ * the Repository in memory, so impact/doctor/search/graph are O(1)-ish).
+ *
+ * Command surface (meant to feel like a prompt, not a CLI):
+ *   <path>                    analyze a repo (bare path = analyze)
+ *   analyze <path>            same, explicit
+ *   impact <file>             affected files if <file> changes
+ *   deps <file>               what <file> imports
+ *   consumers <file>          who imports <file>
+ *   graph [file]              module/edge counts, or a file's neighbors
+ *   doctor                    run the 19-detector suite
+ *   search <query>            fuzzy filename/export search
+ *   plugins                   list user-space plugins
+ *   run <plugin> [args...]    run a user-space plugin against the session
+ *   system                    workspace/system snapshot (kernel state)
+ *   help                      command list
+ *   exit / .exit              leave
+ *
+ * The REPL plumbing (node:repl) lives in apps/cli/shell.ts; this class
+ * is pure command logic, so it is testable without a terminal.
+ */
+
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { analyzeRepository, type AnalyzeRepositoryResult } from "../engine/pipeline";
+import { runDoctor } from "../engine/runDoctor";
+import { calculateAffectedFiles } from "../impact/calculateAffectedFiles";
+import { buildSearchIndex } from "../search/SearchIndex";
+import { search } from "../search/SearchEngine";
+import { buildDependencyGraph } from "../graph/buildDependencyGraph";
+import { Kernel } from "../kernel/Kernel";
+import { SystemManager } from "../system/SystemManager";
+import type { Repository } from "../repository/Repository";
+import type { DependencyGraph, RepositoryMeta } from "../shared/types";
+import { loadPlugins, type ArcluxPluginContext, type LoadedPlugin } from "./plugins";
+
+export interface ShellCommandResult {
+  /** Lines to print to the terminal. */
+  output: string[];
+  /** True when the user wants to leave the session. */
+  exit?: boolean;
+}
+
+export class ArcluxShell {
+  private repository: Repository | null = null;
+  private graph: DependencyGraph | null = null;
+  private meta: RepositoryMeta | null = null;
+  private rootPath = "";
+  private plugins: LoadedPlugin[] = [];
+
+  constructor(private readonly pluginsDir?: string) {}
+
+  /** The current repo's display name for the prompt (e.g. "flask"). */
+  get promptLabel(): string {
+    return this.meta?.name ?? "arclux";
+  }
+
+  async analyze(rootPath: string): Promise<ShellCommandResult> {
+    const expanded = rootPath === "~" ? homedir() : rootPath.startsWith("~/") ? join(homedir(), rootPath.slice(2)) : rootPath;
+    const resolved = resolve(expanded);
+    const result: AnalyzeRepositoryResult = await analyzeRepository({ localPath: resolved });
+    this.repository = result.repository;
+    this.graph = result.graph;
+    this.meta = result.meta;
+    this.rootPath = resolved;
+    return {
+      output: [
+        `Repository: ${result.meta.name}`,
+        `Modules: ${result.moduleCount}`,
+        `Graph: ${result.graph.nodes.length} nodes, ${result.graph.edges.length} edges`,
+        `Scan: ${result.scanSummary.filesScanned} files, ${result.scanSummary.filesParsed} parsed, ${result.scanSummary.filesSkippedNoParser} skipped (no parser)`,
+      ],
+    };
+  }
+
+  async handleCommand(line: string): Promise<ShellCommandResult> {
+    const trimmed = line.trim();
+    if (!trimmed) return { output: [] };
+
+    const [rawCommand, ...rest] = trimmed.split(/\s+/);
+    const command = rawCommand.toLowerCase();
+    const arg = rest.join(" ");
+
+    switch (command) {
+      case "exit":
+      case "quit":
+      case ".exit":
+        return { output: ["Bye."], exit: true };
+
+      case "help":
+        return { output: this.helpText() };
+
+      case "analyze":
+        if (!arg) return { output: ["usage: analyze <path>"] };
+        return this.analyze(arg);
+
+      case "impact": {
+        if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        if (!arg) return { output: ["usage: impact <file>"] };
+        const module = this.repository.getModule(arg);
+        if (!module) return { output: [`module not found: ${arg}`] };
+        const result = calculateAffectedFiles(this.repository, module.id);
+        return {
+          output: [
+            `Direct consumers: ${module.importedBy.length}`,
+            ...module.importedBy.map((id) => `  ${id}`),
+            `Affected total: ${result.totalAffected}`,
+            ...result.affectedFiles.slice(0, 20).map((f) => `  [dist ${f.distance}] ${f.moduleId}`),
+          ],
+        };
+      }
+
+      case "deps": {
+        if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        if (!arg) return { output: ["usage: deps <file>"] };
+        const module = this.repository.getModule(arg);
+        if (!module) return { output: [`module not found: ${arg}`] };
+        return { output: [`imports (${module.imports.length}):`, ...module.imports.map((id) => `  ${id}`)] };
+      }
+
+      case "consumers": {
+        if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        if (!arg) return { output: ["usage: consumers <file>"] };
+        const module = this.repository.getModule(arg);
+        if (!module) return { output: [`module not found: ${arg}`] };
+        return { output: [`imported by (${module.importedBy.length}):`, ...module.importedBy.map((id) => `  ${id}`)] };
+      }
+
+      case "graph": {
+        if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        if (arg) {
+          const module = this.repository.getModule(arg);
+          if (!module) return { output: [`module not found: ${arg}`] };
+          return {
+            output: [
+              `${arg}:`,
+              `  imports: ${module.imports.length}`,
+              `  imported by: ${module.importedBy.length}`,
+              `  calls: ${module.calls.length}`,
+              `  called by: ${module.calledBy.length}`,
+            ],
+          };
+        }
+        const graph = this.graph ?? buildDependencyGraph(this.repository);
+        return { output: [`${graph.nodes.length} nodes, ${graph.edges.length} edges`] };
+      }
+
+      case "doctor": {
+        if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        const result = runDoctor(this.repository);
+        const byCheck = new Map<string, number>();
+        for (const f of result.findings) byCheck.set(f.checkId, (byCheck.get(f.checkId) ?? 0) + 1);
+        return {
+          output: [
+            `${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`,
+            ...[...byCheck.entries()].map(([id, count]) => `  ${id}: ${count}`),
+          ],
+        };
+      }
+
+      case "search": {
+        if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        if (!arg) return { output: ["usage: search <query>"] };
+        const index = buildSearchIndex(this.repository);
+        const results = search(index, arg, { limit: 20 });
+        if (results.length === 0) return { output: ["no matches"] };
+        return {
+          output: results.map((r) => `  ${String(r.score).padStart(3)}  ${r.filePath}`),
+        };
+      }
+
+      case "plugins": {
+        await this.ensurePlugins();
+        if (this.plugins.length === 0) return { output: ["no plugins — drop *.ts files into ~/.arclux/plugins/"] };
+        return { output: this.plugins.map((p) => `  ${p.name}${p.description ? ` — ${p.description}` : ""}`) };
+      }
+
+      case "run": {
+        if (!arg) return { output: ["usage: run <plugin> [args...]"] };
+        await this.ensurePlugins();
+        const [pluginName, ...pluginArgs] = rest;
+        const plugin = this.plugins.find((p) => p.name === pluginName);
+        if (!plugin) {
+          return { output: [`plugin not found: ${pluginName}. Available: ${this.plugins.map((p) => p.name).join(", ")}`] };
+        }
+        const lines: string[] = [];
+        const ctx: ArcluxPluginContext = {
+          repository: this.repository,
+          graph: this.graph,
+          meta: this.meta,
+          rootPath: this.rootPath,
+          log: (message) => lines.push(message),
+        };
+        try {
+          await plugin.run(ctx);
+        } catch (err) {
+          lines.push(`[plugin error] ${err instanceof Error ? err.message : String(err)}`);
+        }
+        return { output: lines.length > 0 ? lines : [`${plugin.name} ran with no output`] };
+      }
+
+      case "system": {
+        const kernel = new Kernel();
+        const manager = new SystemManager({ kernel });
+        const state = manager.snapshot();
+        return {
+          output: [
+            `workspaces: ${state.workspaces.length}`,
+            `processes: ${state.processes.length}`,
+            `services: ${state.services.length}`,
+            `jobs: ${state.jobs.length}`,
+            `health: ${state.health.overall}`,
+          ],
+        };
+      }
+
+      default: {
+        // A bare path (no command prefix) means "analyze this repo" —
+        // the prompt-first experience: `arclux~$ flask/`.
+        if (rawCommand.startsWith(".") || rawCommand.startsWith("/") || rawCommand.includes("/") || rawCommand.endsWith("/")) {
+          return this.analyze(trimmed);
+        }
+        return { output: [`unknown command: ${rawCommand} — try "help"`] };
+      }
+    }
+  }
+
+  private async ensurePlugins(): Promise<void> {
+    if (this.plugins.length > 0) return;
+    this.plugins = await loadPlugins({ dir: this.pluginsDir });
+  }
+
+  private helpText(): string[] {
+    return [
+      "  <path>            analyze a repository (bare path)",
+      "  analyze <path>    same, explicit",
+      "  impact <file>     affected files if <file> changes",
+      "  deps <file>       what <file> imports",
+      "  consumers <file>  who imports <file>",
+      "  graph [file]      graph summary or a file's neighbors",
+      "  doctor            run all detectors",
+      "  search <query>    fuzzy search over paths/exports",
+      "  plugins           list user-space plugins",
+      "  run <plugin>      run a plugin",
+      "  system            workspace/system snapshot",
+      "  help / exit",
+    ];
+  }
+}

--- a/packages/shell/plugins.ts
+++ b/packages/shell/plugins.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * User-space plugin contract for ARCLUX sessions. A plugin is ONE
+ * TypeScript file dropped into ~/.arclux/plugins/ (or any dir passed to
+ * loadPlugins). ARCLUX itself has no idea what a plugin does — the
+ * plugin gets the structural context and builds its own feature on top,
+ * the same way a user-space program runs on Linux without the kernel
+ * knowing what it does.
+ *
+ * Plugin file shape (default export):
+ *
+ *   import type { ArcluxPlugin } from "@arclux/shell";
+ *
+ *   export default {
+ *     name: "my-tool",
+ *     run: async (ctx) => {
+ *       ctx.log("modules: " + (ctx.repository?.moduleCount ?? 0));
+ *     },
+ *   } satisfies ArcluxPlugin;
+ */
+
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import type { Repository } from "../repository/Repository";
+import type { DependencyGraph, RepositoryMeta } from "../shared/types";
+
+/** What a plugin receives when run. This is the stable "user-space API". */
+export interface ArcluxPluginContext {
+  /** The analyzed repo in memory, or null if the session has no repo yet. */
+  repository: Repository | null;
+  /** The dependency graph of the current repo, or null. */
+  graph: DependencyGraph | null;
+  /** Repository metadata (org/name/frameworks/packageManager...), or null. */
+  meta: RepositoryMeta | null;
+  /** Absolute path of the session's current root, or "" if none. */
+  rootPath: string;
+  /** Write a line to the session output. */
+  log(message: string): void;
+}
+
+export interface ArcluxPlugin {
+  name: string;
+  description?: string;
+  run(ctx: ArcluxPluginContext): Promise<void> | void;
+}
+
+export interface LoadedPlugin {
+  name: string;
+  description?: string;
+  run(ctx: ArcluxPluginContext): Promise<void> | void;
+  /** Absolute path of the plugin file — where it was loaded from. */
+  filePath: string;
+}
+
+function defaultPluginsDir(): string {
+  return join(homedir(), ".arclux", "plugins");
+}
+
+export interface LoadPluginsOptions {
+  /** Plugin directory to scan. Defaults to ~/.arclux/plugins. */
+  dir?: string;
+  /** Known plugin files — injectable for tests. */
+  fileNames?: string[];
+}
+
+/**
+ * Scans a plugin directory for *.ts files, dynamically imports each one,
+ * and validates it exposes a default export matching ArcluxPlugin.
+ * A plugin file that fails to load is skipped with the error surfaced —
+ * one bad plugin must not break the whole session (same crash-isolation
+ * rule as runDoctor's safeRun).
+ */
+export async function loadPlugins(options: LoadPluginsOptions = {}): Promise<LoadedPlugin[]> {
+  const dir = resolve(options.dir ?? defaultPluginsDir());
+  const plugins: LoadedPlugin[] = [];
+
+  let fileNames: string[];
+  try {
+    fileNames = options.fileNames ?? readdirSync(dir).filter((f) => f.endsWith(".ts"));
+  } catch {
+    // Directory doesn't exist yet — no plugins, not an error.
+    return [];
+  }
+
+  for (const fileName of fileNames) {
+    const filePath = join(dir, fileName);
+    try {
+      const mod = (await import(pathToFileURL(filePath).href)) as {
+        default?: unknown;
+      };
+      const plugin = mod.default as ArcluxPlugin | undefined;
+      if (!plugin || typeof plugin.run !== "function" || typeof plugin.name !== "string") {
+        console.error(`[shell] plugin ${fileName}: missing default export { name, run(ctx) } — skipped`);
+        continue;
+      }
+      plugins.push({ name: plugin.name, description: plugin.description, run: plugin.run, filePath });
+    } catch (err) {
+      console.error(
+        `[shell] plugin ${fileName} failed to load: ${err instanceof Error ? err.message : String(err)} — skipped`
+      );
+    }
+  }
+
+  return plugins;
+}

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ArcluxShell } from "../packages/shell/ArcluxShell";
+import { loadPlugins } from "../packages/shell/plugins";
+
+const repo = join(__dirname, "fixtures", "python-basic");
+
+describe("ArcluxShell", () => {
+  it("analyzes a repo and serves instant queries", async () => {
+    const shell = new ArcluxShell();
+    const analyze = await shell.handleCommand(repo);
+
+    expect(analyze.output.join("\n")).toContain("Repository:");
+    expect(analyze.output.join("\n")).toContain("Graph:");
+
+    const graph = await shell.handleCommand("graph");
+    expect(graph.output.join("\n")).toMatch(/\d+ nodes, \d+ edges/);
+
+    const help = await shell.handleCommand("help");
+    expect(help.output.join("\n")).toContain("impact <file>");
+  });
+
+  it("accepts a bare path as an analyze command", async () => {
+    const shell = new ArcluxShell();
+    const result = await shell.handleCommand(`${repo}/`);
+    expect(result.output.join("\n")).toContain("Repository:");
+  });
+
+  it("reports no-repo errors before any analysis", async () => {
+    const shell = new ArcluxShell();
+    expect((await shell.handleCommand("impact src/index.ts")).output[0]).toContain("no repo");
+    expect((await shell.handleCommand("doctor")).output[0]).toContain("no repo");
+  });
+
+  it("resolves modules for deps and consumers", async () => {
+    const shell = new ArcluxShell();
+    await shell.handleCommand(repo);
+    const modules = shell["repository"]!.getAllModules();
+    const first = modules[0];
+
+    const deps = await shell.handleCommand(`deps ${first.id}`);
+    expect(deps.output[0]).toMatch(/^imports \(\d+\):$/);
+
+    const consumers = await shell.handleCommand(`consumers ${first.id}`);
+    expect(consumers.output[0]).toMatch(/^imported by \(\d+\):$/);
+  });
+
+  it("runs doctor on an analyzed repo", async () => {
+    const shell = new ArcluxShell();
+    await shell.handleCommand(repo);
+    const result = await shell.handleCommand("doctor");
+    expect(result.output[0]).toMatch(/\d+ error\(s\)/);
+  });
+
+  it("searches the analyzed repo", async () => {
+    const shell = new ArcluxShell();
+    await shell.handleCommand(repo);
+    const result = await shell.handleCommand("search app");
+    expect(result.output.length).toBeGreaterThan(0);
+  });
+
+  it("exits on exit", async () => {
+    const shell = new ArcluxShell();
+    const result = await shell.handleCommand("exit");
+    expect(result.exit).toBe(true);
+  });
+});
+
+describe("loadPlugins", () => {
+  it("loads plugins from a directory", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "arclux-plugins-"));
+    writeFileSync(
+      join(dir, "tool.ts"),
+      `
+        export default {
+          name: "tool",
+          run(ctx) { ctx.log("hello"); },
+        };
+      `
+    );
+    const plugins = await loadPlugins({ dir, fileNames: ["tool.ts"] });
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].name).toBe("tool");
+    expect(plugins[0].filePath).toBe(join(dir, "tool.ts"));
+  });
+
+  it("skips plugins without a valid default export", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "arclux-plugins-"));
+    writeFileSync(join(dir, "bad.ts"), `export const notAPlugin = 42;`);
+    const plugins = await loadPlugins({ dir, fileNames: ["bad.ts"] });
+    expect(plugins).toHaveLength(0);
+  });
+
+  it("returns empty when the plugin directory does not exist", async () => {
+    const plugins = await loadPlugins({ dir: join(tmpdir(), "arclux-plugins-nope-" + Date.now()) });
+    expect(plugins).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Apa ini

**`arclux shell [path]`** — sesi interaktif: analyze repo SEKALI, Repository tinggal di memory, semua query berikutnya instant. Ini jawaban atas pola CLI lokal yang re-analyze tiap dipanggil.

## Command surface

```
arclux~$ flask/          ← ketik path doang = analyze (prompt-first)
flask> impact app.py     ← affected files, INSTANT
flask> deps/consumers <file>
flask> graph [file]
flask> doctor            ← 19-detector suite
flask> search <q>        ← fuzzy path/export search
flask> system            ← workspace snapshot (kernel: ws+processes+services+jobs+health)
flask> run <plugin>      ← user-space plugin
flask> exit
```

## Plugin = user-space (konsep Linux, bukan niru Linux)

Dropping satu file TS di `~/.arclux/plugins/` = fitur baru tanpa ARCLUX harus punya fitur itu. Contract: `export default { name, run(ctx) }`, ctx berisi repository/graph/meta/rootPath yang stabil. Contoh nyata yang udah di-test: 15-baris plugin `biggest-module` nemuin `src/flask/globals.py` (24 consumers) dari repo Flask asli.

## Detail teknis

- `packages/shell/ArcluxShell.ts` — command engine murni (testable tanpa terminal), pakai analyzeRepository/runDoctor/calculateAffectedFiles/buildSearchIndex yang udah ada
- `packages/shell/plugins.ts` — loader: scan dir, dynamic import, crash-isolation (satu plugin rusak gak ngerusak sesi)
- `apps/cli/shell.ts` — node:repl + custom eval (input = command, bukan JS) + promise-chain buat piped stdin (repl default fire eval paralel — query jalan duluan sebelum analyze kelar)
- `~` expansion: `~/flask` jalan dari prompt
- 10 tes baru (shell.test.ts): semua lulus, full suite 613/613

## Berikutnya (dipisah)

- `watch on/off` — wire DaemonRepositoryWatcher, auto re-analyze pas file berubah
- `run <plugin> <args>` — args pass-through (udah di-parse, belum di-pass)