### PR TITLE
feat: boundaries package — source/remote/analysis/evidence policies

### DIFF
--- a/packages/boundaries/AnalysisBoundary.ts
+++ b/packages/boundaries/AnalysisBoundary.ts
@@ -6,4 +6,77 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: boundaries/AnalysisBoundary — not yet implemented.
+/**
+ * AnalysisBoundary — decides HOW BIG or HOW DEEP an analysis may go.
+ *
+ * Limits are policy; the two checks that always apply are hygiene:
+ *   1. Paths that can never be analyzed (node_modules, .git, vendor —
+ *      the same set the indexer's scan ignores).
+ *   2. The configured hard caps (files/bytes/modules), checked against a
+ *      scan summary AFTER a scan so the shell/CLI can report violations
+ *      without having to predict them.
+ */
+
+export interface AnalysisBoundaryViolation {
+  reason: string;
+  detail?: string;
+}
+
+export interface AnalysisBoundaryOptions {
+  maxFiles?: number;
+  maxBytes?: number;
+  maxModules?: number;
+  /** Additional path segments always rejected (besides node_modules/.git). */
+  extraDeniedSegments?: string[];
+}
+
+export interface ScanFacts {
+  filesScanned: number;
+  filesParsed: number;
+  moduleCount: number;
+  totalBytes?: number;
+}
+
+const ALWAYS_DENIED_SEGMENTS = ["node_modules", ".git", "vendor"];
+
+export class AnalysisBoundary {
+  private readonly maxFiles: number;
+  private readonly maxBytes: number;
+  private readonly maxModules: number;
+  private readonly deniedSegments: string[];
+
+  constructor(options: AnalysisBoundaryOptions = {}) {
+    this.maxFiles = options.maxFiles ?? 100_000;
+    this.maxBytes = options.maxBytes ?? 2 * 1024 * 1024 * 1024;
+    this.maxModules = options.maxModules ?? 100_000;
+    this.deniedSegments = [...ALWAYS_DENIED_SEGMENTS, ...(options.extraDeniedSegments ?? [])];
+  }
+
+  /** True when a path contains a segment that can never be analyzed. */
+  isDeniedPath(path: string): boolean {
+    return this.deniedSegments.some((segment) => path.split("/").includes(segment));
+  }
+
+  /** Checks a scan summary against the configured caps. */
+  checkScan(facts: ScanFacts): AnalysisBoundaryViolation[] {
+    const violations: AnalysisBoundaryViolation[] = [];
+
+    if (facts.filesScanned > this.maxFiles) {
+      violations.push({
+        reason: `scan exceeds maxFiles (${facts.filesScanned} > ${this.maxFiles})`,
+      });
+    }
+    if (facts.totalBytes !== undefined && facts.totalBytes > this.maxBytes) {
+      violations.push({
+        reason: `scan exceeds maxBytes (${facts.totalBytes} > ${this.maxBytes})`,
+      });
+    }
+    if (facts.moduleCount > this.maxModules) {
+      violations.push({
+        reason: `repository exceeds maxModules (${facts.moduleCount} > ${this.maxModules})`,
+      });
+    }
+
+    return violations;
+  }
+}

