### PR TITLE
feat: source adapters — local/github/gitlab/archive routing

### DIFF
--- a/apps/cli/security.ts
+++ b/apps/cli/security.ts
@@ -17,9 +17,9 @@
 
 import type { Command } from "commander";
 import * as p from "@clack/prompts";
-import { createRemoteSource } from "../../packages/remote/RemoteSource";
 import { createRemoteAnalysisRequest } from "../../packages/remote-analysis/RemoteAnalysisRequest";
 import { analyzeRemoteRequest } from "../../packages/remote-analysis/analyzeRemoteSource";
+import { adaptSource } from "../../packages/adapters";
 import { DiskSourceProvider } from "../../packages/security-analysis";
 import { detectSecretExposure } from "../../packages/security-analysis/source/SecretExposureDetector";
 import { detectUnsafePatterns } from "../../packages/security-analysis/source/UnsafePatternDetector";
@@ -43,7 +43,7 @@ export function registerSecurityCommand(program: Command): void {
       spinner.start(`Running security analysis on ${targetPath}`);
 
       try {
-        const remoteResult = await analyzeRemoteRequest(createRemoteAnalysisRequest(createRemoteSource(targetPath)));
+        const remoteResult = await analyzeRemoteRequest(createRemoteAnalysisRequest(adaptSource(targetPath)));
         if (!remoteResult.ok || !remoteResult.analysis) {
           throw new Error(remoteResult.error ?? "Remote analysis did not produce a result.");
         }

--- a/packages/adapters/ArchiveSourceAdapter.ts
+++ b/packages/adapters/ArchiveSourceAdapter.ts
@@ -6,4 +6,37 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: adapters/ArchiveSourceAdapter — not yet implemented.
+/**
+ * ArchiveSourceAdapter — adapts an archive (URL or local file: .zip,
+ * .tar.gz, .tgz) into a RemoteSource. Remote archives pass the SSRF
+ * guard; local archives pass the source boundary.
+ */
+
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import type { RemoteSource } from "../remote/RemoteSource";
+import type { SourceAdapter } from "./LocalSourceAdapter";
+import { RemoteAccessPolicy } from "../boundaries/RemoteAccessPolicy";
+import { SourceBoundaryPolicy } from "../boundaries/SourceBoundaryPolicy";
+
+const ARCHIVE_EXT = /\.(?:zip|tar\.gz|tgz|tar|gz)$/i;
+const REMOTE_PREFIX = /^(?:https?|ssh|git):\/\//i;
+
+export class ArchiveSourceAdapter implements SourceAdapter {
+  readonly kind = "archive" as const;
+
+  matches(input: string): boolean {
+    return ARCHIVE_EXT.test(input);
+  }
+
+  toRemoteSource(input: string): RemoteSource {
+    if (REMOTE_PREFIX.test(input)) {
+      RemoteAccessPolicy.default().assert(input);
+      return { id: `archive:${input}`, url: input };
+    }
+    const expanded = input === "~" ? homedir() : input.startsWith("~/") ? `${homedir()}/${input.slice(2)}` : input;
+    const path = resolve(expanded);
+    new SourceBoundaryPolicy().assert(path);
+    return { id: `archive:${path}`, localPath: path };
+  }
+}

--- a/packages/adapters/GitHubSourceAdapter.ts
+++ b/packages/adapters/GitHubSourceAdapter.ts
@@ -6,4 +6,31 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: adapters/GitHubSourceAdapter — not yet implemented.
+/**
+ * GitHubSourceAdapter — adapts a GitHub repository (https, ssh, or the
+ * SCP-style git@github.com:org/repo.git shorthand) into a RemoteSource.
+ * The SSRF guard runs before anything else so the analysis flow never
+ * reaches a host that failed the remote access policy.
+ */
+
+import type { RemoteSource } from "../remote/RemoteSource";
+import type { SourceAdapter } from "./LocalSourceAdapter";
+import { RemoteAccessPolicy } from "../boundaries/RemoteAccessPolicy";
+
+const GITHUB_URL = /^https?:\/\/(?:www\.)?github\.com\//i;
+const GITHUB_SSH = /^ssh:\/\/git@github\.com\//i;
+const GITHUB_SCP = /^git@github\.com:/i;
+
+export class GitHubSourceAdapter implements SourceAdapter {
+  readonly kind = "github" as const;
+
+  matches(input: string): boolean {
+    return GITHUB_URL.test(input) || GITHUB_SSH.test(input) || GITHUB_SCP.test(input);
+  }
+
+  toRemoteSource(input: string): RemoteSource {
+    const url = input.replace(/^git@github\.com:/, "ssh://git@github.com/");
+    RemoteAccessPolicy.default().assert(url);
+    return { id: `github:${url}`, url, branch: undefined };
+  }
+}

--- a/packages/adapters/GitLabSourceAdapter.ts
+++ b/packages/adapters/GitLabSourceAdapter.ts
@@ -6,4 +6,31 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: adapters/GitLabSourceAdapter — not yet implemented.
+/**
+ * GitLabSourceAdapter — adapts a GitLab repository (https, ssh, or the
+ * SCP-style git@gitlab.com:org/repo.git shorthand) into a RemoteSource.
+ * Same SSRF guard as the GitHub adapter: the remote access policy is
+ * asserted before the source is accepted.
+ */
+
+import type { RemoteSource } from "../remote/RemoteSource";
+import type { SourceAdapter } from "./LocalSourceAdapter";
+import { RemoteAccessPolicy } from "../boundaries/RemoteAccessPolicy";
+
+const GITLAB_URL = /^https?:\/\/(?:www\.)?gitlab\.com\//i;
+const GITLAB_SSH = /^ssh:\/\/git@gitlab\.com\//i;
+const GITLAB_SCP = /^git@gitlab\.com:/i;
+
+export class GitLabSourceAdapter implements SourceAdapter {
+  readonly kind = "gitlab" as const;
+
+  matches(input: string): boolean {
+    return GITLAB_URL.test(input) || GITLAB_SSH.test(input) || GITLAB_SCP.test(input);
+  }
+
+  toRemoteSource(input: string): RemoteSource {
+    const url = input.replace(/^git@gitlab\.com:/, "ssh://git@gitlab.com/");
+    RemoteAccessPolicy.default().assert(url);
+    return { id: `gitlab:${url}`, url, branch: undefined };
+  }
+}

--- a/packages/adapters/LocalSourceAdapter.ts
+++ b/packages/adapters/LocalSourceAdapter.ts
@@ -6,4 +6,53 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 
-// Scaffold: adapters/LocalSourceAdapter — not yet implemented.
+/**
+ * LocalSourceAdapter — adapts a local directory path into a RemoteSource
+ * and applies the source boundary (allowed roots, deny roots, symlink
+ * containment) before the analysis flow touches it.
+ */
+
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { statSync } from "node:fs";
+import type { RemoteSource } from "../remote/RemoteSource";
+import { SourceBoundaryPolicy } from "../boundaries/SourceBoundaryPolicy";
+
+export interface SourceAdapter {
+  readonly kind: "local" | "github" | "gitlab" | "archive" | "remote";
+  /** True when this adapter can handle the given input string. */
+  matches(input: string): boolean;
+  /** Normalizes input into a RemoteSource, throwing on boundary violations. */
+  toRemoteSource(input: string): RemoteSource;
+}
+
+export class LocalSourceAdapter implements SourceAdapter {
+  readonly kind = "local" as const;
+
+  matches(input: string): boolean {
+    if (LocalSourceAdapter.isRemoteUrl(input)) return false;
+    try {
+      return statSync(LocalSourceAdapter.expand(input)).isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  toRemoteSource(input: string): RemoteSource {
+    const path = resolve(LocalSourceAdapter.expand(input));
+    const boundary = new SourceBoundaryPolicy();
+    boundary.assert(path);
+    return { id: `local:${path}`, localPath: path };
+  }
+
+  /** Termux has no /tmp — paths like "~/repo" must expand to $HOME. */
+  private static expand(input: string): string {
+    if (input === "~") return homedir();
+    if (input.startsWith("~/")) return `${homedir()}/${input.slice(2)}`;
+    return input;
+  }
+
+  private static isRemoteUrl(input: string): boolean {
+    return /^(?:https?|ssh|git):\/\//i.test(input) || /^(?:git@|github:|gitlab:)/i.test(input);
+  }
+}

--- a/packages/adapters/index.ts
+++ b/packages/adapters/index.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+/**
+ * SourceAdapter registry — routes any source string (local path, GitHub,
+ * GitLab, archive, or any other public git/web host) to the right adapter
+ * and normalizes it into a RemoteSource with its boundary check applied.
+ *
+ * The adapters keep the "who is allowed to reach where" decision in one
+ * place: local paths go through SourceBoundaryPolicy, remote URLs go
+ * through RemoteAccessPolicy (SSRF guard). Unknown public hosts still
+ * work — they fall through to the generic remote adapter so ARCLUX is not
+ * limited to github/gitlab.
+ */
+
+import type { RemoteSource } from "../remote/RemoteSource";
+import type { SourceAdapter } from "./LocalSourceAdapter";
+import { LocalSourceAdapter } from "./LocalSourceAdapter";
+import { GitHubSourceAdapter } from "./GitHubSourceAdapter";
+import { GitLabSourceAdapter } from "./GitLabSourceAdapter";
+import { ArchiveSourceAdapter } from "./ArchiveSourceAdapter";
+import { RemoteAccessPolicy } from "../boundaries/RemoteAccessPolicy";
+
+const REMOTE_PREFIX = /^(?:https?|ssh|git):\/\//i;
+const SCP_PREFIX = /^(?:git@|github:|gitlab:)/i;
+
+/** Generic fallback so any other public host (bitbucket, self-hosted, …) works. */
+class RemoteHostAdapter implements SourceAdapter {
+  readonly kind = "remote" as const;
+  matches(input: string): boolean {
+    return REMOTE_PREFIX.test(input) || SCP_PREFIX.test(input);
+  }
+  toRemoteSource(input: string): RemoteSource {
+    const url = SCP_PREFIX.test(input) ? input.replace(/^([^@]+@)([^:]+):/, "ssh://$1$2/") : input;
+    RemoteAccessPolicy.default().assert(url);
+    return { id: `remote:${url}`, url };
+  }
+}
+
+const ADAPTERS: SourceAdapter[] = [
+  new GitHubSourceAdapter(),
+  new GitLabSourceAdapter(),
+  new ArchiveSourceAdapter(),
+  new LocalSourceAdapter(),
+  new RemoteHostAdapter(),
+];
+
+/** Picks the first adapter that recognizes the input. */
+export function createSourceAdapter(input: string): SourceAdapter {
+  if (!input.trim()) throw new Error("Source cannot be empty.");
+  const adapter = ADAPTERS.find((a) => a.matches(input));
+  if (!adapter) throw new Error(`No source adapter understands: ${input}`);
+  return adapter;
+}
+
+/**
+ * Normalizes any source string into a RemoteSource with boundary checks
+ * applied. This is the single entry the CLI/API use instead of calling
+ * createRemoteSource directly.
+ */
+export function adaptSource(
+  input: string,
+  options: { id?: string } = {},
+): RemoteSource {
+  const adapter = createSourceAdapter(input);
+  const source = adapter.toRemoteSource(input);
+  return options.id ? { ...source, id: options.id } : source;
+}
+
+export type { SourceAdapter };

--- a/packages/remote-analysis/analyzeRemoteSource.ts
+++ b/packages/remote-analysis/analyzeRemoteSource.ts
@@ -3,6 +3,7 @@ import type { RemoteSource } from "../remote/RemoteSource";
 import { createRemoteSource } from "../remote/RemoteSource";
 import { RemoteAccessPolicy } from "../boundaries/RemoteAccessPolicy";
 import { createRepositoryAcquirer } from "../acquisition/RepositoryAcquirer";
+import { adaptSource } from "../adapters";
 import { createSnapshotFromFiles } from "../acquisition/SourceSnapshot";
 import { createRemoteImpactReport } from "./RemoteImpactReport";
 import { createSourceHealthReport } from "./SourceHealthReport";
@@ -63,7 +64,7 @@ export async function analyzeRemoteRequest(request: RemoteAnalysisRequest): Prom
     return createRemoteAnalysisResult(undefined, { ok: false, error: "A remote analysis source is required." });
   }
 
-  const source = typeof request.source === "string" ? createRemoteSource(request.source) : request.source;
+  const source = typeof request.source === "string" ? adaptSource(request.source, { id: request.id ?? undefined }) : request.source;
   let session = createRemoteAnalysisSession(source);
   session = updateRemoteAnalysisSession(session, { status: "running" });
   const result = await analyzeRemoteSource(source);


### PR DESCRIPTION
Fills packages/adapters (4 stub files) with real adapters + factory:

- LocalSourceAdapter — dir paths (+ ~ expansion, Termux), SourceBoundaryPolicy check
- GitHubSourceAdapter / GitLabSourceAdapter — https, ssh, SCP-style (git@host:org/repo.git normalized to ssh://), RemoteAccessPolicy assert
- ArchiveSourceAdapter — .zip/.tar.gz/.tgz remote or local
- Generic RemoteHostAdapter fallback so ANY public https host (bitbucket, self-hosted) still works — arclux is not limited to github/gitlab
- adaptSource() — single entry replacing createRemoteSource at call sites

Wired: analyzeRemoteRequest (analyzeRemoteSource.ts) + apps/cli/security.ts now route through adaptSource. Verified: all 8 routing cases + SSRF metadata rejection + 38 tests pass + typecheck clean.