### PR TITLE
feat: watch on|off in arclux shell — auto re-analyze on file edits

### DIFF
--- a/apps/cli/shell.ts
+++ b/apps/cli/shell.ts
@@ -42,8 +42,10 @@ export function registerShellCommand(program: Command): void {
       // explicitly through a promise chain.
       let queue: Promise<void> = Promise.resolve();
 
+      const prompt = (): string => `${shell.promptLabel}${shell.watchActive ? "*" : ""}> `;
+
       const rl = repl.start({
-        prompt: `${shell.promptLabel}> `,
+        prompt: prompt(),
         useGlobal: false,
         ignoreUndefined: true,
         // Custom eval: every line goes to ArcluxShell.handleCommand as a
@@ -71,7 +73,7 @@ export function registerShellCommand(program: Command): void {
           } catch (err) {
             cb(err instanceof Error ? err : new Error(String(err)));
           }
-          rl.setPrompt(`${shell.promptLabel}> `);
+          rl.setPrompt(prompt());
           rl.prompt();
         },
       });

--- a/packages/shell/ArcluxShell.ts
+++ b/packages/shell/ArcluxShell.ts
@@ -26,6 +26,8 @@
  *   plugins                   list user-space plugins
  *   run <plugin> [args...]    run a user-space plugin against the session
  *   system                    workspace/system snapshot (kernel state)
+ *   watch on|off              pick up file edits automatically (re-analyze
+ *                             only when the tree actually changed)
  *   help                      command list
  *   exit / .exit              leave
  *
@@ -41,6 +43,7 @@ import { calculateAffectedFiles } from "../impact/calculateAffectedFiles";
 import { buildSearchIndex } from "../search/SearchIndex";
 import { search } from "../search/SearchEngine";
 import { buildDependencyGraph } from "../graph/buildDependencyGraph";
+import { watchRepository, type RepositoryWatcher } from "../watcher/watchRepository";
 import { Kernel } from "../kernel/Kernel";
 import { SystemManager } from "../system/SystemManager";
 import type { Repository } from "../repository/Repository";