--- a/packages/boundaries/EvidenceBoundary.ts
+++ b/packages/boundaries/EvidenceBoundary.ts
@@ -6,4 +6,71 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: boundaries/EvidenceBoundary — not yet implemented.
+/**
+ * EvidenceBoundary — decides WHAT evidence analysis may retain and show.
+ *
+ * The hard rule that always applies is redaction: findings must never
+ * leak secrets (API keys, tokens, passwords, AWS credentials, private
+ * keys, connection strings). The soft rule is capping — per-check output
+ * limits so one noisy detector can't flood a report.
+ */
+
+export interface EvidenceBoundaryOptions {
+  /** Max findings retained per checkId. Default 100. */
+  maxFindingsPerCheck?: number;
+  /** Max length of a single finding message; longer messages are trimmed. */
+  maxMessageLength?: number;
+  /** When false, redaction is disabled. Default true. */
+  redactSecrets?: boolean;
+}
+
+const SECRET_PATTERNS: Array<{ label: string; re: RegExp }> = [
+  { label: "api key", re: /(api[_-]?key|apikey)["'\s:=]+[A-Za-z0-9_-]{12,}/gi },
+  { label: "token", re: /(token|secret|passwd|password)["'\s:=]+[A-Za-z0-9_\-.]{12,}/gi },
+  { label: "bearer", re: /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}/gi },
+  { label: "github token", re: /gh[pousr]_[A-Za-z0-9]{30,}/g },
+  { label: "aws key", re: /AKIA[0-9A-Z]{16}/g },
+  { label: "private key", re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/g },
+  { label: "connection string", re: /(mongodb|postgres(ql)?|mysql|redis):\/\/[^\s"']+/gi },
+];
+
+export class EvidenceBoundary {
+  private readonly maxFindingsPerCheck: number;
+  private readonly maxMessageLength: number;
+  private readonly redactSecrets: boolean;
+
+  constructor(options: EvidenceBoundaryOptions = {}) {
+    this.maxFindingsPerCheck = options.maxFindingsPerCheck ?? 100;
+    this.maxMessageLength = options.maxMessageLength ?? 500;
+    this.redactSecrets = options.redactSecrets ?? true;
+  }
+
+  /** Replaces secret-shaped substrings with a placeholder. */
+  redact(text: string): string {
+    if (!this.redactSecrets) return text;
+    let out = text;
+    for (const { label, re } of SECRET_PATTERNS) {
+      out = out.replace(re, `[REDACTED:${label}]`);
+    }
+    return out;
+  }
+
+  /** Caps findings per checkId and trims message lengths. */
+  cap<T extends { checkId: string; message: string }>(findings: T[]): T[] {
+    const seen = new Map<string, number>();
+    const out: T[] = [];
+    for (const finding of findings) {
+      const count = seen.get(finding.checkId) ?? 0;
+      if (count >= this.maxFindingsPerCheck) continue;
+      seen.set(finding.checkId, count + 1);
+      out.push({
+        ...finding,
+        message:
+          finding.message.length > this.maxMessageLength
+            ? `${finding.message.slice(0, this.maxMessageLength)}…`
+            : finding.message,
+      });
+    }
+    return out;
+  }
+}

--- a/packages/boundaries/RemoteAccessPolicy.ts
+++ b/packages/boundaries/RemoteAccessPolicy.ts
@@ -6,4 +6,126 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: boundaries/RemoteAccessPolicy — not yet implemented.
+/**
+ * RemoteAccessPolicy — decides WHERE remote acquisition may reach.
+ *
+ * The non-negotiable part is the SSRF guard: an analysis tool that clones
+ * attacker-supplied URLs must not be tricked into hitting private
+ * networks, link-local addresses, or cloud metadata endpoints
+ * (169.254.169.254). Everything else (host/protocol allowlists) is
+ * mechanism, configured by the caller.
+ */
+
+import { isIP } from "node:net";
+
+export interface RemoteAccessViolation {
+  url: string;
+  reason: string;
+}
+
+export interface RemoteAccessPolicyOptions {
+  /** If set, only these hostnames are allowed. */
+  allowedHosts?: string[];
+  /** Hostnames explicitly rejected even if allowlisted. */
+  blockedHosts?: string[];
+  /** Allowed protocols. Default: http:, https:, ssh:, git:. */
+  allowedProtocols?: string[];
+  /** Reject IPs in private/reserved ranges and the metadata endpoint. */
+  blockPrivateNetworks?: boolean;
+  /** Reject URLs longer than this. Default 2048. */
+  maxUrlLength?: number;
+}
+
+const DEFAULT_PROTOCOLS = ["http:", "https:", "ssh:", "git:"];
+
+function isPrivateAddress(hostname: string): boolean {
+  // URL.hostname keeps the brackets on IPv6 literals ("[::1]"), strip them
+  // before any classification so isIP sees the raw address.
+  const bare = hostname.replace(/^\[|\]$/g, "");
+  const ip = isIP(bare);
+  if (ip === 0) return false; // hostname, not an IP literal
+
+  if (ip === 4) {
+    const parts = bare.split(".").map(Number);
+    const [a, b] = parts;
+    if (a === 10) return true; // 10.0.0.0/8
+    if (a === 127) return true; // loopback
+    if (a === 169 && b === 254) return true; // link-local incl. cloud metadata
+    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16/12
+    if (a === 192 && b === 168) return true; // 192.168/16
+    if (a === 0) return true; // 0.0.0.0/8
+    if (a >= 224) return true; // multicast/reserved
+    return false;
+  }
+
+  // IPv6: loopback, link-local, unique-local, unspecified, multicast.
+  return (
+    bare === "::1" ||
+    bare.startsWith("fe80:") ||
+    bare.startsWith("fc") ||
+    bare.startsWith("fd") ||
+    bare.startsWith("::") ||
+    bare.startsWith("ff")
+  );
+}
+
+export class RemoteAccessPolicy {
+  private readonly allowedHosts: string[];
+  private readonly blockedHosts: string[];
+  private readonly allowedProtocols: string[];
+  private readonly blockPrivateNetworks: boolean;
+  private readonly maxUrlLength: number;
+
+  constructor(options: RemoteAccessPolicyOptions = {}) {
+    this.allowedHosts = options.allowedHosts ?? [];
+    this.blockedHosts = options.blockedHosts ?? [];
+    this.allowedProtocols = options.allowedProtocols ?? DEFAULT_PROTOCOLS;
+    this.blockPrivateNetworks = options.blockPrivateNetworks ?? true;
+    this.maxUrlLength = options.maxUrlLength ?? 2048;
+  }
+
+  static default(): RemoteAccessPolicy {
+    return new RemoteAccessPolicy();
+  }
+
+  check(url: string): RemoteAccessViolation[] {
+    const violations: RemoteAccessViolation[] = [];
+
+    if (url.length > this.maxUrlLength) {
+      violations.push({ url, reason: `URL exceeds max length (${this.maxUrlLength})` });
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return [...violations, { url, reason: "not a parseable URL" }];
+    }
+
+    if (!this.allowedProtocols.includes(parsed.protocol)) {
+      violations.push({ url, reason: `protocol not allowed: ${parsed.protocol}` });
+    }
+
+    if (this.blockedHosts.includes(parsed.hostname)) {
+      violations.push({ url, reason: `host is blocked: ${parsed.hostname}` });
+    }
+
+    if (this.allowedHosts.length > 0 && !this.allowedHosts.includes(parsed.hostname)) {
+      violations.push({ url, reason: `host not in allowlist: ${parsed.hostname}` });
+    }
+
+    if (this.blockPrivateNetworks && isPrivateAddress(parsed.hostname)) {
+      violations.push({ url, reason: `private/reserved address blocked (SSRF guard): ${parsed.hostname}` });
+    }
+
+    return violations;
+  }
+
+  /** Throws on the first violation. */
+  assert(url: string): void {
+    const violations = this.check(url);
+    if (violations.length > 0) {
+      throw new Error(`Remote access violation: ${violations[0].reason} (${url})`);
+    }
+  }
+}

--- a/packages/boundaries/SourceBoundaryPolicy.ts
+++ b/packages/boundaries/SourceBoundaryPolicy.ts
@@ -6,4 +6,134 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: boundaries/SourceBoundaryPolicy — not yet implemented.
+/**
+ * SourceBoundaryPolicy — decides WHERE ARCLUX is allowed to look.
+ *
+ * Mechanism, not policy: the class ships with permissive defaults (any
+ * local directory is analyzable) and enforces whatever the caller
+ * configures on top (allowed roots, deny roots, remote allowance). The
+ * two hard rules that always apply are safety rules, not policy choices:
+ *   1. Windows drive paths and UNC paths must not be misinterpreted as
+ *      URLs (the Node URL parser accepts "D:/foo" without throwing).
+ *   2. Local analysis must not escape an allowed root through symlinks
+ *      (realpath containment check).
+ */
+
+import { realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+import { isAbsoluteLocalPath } from "../acquisition/AcquisitionPolicy";
+
+export type SourceKind = "local" | "remote-git" | "unknown";
+
+export interface SourceBoundaryViolation {
+  source: string;
+  reason: string;
+}
+
+export interface SourceBoundaryPolicyOptions {
+  /** If set, local sources must resolve inside one of these roots. */
+  allowedRoots?: string[];
+  /** Local sources resolving inside any of these are rejected. */
+  denyRoots?: string[];
+  /** When false, remote git URLs are rejected. Default true. */
+  allowRemote?: boolean;
+}
+
+const REMOTE_GIT_RE = /^(https?|ssh|git):\/\//;
+
+export class SourceBoundaryPolicy {
+  private readonly allowedRoots: string[];
+  private readonly denyRoots: string[];
+  private readonly allowRemote: boolean;
+
+  constructor(options: SourceBoundaryPolicyOptions = {}) {
+    // Roots are realpath'd up front: /tmp is a symlink on Termux, so a
+    // textual comparison against "/tmp/..." would reject every path under
+    // it (or worse, accept an escape). Compare real locations.
+    this.allowedRoots = (options.allowedRoots ?? []).map((p) => realpathOr(p));
+    this.denyRoots = (options.denyRoots ?? []).map((p) => realpathOr(p));
+    this.allowRemote = options.allowRemote ?? true;
+  }
+
+  classify(source: string): SourceKind {
+    if (REMOTE_GIT_RE.test(source)) return "remote-git";
+    if (isAbsoluteLocalPath(source) || !source.includes("://")) return "local";
+    return "unknown";
+  }
+
+  /** Returns every violation for a source. Empty array = allowed. */
+  check(source: string): SourceBoundaryViolation[] {
+    const kind = this.classify(source);
+    const violations: SourceBoundaryViolation[] = [];
+
+    if (kind === "unknown") {
+      return [{ source, reason: `unrecognized source kind: ${source}` }];
+    }
+
+    if (kind === "remote-git") {
+      if (!this.allowRemote) {
+        violations.push({ source, reason: "remote git sources are disabled by policy" });
+      }
+      return violations;
+    }
+
+    // ── local ────────────────────────────────────────────────
+    const resolved = resolve(source);
+
+    for (const denied of this.denyRoots) {
+      if (isWithin(resolved, denied)) {
+        violations.push({ source, reason: `resolves inside a denied root: ${denied}` });
+      }
+    }
+
+    if (this.allowedRoots.length > 0) {
+      const inside = this.allowedRoots.some((root) => isWithin(resolved, root));
+      if (!inside) {
+        violations.push({ source, reason: `outside every allowed root (${this.allowedRoots.join(", ")})` });
+      }
+    }
+
+    // Symlink containment: a path that is textually inside an allowed root
+    // can still point OUTSIDE it through a symlink. realpath resolves the
+    // actual location; if it escapes every allowed root, reject. Only
+    // needed when the textual path passed the allowed-roots check — a path
+    // that is already outside is reported once, not twice.
+    if (this.allowedRoots.length > 0) {
+      const containingRoot = this.allowedRoots.find((root) => isWithin(resolved, root));
+      if (containingRoot !== undefined) {
+        let actual: string;
+        try {
+          actual = realpathSync(resolved);
+        } catch {
+          actual = resolved;
+        }
+        if (!this.allowedRoots.some((root) => isWithin(actual, root))) {
+          violations.push({ source, reason: `resolves through symlinks to: ${actual} — outside allowed roots` });
+        }
+      }
+    }
+
+    return violations;
+  }
+
+  /** Throws on the first violation. */
+  assert(source: string): void {
+    const violations = this.check(source);
+    if (violations.length > 0) {
+      throw new Error(`Source boundary violation: ${violations[0].reason} (${source})`);
+    }
+  }
+}
+
+function isWithin(path: string, root: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel) && !rel.split(sep).includes(".."));
+}
+
+function realpathOr(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}

--- a/packages/boundaries/index.ts
+++ b/packages/boundaries/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+export * from "./AnalysisBoundary";
+export * from "./EvidenceBoundary";
+export * from "./RemoteAccessPolicy";
+export * from "./SourceBoundaryPolicy";

--- a/packages/remote-analysis/analyzeRemoteSource.ts
+++ b/packages/remote-analysis/analyzeRemoteSource.ts
@@ -1,6 +1,7 @@
 import { RemoteRepository } from "../remote/RemoteRepository";
 import type { RemoteSource } from "../remote/RemoteSource";
 import { createRemoteSource } from "../remote/RemoteSource";
+import { RemoteAccessPolicy } from "../boundaries/RemoteAccessPolicy";
 import { createRepositoryAcquirer } from "../acquisition/RepositoryAcquirer";
 import { createSnapshotFromFiles } from "../acquisition/SourceSnapshot";
 import { createRemoteImpactReport } from "./RemoteImpactReport";
@@ -13,6 +14,12 @@ import { createRemoteAnalysisSession, updateRemoteAnalysisSession } from "./Remo
 export async function analyzeRemoteSource(source: RemoteSource): Promise<RemoteAnalysisResult> {
   const startedAt = new Date().toISOString();
   try {
+    // SSRF guard before anything else: a remote URL must pass the access
+    // policy (protocol/host allowlists + private-network/metadata block)
+    // or the analysis is refused outright.
+    if (source.url) {
+      RemoteAccessPolicy.default().assert(source.url);
+    }
     const acquisition = source.localPath
       ? await createRepositoryAcquirer(source.localPath).acquire()
       : undefined;

--- a/packages/shell/ArcluxShell.ts
+++ b/packages/shell/ArcluxShell.ts
@@ -44,6 +44,9 @@ import { buildSearchIndex } from "../search/SearchIndex";
 import { search } from "../search/SearchEngine";
 import { buildDependencyGraph } from "../graph/buildDependencyGraph";
 import { watchRepository, type RepositoryWatcher } from "../watcher/watchRepository";
+import { SourceBoundaryPolicy } from "../boundaries/SourceBoundaryPolicy";
+import { AnalysisBoundary } from "../boundaries/AnalysisBoundary";
+import { EvidenceBoundary } from "../boundaries/EvidenceBoundary";
 import { loadPlugins, type ArcluxPluginContext, type LoadedPlugin } from "./plugins";
 import { loadDetectors, type LoadedDetector } from "./detectors";
 import { RepositoryQuery } from "./query";
@@ -112,16 +115,24 @@ export class ArcluxShell {
     await this.dispose();
     const expanded = rootPath === "~" ? homedir() : rootPath.startsWith("~/") ? join(homedir(), rootPath.slice(2)) : rootPath;
     const resolved = resolve(expanded);
+    const boundary = new SourceBoundaryPolicy().check(expanded);
     const result: AnalyzeRepositoryResult = await analyzeRepository({ localPath: resolved });
     this.applyResult(result);
     this.rootPath = resolved;
     this.session.openWorkspace(resolved);
+    const analysisBoundary = new AnalysisBoundary().checkScan({
+      filesScanned: result.scanSummary.filesScanned,
+      filesParsed: result.scanSummary.filesParsed,
+      moduleCount: result.moduleCount,
+    });
     return {
       output: [
         `Repository: ${result.meta.name}`,
         `Modules: ${result.moduleCount}`,
         `Graph: ${result.graph.nodes.length} nodes, ${result.graph.edges.length} edges`,
         `Scan: ${result.scanSummary.filesScanned} files, ${result.scanSummary.filesParsed} parsed, ${result.scanSummary.filesSkippedNoParser} skipped (no parser)`,
+        ...boundary.map((v) => `Boundary: ${v.reason}`),
+        ...analysisBoundary.map((v) => `Boundary: ${v.reason}`),
       ],
     };
   }
@@ -207,14 +218,16 @@ export class ArcluxShell {
         await this.refreshFromWatcher();
         await this.ensureDetectors();
         const result = runDoctor(this.repository, { extraDetectors: this.detectors });
+        const boundary = new EvidenceBoundary({ maxFindingsPerCheck: 20 });
+        const findings = boundary.cap(result.findings.map((f) => ({ ...f, message: boundary.redact(f.message) })));
         const byCheck = new Map<string, number>();
-        for (const f of result.findings) byCheck.set(f.checkId, (byCheck.get(f.checkId) ?? 0) + 1);
+        for (const f of findings) byCheck.set(f.checkId, (byCheck.get(f.checkId) ?? 0) + 1);
         const total = this.detectors.length;
         return {
           output: [
             `${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`,
             `detectors: 19 built-in${total > 0 ? ` + ${total} user (${this.detectors.map((d) => d.checkId).join(", ")})` : ""}`,
-            ...[...byCheck.entries()].map(([id, count]) => `  ${id}: ${count}`),
+            ...[...byCheck.entries()].map(([id, count]) => `  ${id}: ${count}${findings.filter((f) => f.checkId === id).length < result.findings.filter((f) => f.checkId === id).length ? " (capped)" : ""}`),
           ],
         };
       }

--- a/progres/status-infra.md
+++ b/progres/status-infra.md
@@ -484,3 +484,44 @@ ARCLUX.main
 **Status:** Done
 
 New CLI command apps/cli/security.ts: runs secrets + unsafe patterns + data-flow + trust boundary + cross-boundary detectors and the attack-surface map, prints summary or --json/--sarif report; exit 1 on critical/high findings (--no-fail to override). Wired into apps/cli/index.ts. Verified on playground/nextjs-demo (0 findings, 4 reachable/2 unreachable = experiment match) and tests/fixtures/security-leaks (findings + valid SARIF).
+
+## 2026-08-18 — Shell: interactive session (PR #514)
+
+**Status:** Done
+
+`arclux shell` interactive REPL (apps/cli/shell.ts + packages/shell/ArcluxShell.ts + plugins.ts). node:repl with custom eval + promise chain for piped stdin (`echo "analyze ~/flask" | arclux shell`). Commands: analyze/impact/deps/consumers/graph/doctor/search/plugins/run/watch/system/processes/services/exit/help. `~` expanded to $HOME (Termux has no /tmp). Analyzed repo stays in memory so impact/doctor/search/graph are O(1)-ish. Merged into ARCLUX.main.
+
+## 2026-08-18 — Shell: watch on/off (PR #515)
+
+**Status:** Done
+
+`watch on|off` in the shell wraps watchRepository + chokidar with `ignoreInitial: true`. Prompt changes to `flask*>`. Known race: initial scan emits watch events during the first analyze — chokidar's ready event ordering; mitigate with a debounce window. Verified standalone via tests + manual run on ~/flask.
+
+## 2026-08-18 — Shell: platform layer (PR #516)
+
+**Status:** Done
+
+User-space detectors (`~/.arclux/detectors/*.ts` → runDoctor extraDetectors, 19 built-in + N user), ShellSession (workspace + environment + processes + services, session.ts), RepositoryQuery (query.ts), plugin args (ctx.args). Doctor report shows built-in vs user detector counts. Merged into ARCLUX.main.
+
+## 2026-08-19 — Boundaries package (PR #517)
+
+**Status:** Done
+
+Filled the boundaries stub package (was 9-line placeholder) with 4 real policies + index.ts:
+
+- **SourceBoundaryPolicy** — classify (local / remote-git / unknown), allowedRoots/denyRoots, symlink containment (only when the textual path is inside an allowed root — avoids double-reporting). Roots realpath'd in constructor because Termux `/tmp` is a symlink.
+- **RemoteAccessPolicy** — SSRF guard: blocks 10/8, 127/8, 169.254.x.x metadata, 172.16/12, 192.168/16, 0/8, ≥224, IPv6 loopback/link-local/ULA. Protocol + host allowlists, maxUrlLength 2048. IPv6 brackets stripped before isIP() — URL.hostname keeps `[::1]` brackets.
+- **AnalysisBoundary** — hard caps: maxFiles 100k / maxBytes 2GiB / maxModules 100k; denied path segments node_modules/.git/vendor + extra.
+- **EvidenceBoundary** — redact() secrets (api key, token/secret/password with `["'\s:=]+` separator, bearer, gh[pousr]_, AKIA, private keys, connection strings) + cap() per-check limits + message length trim.
+- index.ts exports all four; zero new runtime deps.
+
+Wired into real consumers (no dead code):
+- `analyzeRemoteSource` (packages/remote-analysis/analyzeRemoteSource.ts) — SSRF assert on `source.url` before anything else.
+- Shell `analyze` — appends `Boundary:` violation lines from SourceBoundaryPolicy + AnalysisBoundary.
+- Shell `doctor` — EvidenceBoundary({maxFindingsPerCheck: 20}) redact+cap with `(capped)` marker.
+
+Verified end-to-end on ~/flask: analyze clean (0 violations, permissive defaults), doctor shows `circularDependency: 20 (capped)`, SSRF guard blocks `http://169.254.169.254/latest/meta-data/` and `http://[::1]/x.git` while `https://github.com/...` passes. 16 new tests in tests/boundaries.test.ts → suite 625→641.
+
+Gotchas learned: SCP-style `git@github.com:foo/bar.git` is NOT a URL (use ssh://); "token is sk_..." regex never matches (is is a word, not a value — use `token=sk_...`); private-key pattern needs the `-----` fence; `/etc` on Termux is a symlink (use a second tmpdir in tests).
+
+Infra note: vitest 4's rolldown bundler has no native Termux binary — needs `@rolldown/binding-wasm32-wasi` + emnapi runtime. On this machine: `pnpm install --force` restored the working tree; NAPI_RS_NATIVE_LIBRARY_PATH / NAPI_RS_FORCE_WASI are the escape hatches.

--- a/tests/boundaries.test.ts
+++ b/tests/boundaries.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SourceBoundaryPolicy } from "../packages/boundaries/SourceBoundaryPolicy";
+import { RemoteAccessPolicy } from "../packages/boundaries/RemoteAccessPolicy";
+import { AnalysisBoundary } from "../packages/boundaries/AnalysisBoundary";
+import { EvidenceBoundary } from "../packages/boundaries/EvidenceBoundary";
+
+describe("SourceBoundaryPolicy", () => {
+  it("classifies sources", () => {
+    const policy = new SourceBoundaryPolicy();
+    expect(policy.classify("/home/user/repo")).toBe("local");
+    expect(policy.classify("~/repo")).toBe("local");
+    expect(policy.classify("https://github.com/foo/bar.git")).toBe("remote-git");
+    expect(policy.classify("ftp://host/file")).toBe("unknown");
+  });
+
+  it("allows local paths and remote git by default", () => {
+    const policy = new SourceBoundaryPolicy();
+    expect(policy.check("/home/user/repo")).toEqual([]);
+    expect(policy.check("https://github.com/foo/bar.git")).toEqual([]);
+  });
+
+  it("rejects remote when allowRemote is false", () => {
+    const policy = new SourceBoundaryPolicy({ allowRemote: false });
+    expect(policy.check("https://github.com/foo/bar.git")).toHaveLength(1);
+  });
+
+  it("enforces allowed roots and deny roots", () => {
+    const root = mkdtempSync(join(tmpdir(), "arclux-bounds-"));
+    const outside = mkdtempSync(join(tmpdir(), "arclux-other-"));
+    mkdirSync(join(root, "private"), { recursive: true });
+    mkdirSync(join(root, "app"), { recursive: true });
+    const policy = new SourceBoundaryPolicy({ allowedRoots: [root], denyRoots: [join(root, "private")] });
+    expect(policy.check(join(root, "app"))).toEqual([]);
+    expect(policy.check(join(root, "private", "x"))).toHaveLength(1);
+    expect(policy.check(join(outside, "x"))).toHaveLength(1);
+  });
+
+  it("rejects symlink escapes from allowed roots", () => {
+    const root = mkdtempSync(join(tmpdir(), "arclux-bounds-"));
+    const outside = mkdtempSync(join(tmpdir(), "arclux-outside-"));
+    const link = join(root, "escape");
+    try {
+      symlinkSync(outside, link);
+    } catch {
+      return; // symlinks unsupported on this fs — nothing to assert
+    }
+    const policy = new SourceBoundaryPolicy({ allowedRoots: [root] });
+    expect(policy.check(link)).toHaveLength(1);
+    expect(policy.check(join(root, "app"))).toEqual([]);
+  });
+
+  it("assert throws on first violation", () => {
+    const policy = new SourceBoundaryPolicy({ allowRemote: false });
+    expect(() => policy.assert("https://github.com/foo/bar.git")).toThrow(/remote git sources are disabled/);
+  });
+});
+
+describe("RemoteAccessPolicy", () => {
+  const policy = RemoteAccessPolicy.default();
+
+  it("allows public git hosts", () => {
+    expect(policy.check("https://github.com/foo/bar.git")).toEqual([]);
+    expect(policy.check("ssh://git@github.com/foo/bar.git")).toEqual([]);
+  });
+
+  it("blocks private networks (SSRF guard)", () => {
+    expect(policy.check("http://127.0.0.1:3000/repo.git")).toHaveLength(1);
+    expect(policy.check("http://10.0.0.5/repo.git")).toHaveLength(1);
+    expect(policy.check("http://192.168.1.10/repo.git")).toHaveLength(1);
+    expect(policy.check("http://172.16.0.1/repo.git")).toHaveLength(1);
+    expect(policy.check("http://169.254.169.254/latest/meta-data/")).toHaveLength(1);
+    expect(policy.check("http://[::1]/repo.git")).toHaveLength(1);
+  });
+
+  it("blocks disallowed protocols", () => {
+    expect(policy.check("ftp://example.com/repo.git")).toHaveLength(1);
+  });
+
+  it("enforces host allowlists and blocklists", () => {
+    const restricted = new RemoteAccessPolicy({ allowedHosts: ["github.com"], blockedHosts: ["evil.com"] });
+    expect(restricted.check("https://github.com/foo/bar.git")).toEqual([]);
+    expect(restricted.check("https://gitlab.com/foo/bar.git")).toHaveLength(1);
+    const blocked = new RemoteAccessPolicy({ blockedHosts: ["github.com"] });
+    expect(blocked.check("https://github.com/foo/bar.git")).toHaveLength(1);
+  });
+
+  it("rejects oversized URLs", () => {
+    const small = new RemoteAccessPolicy({ maxUrlLength: 20 });
+    expect(small.check("https://github.com/foo/bar.git")).toHaveLength(1);
+  });
+});
+
+describe("AnalysisBoundary", () => {
+  it("flags denied paths", () => {
+    const boundary = new AnalysisBoundary();
+    expect(boundary.isDeniedPath("app/node_modules/x/index.js")).toBe(true);
+    expect(boundary.isDeniedPath("src/.git/config")).toBe(true);
+    expect(boundary.isDeniedPath("src/app.ts")).toBe(false);
+  });
+
+  it("enforces caps against a scan summary", () => {
+    const boundary = new AnalysisBoundary({ maxFiles: 10, maxModules: 5 });
+    expect(boundary.checkScan({ filesScanned: 5, filesParsed: 5, moduleCount: 4 })).toEqual([]);
+    const violations = boundary.checkScan({ filesScanned: 12, filesParsed: 12, moduleCount: 8 });
+    expect(violations).toHaveLength(2);
+  });
+
+  it("honors extra denied segments", () => {
+    const boundary = new AnalysisBoundary({ extraDeniedSegments: ["generated"] });
+    expect(boundary.isDeniedPath("src/generated/types.ts")).toBe(true);
+  });
+});
+
+describe("EvidenceBoundary", () => {
+  it("redacts secrets", () => {
+    const boundary = new EvidenceBoundary();
+    expect(boundary.redact("token=sk_live_abcDEF1234567890XYZ end")).toContain("[REDACTED:token]");
+    expect(boundary.redact("password=sup3rSecret123456")).toContain("[REDACTED");
+    expect(boundary.redact("api_key: abcdef0123456789abcdef")).toContain("[REDACTED:api key]");
+    expect(boundary.redact("AKIAIOSFODNN7EXAMPLE")).toContain("[REDACTED:aws key]");
+    expect(boundary.redact("Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U")).toContain("[REDACTED:bearer]");
+    expect(boundary.redact("-----BEGIN RSA PRIVATE KEY----- material")).toContain("[REDACTED:private key]");
+    expect(boundary.redact("plain message without secrets")).not.toContain("REDACTED");
+  });
+
+  it("caps findings per check and trims long messages", () => {
+    const boundary = new EvidenceBoundary({ maxFindingsPerCheck: 2, maxMessageLength: 20 });
+    const findings = [
+      { checkId: "a", message: "one" },
+      { checkId: "a", message: "two" },
+      { checkId: "a", message: "three" },
+      { checkId: "b", message: "four" },
+      { checkId: "b", message: "this message is much longer than twenty characters" },
+    ];
+    const capped = boundary.cap(findings);
+    expect(capped.filter((f) => f.checkId === "a")).toHaveLength(2);
+    expect(capped.filter((f) => f.checkId === "b")).toHaveLength(2);
+    expect(capped.find((f) => f.checkId === "b" && f.message.startsWith("this message"))?.message.length).toBe(21);
+  });
+});


### PR DESCRIPTION
Fills the boundaries stub package with 4 real policies (SourceBoundaryPolicy, RemoteAccessPolicy, AnalysisBoundary, EvidenceBoundary) + index export.

- SSRF guard wired into analyzeRemoteSource (assert on source.url)
- Shell analyze appends Boundary violation lines; doctor redacts+caps findings with (capped) marker
- 16 new tests; full suite 641 passing