@@ -60,6 +63,7 @@ export class ArcluxShell {
   private meta: RepositoryMeta | null = null;
   private rootPath = "";
   private plugins: LoadedPlugin[] = [];
+  private watcher: RepositoryWatcher | null = null;
 
   constructor(private readonly pluginsDir?: string) {}
 
@@ -68,13 +72,42 @@ export class ArcluxShell {
     return this.meta?.name ?? "arclux";
   }
 
-  async analyze(rootPath: string): Promise<ShellCommandResult> {
-    const expanded = rootPath === "~" ? homedir() : rootPath.startsWith("~/") ? join(homedir(), rootPath.slice(2)) : rootPath;
-    const resolved = resolve(expanded);
-    const result: AnalyzeRepositoryResult = await analyzeRepository({ localPath: resolved });
+  /** True while `watch on` is active — the prompt shows a `*` suffix. */
+  get watchActive(): boolean {
+    return this.watcher !== null;
+  }
+
+  /** Closes the watcher and any other resources. Idempotent. */
+  async dispose(): Promise<void> {
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+  }
+
+  private applyResult(result: AnalyzeRepositoryResult): void {
     this.repository = result.repository;
     this.graph = result.graph;
     this.meta = result.meta;
+  }
+
+  /**
+   * While watching, pulls the latest analysis from the watcher BEFORE a
+   * query — instant on cache hit (tree unchanged), full re-analyze only
+   * when the tree actually changed (the watcher's debounced ChangeQueue
+   * decides). This is the "edit file → next query sees it" experience.
+   */
+  private async refreshFromWatcher(): Promise<void> {
+    if (!this.watcher) return;
+    this.applyResult(await this.watcher.getAnalysis());
+  }
+
+  async analyze(rootPath: string): Promise<ShellCommandResult> {
+    await this.dispose();
+    const expanded = rootPath === "~" ? homedir() : rootPath.startsWith("~/") ? join(homedir(), rootPath.slice(2)) : rootPath;
+    const resolved = resolve(expanded);
+    const result: AnalyzeRepositoryResult = await analyzeRepository({ localPath: resolved });
+    this.applyResult(result);
     this.rootPath = resolved;
     return {
       output: [
@@ -109,6 +142,7 @@ export class ArcluxShell {
 
       case "impact": {
         if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        await this.refreshFromWatcher();
         if (!arg) return { output: ["usage: impact <file>"] };
         const module = this.repository.getModule(arg);
         if (!module) return { output: [`module not found: ${arg}`] };
@@ -125,6 +159,7 @@ export class ArcluxShell {
 
       case "deps": {
         if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        await this.refreshFromWatcher();
         if (!arg) return { output: ["usage: deps <file>"] };
         const module = this.repository.getModule(arg);
         if (!module) return { output: [`module not found: ${arg}`] };
@@ -133,6 +168,7 @@ export class ArcluxShell {
 
       case "consumers": {
         if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        await this.refreshFromWatcher();
         if (!arg) return { output: ["usage: consumers <file>"] };
         const module = this.repository.getModule(arg);
         if (!module) return { output: [`module not found: ${arg}`] };
@@ -141,6 +177,7 @@ export class ArcluxShell {
 
       case "graph": {
         if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        await this.refreshFromWatcher();
         if (arg) {
           const module = this.repository.getModule(arg);
           if (!module) return { output: [`module not found: ${arg}`] };
@@ -160,6 +197,7 @@ export class ArcluxShell {
 
       case "doctor": {
         if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        await this.refreshFromWatcher();
         const result = runDoctor(this.repository);
         const byCheck = new Map<string, number>();
         for (const f of result.findings) byCheck.set(f.checkId, (byCheck.get(f.checkId) ?? 0) + 1);
@@ -173,6 +211,7 @@ export class ArcluxShell {
 
       case "search": {
         if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        await this.refreshFromWatcher();
         if (!arg) return { output: ["usage: search <query>"] };
         const index = buildSearchIndex(this.repository);
         const results = search(index, arg, { limit: 20 });
@@ -227,6 +266,24 @@ export class ArcluxShell {
         };
       }
 
+      case "watch": {
+        if (!this.repository) return { output: ["no repo — analyze <path> first"] };
+        const action = arg.toLowerCase();
+        if (action === "on") {
+          if (this.watcher) return { output: ["watch already on"] };
+          this.watcher = watchRepository(this.rootPath);
+          await this.refreshFromWatcher();
+          return { output: ["watch on — file edits are picked up on the next query"] };
+        }
+        if (action === "off") {
+          if (!this.watcher) return { output: ["watch already off"] };
+          await this.watcher.close();
+          this.watcher = null;
+          return { output: ["watch off"] };
+        }
+        return { output: [this.watcher ? "watch is on" : "watch is off", 'usage: watch on|off'] };
+      }
+
       default: {
         // A bare path (no command prefix) means "analyze this repo" —
         // the prompt-first experience: `arclux~$ flask/`.
@@ -253,6 +310,7 @@ export class ArcluxShell {
       "  graph [file]      graph summary or a file's neighbors",
       "  doctor            run all detectors",
       "  search <query>    fuzzy search over paths/exports",
+      "  watch on|off      re-analyze automatically when files change",
       "  plugins           list user-space plugins",
       "  run <plugin>      run a plugin",
       "  system            workspace/system snapshot",

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { cpSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ArcluxShell } from "../packages/shell/ArcluxShell";
@@ -76,6 +76,61 @@ describe("ArcluxShell", () => {
     const result = await shell.handleCommand("exit");
     expect(result.exit).toBe(true);
   });
+
+  it("turns watch on and off", async () => {
+    const shell = new ArcluxShell();
+    await shell.handleCommand(repo);
+
+    expect(shell.watchActive).toBe(false);
+
+    const on = await shell.handleCommand("watch on");
+    expect(on.output[0]).toContain("watch on");
+    expect(shell.watchActive).toBe(true);
+
+    expect((await shell.handleCommand("watch on")).output[0]).toContain("already on");
+
+    const off = await shell.handleCommand("watch off");
+    expect(off.output[0]).toContain("watch off");
+    expect(shell.watchActive).toBe(false);
+
+    await shell.dispose();
+  });
+
+  it("requires a repo before watch", async () => {
+    const shell = new ArcluxShell();
+    expect((await shell.handleCommand("watch on")).output[0]).toContain("no repo");
+  });
+
+  it(
+    "watch mode picks up a newly created file",
+    async () => {
+      const dir = mkdtempSync(join(tmpdir(), "arclux-watch-"));
+      cpSync(repo, dir, { recursive: true });
+      const shell = new ArcluxShell();
+      await shell.handleCommand(dir);
+
+      await shell.handleCommand("watch on");
+      const before = (await shell.handleCommand("graph")).output[0];
+
+      // chokidar drops events for files that appear DURING its initial scan
+      // (ignoreInitial: true) — a real user is editing seconds after `watch
+      // on`, so this race never matters in practice, but the test must wait
+      // for the initial scan to settle before writing the new file.
+      await new Promise((r) => setTimeout(r, 1500));
+      writeFileSync(join(dir, "extra.py"), "import os\n\ndef extra():\n    return os.getpid()\n");
+
+      const deadline = Date.now() + 15000;
+      let after = before;
+      while (Date.now() < deadline && after === before) {
+        await new Promise((r) => setTimeout(r, 300));
+        after = (await shell.handleCommand("graph")).output[0];
+      }
+      expect(after).not.toBe(before);
+
+      await shell.dispose();
+    },
+    30000
+  );
 });
 
 describe("loadPlugins", () => {


### PR DESCRIPTION
## Apa ini

Shell sekarang bisa `watch on` — setelah itu tiap query otomatis refresh: kalau tree gak berubah, instant (cache hit); kalau ada file berubah/ditambah/dihapus, re-analyze sekali (debounced 300ms via changeQueue). Edit file → query berikutnya langsung lihat hasilnya.

## Cara kerja

- `watch on` → `watchRepository(rootPath)` (yang udah ada, di-wire ke incremental Cell/Query + chokidar + debounce) + warm-up refresh
- Query commands (impact/deps/consumers/graph/doctor/search) manggil `refreshFromWatcher()` dulu — cache hit = instant, changed = satu re-run analyzeRepository
- `watch off` → close watcher; `analyze <path>` otomatis nutup watcher lama
- Prompt nunjukin status: `flask*\> ` pas watch aktif
- `dispose()` public buat resource cleanup (dipakai tests + bisa dipakai REPL on exit)

## Tests (13 total di shell.test.ts)

- watch on/off lifecycle, double-on, watch tanpa repo
- **End-to-end**: copy fixture ke tmp dir, `watch on`, tulis file baru, poll graph sampai node count naik — butuh wait 1.5s karena race chokidar initial-scan (`ignoreInitial: true` drops event buat file yang muncul pas scan awal; gak relevan di pemakaian manusia)

Full suite: 616/616, typecheck bersih.