### PR TITLE
feat: daemon /impact endpoint + hardened vscode extension

### DIFF
--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -13,14 +13,36 @@
   "contributes": {
     "commands": [
       {
-        "command": "arclux.showAnalysis",
-        "title": "ARCLUX: Show Analysis"
+        "command": "arclux.menu",
+        "title": "ARCLUX: Command Menu"
       },
       {
-        "command": "arclux.connectDaemon",
+        "command": "arclux.refresh",
+        "title": "ARCLUX: Refresh Status"
+      },
+      {
+        "command": "arclux.impact",
+        "title": "ARCLUX: Trace Impact of a File"
+      },
+      {
+        "command": "arclux.connect",
         "title": "ARCLUX: Connect to Daemon"
       }
-    ]
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "arclux.impact",
+          "group": "arclux@1"
+        }
+      ],
+      "commandPalette": [
+        {
+          "command": "arclux.menu",
+          "when": "true"
+        }
+      ]
+    }
   },
   "scripts": {
     "build": "tsc -p .",

--- a/apps/vscode-extension/src/daemonClient.ts
+++ b/apps/vscode-extension/src/daemonClient.ts
@@ -10,9 +10,9 @@
 // packages/networking/ServiceEndpoint.ts writes -- see
 // computeDaemonId in packages/daemon/DaemonProcess.ts for how the id
 // is derived from a repo root path) and subscribes to its SSE stream.
-// Verified 2026-08-14: pnpm install && pnpm build pass (tsc strict,
-// @types/vscode ^1.85). Only manual test in VS Code's Extension
-// Development Host (F5) remains.
+// Also exposes the /analysis and /impact endpoints for polling and
+// editor-side impact queries, plus auto-reconnecting SSE so the
+// extension recovers when the daemon restarts or the connection drops.
 
 import * as fs from "fs";
 import * as os from "os";
@@ -26,8 +26,31 @@ export interface DaemonEndpoint {
   baseUrl: string;
 }
 
+export interface AnalysisSnapshot {
+  moduleCount: number;
+  meta: { name?: string; defaultBranch?: string; provider?: string };
+  graph?: { nodes: number; edges: number };
+  scan?: { filesScanned: number; filesParsed: number };
+}
+
+export interface ImpactQuery {
+  ok: boolean;
+  file: string;
+  moduleId?: string;
+  error?: string;
+  suggestions?: string[];
+  consumers?: string[];
+  directConsumers?: number;
+  affected?: { moduleId: string; filePath: string; distance: number }[];
+  totalAffected?: number;
+}
+
 function arcluxRoot(): string {
   return process.env.ARCLUX_ROOT || path.join(os.homedir(), ".arclux");
+}
+
+function endpointsDir(): string {
+  return path.join(arcluxRoot(), "endpoints");
 }
 
 /** Same id derivation as packages/daemon/DaemonProcess.ts's computeDaemonId -- duplicated here (not imported) because the extension is a separate npm package with no dependency on the monorepo's packages/*. */
@@ -38,12 +61,92 @@ function computeDaemonId(rootPath: string): string {
 
 export function findDaemonEndpoint(repositoryRoot: string): DaemonEndpoint | null {
   const daemonId = computeDaemonId(repositoryRoot);
-  const file = path.join(arcluxRoot(), "endpoints", `${daemonId}.json`);
+  const file = path.join(endpointsDir(), `${daemonId}.json`);
   try {
-    return JSON.parse(fs.readFileSync(file, "utf8"));
+    return JSON.parse(fs.readFileSync(file, "utf8")) as DaemonEndpoint;
   } catch {
     return null;
   }
+}
+
+/**
+ * Watches the daemon endpoint directory. Fires immediately if endpoints
+ * already exist, then whenever a file is added/removed/renamed. Returns a
+ * dispose function. The watcher survives endpoint files appearing later
+ * (daemon started after the editor) or being removed (daemon stopped).
+ */
+export function watchEndpointsDir(onChange: (endpoints: DaemonEndpoint[]) => void): () => void {
+  let disposed = false;
+  const dir = endpointsDir();
+
+  const scan = () => {
+    if (disposed) return;
+    let endpoints: DaemonEndpoint[] = [];
+    try {
+      endpoints = fs
+        .readdirSync(dir)
+        .filter((f) => f.endsWith(".json"))
+        .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), "utf8")) as DaemonEndpoint);
+    } catch {
+      // Directory doesn't exist yet — the daemon creates it on first start.
+    }
+    onChange(endpoints);
+  };
+
+  scan();
+
+  let watcher: fs.FSWatcher | null = null;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    watcher = fs.watch(dir, (eventType, filename) => {
+      if (filename?.endsWith(".json")) scan();
+    });
+  } catch {
+    // Fall back to polling in case fs.watch is unavailable (some
+    // network filesystems).
+    const timer = setInterval(scan, 5000);
+    return () => {
+      disposed = true;
+      clearInterval(timer);
+    };
+  }
+
+  return () => {
+    disposed = true;
+    watcher?.close();
+  };
+}
+
+function requestJson<T>(baseUrl: string, route: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const req = http.get(`${baseUrl}${route}`, (res) => {
+      let body = "";
+      res.on("data", (chunk: Buffer) => (body += chunk.toString()));
+      res.on("end", () => {
+        try {
+          const parsed = JSON.parse(body);
+          if (res.statusCode && res.statusCode >= 400) {
+            reject(new Error((parsed && parsed.error) || `HTTP ${res.statusCode}`));
+            return;
+          }
+          resolve(parsed as T);
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    });
+    req.on("error", reject);
+  });
+}
+
+/** GET /analysis — current analysis state, for polling. */
+export function fetchAnalysis(endpoint: DaemonEndpoint): Promise<AnalysisSnapshot> {
+  return requestJson<AnalysisSnapshot>(endpoint.baseUrl, "/analysis");
+}
+
+/** GET /impact?file= — consumers + transitive affected set for one file. */
+export function fetchImpact(endpoint: DaemonEndpoint, filePath: string): Promise<ImpactQuery> {
+  return requestJson<ImpactQuery>(endpoint.baseUrl, `/impact?file=${encodeURIComponent(filePath)}`);
 }
 
 export interface DaemonSseHandlers {
@@ -52,27 +155,66 @@ export interface DaemonSseHandlers {
   onError?: (err: Error) => void;
 }
 
-/** Subscribes to the daemon's GET /events SSE stream. Returns a function to close the connection. */
+/**
+ * Subscribes to the daemon's GET /events SSE stream with automatic
+ * reconnect. Reconnects on any connection drop with backoff (1s, 2s,
+ * 4s, …, capped at 30s) while the stream is not explicitly closed.
+ * Returns a function to close the connection permanently.
+ */
 export function subscribeDaemonEvents(endpoint: DaemonEndpoint, handlers: DaemonSseHandlers): () => void {
-  const req = http.get(`${endpoint.baseUrl}/events`, (res) => {
-    let buffer = "";
-    res.on("data", (chunk: Buffer) => {
-      buffer += chunk.toString();
-      const parts = buffer.split("\n\n");
-      buffer = parts.pop() ?? "";
-      for (const part of parts) {
-        const eventLine = part.split("\n").find((l) => l.startsWith("event: "));
-        const dataLine = part.split("\n").find((l) => l.startsWith("data: "));
-        if (!eventLine || !dataLine) continue;
-        const event = eventLine.slice("event: ".length);
-        const data = JSON.parse(dataLine.slice("data: ".length));
-        if (event === "analysis") handlers.onAnalysis?.(data);
-        if (event === "diagnostics") handlers.onDiagnostics?.(data);
-      }
+  let closed = false;
+  let req: http.ClientRequest | null = null;
+  let retryDelay = 1000;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const connect = () => {
+    if (closed) return;
+    req = http.get(`${endpoint.baseUrl}/events`, (res) => {
+      retryDelay = 1000; // reset backoff on successful (re)connect
+      let buffer = "";
+      res.on("data", (chunk: Buffer) => {
+        buffer += chunk.toString();
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
+        for (const part of parts) {
+          const eventLine = part.split("\n").find((l) => l.startsWith("event: "));
+          const dataLine = part.split("\n").find((l) => l.startsWith("data: "));
+          if (!eventLine || !dataLine) continue;
+          const event = eventLine.slice("event: ".length);
+          try {
+            const data = JSON.parse(dataLine.slice("data: ".length));
+            if (event === "analysis") handlers.onAnalysis?.(data);
+            if (event === "diagnostics") handlers.onDiagnostics?.(data);
+          } catch {
+            // Skip malformed frames rather than killing the stream.
+          }
+        }
+      });
+      res.on("end", () => scheduleReconnect());
+      res.on("error", () => scheduleReconnect());
     });
-  });
 
-  req.on("error", (err) => handlers.onError?.(err));
+    req.on("error", (err) => {
+      handlers.onError?.(err);
+      scheduleReconnect();
+    });
+  };
 
-  return () => req.destroy();
+  const scheduleReconnect = () => {
+    if (closed || retryTimer) return;
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      if (closed) return;
+      connect();
+    }, retryDelay);
+    retryDelay = Math.min(retryDelay * 2, 30000);
+  };
+
+  connect();
+
+  return () => {
+    closed = true;
+    if (retryTimer) clearTimeout(retryTimer);
+    req?.destroy();
+  };
 }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -6,95 +6,315 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Verified 2026-08-14: pnpm install && pnpm build pass (tsc strict,
-// @types/vscode ^1.85). Only manual test in VS Code's Extension
-// Development Host (F5) remains.
+// VS Code extension for ARCLUX: connects to a running `arclux daemon
+// --detach` for the open workspace, shows module count in the status bar,
+// surfaces diagnostics findings in the Problems panel, and adds an
+// impact command that answers "what breaks if I change this file" from
+// inside the editor.
 //
-// Minimal viable extension: connects to a running `arclux daemon
-// --detach` for the open workspace, shows module count in the status
-// bar, and surfaces diagnostics findings (packages/diagnostics/
-// DiagnosticEngine.ts's output, forwarded by ArcluxDaemon over SSE) in
-// VS Code's built-in Problems panel via a DiagnosticCollection --
-// reuses VS Code's own UI for this instead of building a custom panel.
+// Robustness (not a one-shot connect):
+//   - auto-connect when the daemon starts after the editor (watches the
+//     ~/.arclux/endpoints directory)
+//   - auto-reconnect SSE with backoff when the connection drops
+//   - 30s poll of GET /analysis so the status bar stays fresh even if SSE
+//     is unavailable
+//   - re-connect when the workspace folder changes
+//   - commands: arclux.connect, arclux.refresh, arclux.impact, arclux.menu
+//   - status bar click opens the command menu
 
 import * as vscode from "vscode";
-import { findDaemonEndpoint, subscribeDaemonEvents } from "./daemonClient";
+import * as path from "path";
+import {
+  findDaemonEndpoint,
+  watchEndpointsDir,
+  fetchAnalysis,
+  fetchImpact,
+  subscribeDaemonEvents,
+  type DaemonEndpoint,
+  type AnalysisSnapshot,
+} from "./daemonClient";
 
 let statusBarItem: vscode.StatusBarItem;
 let diagnosticCollection: vscode.DiagnosticCollection;
+
 let closeSse: (() => void) | null = null;
+let closeEndpointWatcher: (() => void) | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
 
-function connect(workspaceRoot: string): void {
-  const endpoint = findDaemonEndpoint(workspaceRoot);
+let workspaceRoot: string | null = null;
+let endpoint: DaemonEndpoint | null = null;
+let lastAnalysis: AnalysisSnapshot | null = null;
 
+const POLL_INTERVAL_MS = 30_000;
+
+function setStatus(text: string, tooltip?: string): void {
+  statusBarItem.text = text;
+  if (tooltip) statusBarItem.tooltip = tooltip;
+}
+
+function relPath(filePath: string): string | null {
+  if (!workspaceRoot) return null;
+  const rel = path.relative(workspaceRoot, filePath);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  return rel.replace(/\\/g, "/");
+}
+
+async function refreshAnalysis(): Promise<void> {
+  if (!endpoint) return;
+  try {
+    lastAnalysis = await fetchAnalysis(endpoint);
+    const { moduleCount, graph, meta } = lastAnalysis;
+    const graphPart = graph ? `, ${graph.nodes} nodes / ${graph.edges} edges` : "";
+    setStatus(
+      `$(check) ARCLUX: ${moduleCount} modules${graphPart}`,
+      meta.name ? `ARCLUX — ${meta.name} (${moduleCount} modules)` : undefined
+    );
+  } catch {
+    // Transient — the next poll or SSE event will update the status.
+  }
+}
+
+function connect(root: string): void {
+  const found = findDaemonEndpoint(root);
+  if (!found) {
+    endpoint = null;
+    setStatus("$(circle-slash) ARCLUX: not running", "Run `arclux daemon --detach` in this repository's terminal");
+    return;
+  }
+  endpoint = found;
+  setStatus("$(sync~spin) ARCLUX: connecting...");
+
+  closeSse?.();
+  closeSse = subscribeDaemonEvents(found, {
+    onAnalysis: (data: any) => {
+      lastAnalysis = data as AnalysisSnapshot;
+      const moduleCount = (data as AnalysisSnapshot).moduleCount;
+      setStatus(`$(check) ARCLUX: ${moduleCount} modules`);
+      refreshAnalysis();
+    },
+    onDiagnostics: (data: any) => {
+      updateDiagnostics(data);
+    },
+    onError: () => {
+      setStatus("$(warning) ARCLUX: reconnecting…");
+    },
+  });
+
+  refreshAnalysis();
+}
+
+function updateDiagnostics(data: any): void {
+  diagnosticCollection.clear();
+  const byFile = new Map<string, vscode.Diagnostic[]>();
+
+  for (const finding of data.findings ?? []) {
+    for (const loc of finding.locations ?? []) {
+      const list = byFile.get(loc.filePath) ?? [];
+      const line = Math.max(0, (loc.line ?? 1) - 1);
+      const range = new vscode.Range(line, 0, line, 0);
+      const severity =
+        finding.severity === "error"
+          ? vscode.DiagnosticSeverity.Error
+          : finding.severity === "warning"
+            ? vscode.DiagnosticSeverity.Warning
+            : vscode.DiagnosticSeverity.Information;
+      list.push(new vscode.Diagnostic(range, finding.message, severity));
+      byFile.set(loc.filePath, list);
+    }
+  }
+
+  for (const [filePath, diagnostics] of byFile) {
+    const uri = vscode.Uri.file(path.join(workspaceRoot ?? "", filePath));
+    diagnosticCollection.set(uri, diagnostics);
+  }
+}
+
+async function commandImpact(): Promise<void> {
   if (!endpoint) {
-    statusBarItem.text = "$(circle-slash) ARCLUX: not running";
-    statusBarItem.tooltip = "Run `arclux daemon --detach` in this repository's terminal";
+    vscode.window.showErrorMessage("ARCLUX daemon is not running. Run `arclux daemon --detach` first.");
+    return;
+  }
+  if (!workspaceRoot) {
+    vscode.window.showErrorMessage("No workspace is open.");
     return;
   }
 
-  statusBarItem.text = "$(sync~spin) ARCLUX: connecting...";
+  const activeFile = vscode.window.activeTextEditor?.document.uri.fsPath;
+  const relative = activeFile ? relPath(activeFile) : null;
 
-  closeSse = subscribeDaemonEvents(endpoint, {
-    onAnalysis: (data: any) => {
-      statusBarItem.text = `$(check) ARCLUX: ${data.moduleCount} modules`;
-    },
-    onDiagnostics: (data: any) => {
-      diagnosticCollection.clear();
-      const byFile = new Map<string, vscode.Diagnostic[]>();
+  const pick = await vscode.window.showQuickPick(
+    [
+      {
+        label: "$(file-code) Current file",
+        description: relative ?? "(no active editor — type a path instead)",
+        detail: "Impact of the file you're currently editing",
+        value: relative ?? undefined,
+      },
+      {
+        label: "$(type-hierarchy) Type a relative path…",
+        description: "e.g. src/components/Button.tsx",
+        value: undefined,
+      },
+    ],
+    { placeHolder: "Which file do you want to trace?" }
+  );
+  if (!pick) return;
 
-      for (const finding of data.findings ?? []) {
-        for (const loc of finding.locations ?? []) {
-          const list = byFile.get(loc.filePath) ?? [];
-          const line = Math.max(0, (loc.line ?? 1) - 1);
-          const range = new vscode.Range(line, 0, line, 0);
-          const severity =
-            finding.severity === "error" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning;
-          list.push(new vscode.Diagnostic(range, finding.message, severity));
-          byFile.set(loc.filePath, list);
-        }
-      }
+  let file = pick.value;
+  if (!file) {
+    const input = await vscode.window.showInputBox({
+      prompt: "Relative file path",
+      value: relative ?? "",
+      placeHolder: "src/components/Button.tsx",
+    });
+    if (!input) return;
+    file = input;
+  }
 
-      for (const [filePath, diagnostics] of byFile) {
-        const uri = vscode.Uri.file(`${workspaceRoot}/${filePath}`);
-        diagnosticCollection.set(uri, diagnostics);
-      }
-    },
-    onError: () => {
-      statusBarItem.text = "$(warning) ARCLUX: connection lost";
-    },
-  });
+  setStatus("$(sync~spin) ARCLUX: tracing impact…");
+  try {
+    const result = await fetchImpact(endpoint, file);
+    if (!result.ok) {
+      setStatus("$(warning) ARCLUX: impact failed");
+      const suggestions = result.suggestions?.length
+        ? `\nDid you mean:\n${result.suggestions.map((s) => `  ${s}`).join("\n")}`
+        : "";
+      vscode.window.showErrorMessage(`ARCLUX: ${result.error ?? "module not found"}${suggestions}`);
+      return;
+    }
+
+    const consumers = (result.consumers ?? []).map((c) => ({
+      label: `$(references) ${c}`,
+      description: "consumer",
+      detail: `distance 1 — imports ${result.file}`,
+      filePath: c,
+    }));
+    const affected = (result.affected ?? []).map((a) => ({
+      label: `$(diff) ${a.filePath}`,
+      description: a.distance === 2 ? "transitively affected" : `distance ${a.distance}`,
+      detail: `chain of ${a.distance} imports away`,
+      filePath: a.filePath,
+    }));
+
+    const selected = await vscode.window.showQuickPick([...consumers, ...affected], {
+      placeHolder: `${result.file}: ${result.directConsumers} direct consumers, ${result.totalAffected} files affected in total`,
+      matchOnDescription: true,
+    });
+
+    if (selected?.filePath) {
+      const full = path.join(workspaceRoot, selected.filePath);
+      const doc = await vscode.workspace.openTextDocument(full);
+      await vscode.window.showTextDocument(doc, { preview: true });
+    }
+
+    setStatus(
+      `$(check) ARCLUX: ${result.file} → ${result.totalAffected} affected`,
+      `${result.directConsumers} direct consumers, ${result.totalAffected} files affected in total`
+    );
+  } catch (err) {
+    setStatus("$(warning) ARCLUX: impact failed");
+    vscode.window.showErrorMessage(`ARCLUX: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+async function commandMenu(): Promise<void> {
+  const choice = await vscode.window.showQuickPick(
+    [
+      { label: "$(refresh) Refresh status", description: "Re-read GET /analysis now", id: "refresh" },
+      { label: "$(type-hierarchy) Impact (current file)…", description: "What breaks if I change this file", id: "impact" },
+      { label: "$(plug) Reconnect", description: "Force a reconnect to the daemon", id: "reconnect" },
+      {
+        label: "$(open-preview) Open analysis report",
+        description: lastAnalysis ? `${lastAnalysis.moduleCount} modules` : "no analysis yet",
+        id: "report",
+      },
+    ],
+    { placeHolder: "ARCLUX — choose an action" }
+  );
+  if (!choice) return;
+
+  if (choice.id === "refresh") await refreshAnalysis();
+  if (choice.id === "impact") await commandImpact();
+  if (choice.id === "reconnect" && workspaceRoot) connect(workspaceRoot);
+  if (choice.id === "report") {
+    const text = lastAnalysis
+      ? `ARCLUX ${lastAnalysis.meta.name ?? ""}: ${lastAnalysis.moduleCount} modules` +
+        (lastAnalysis.graph ? `, ${lastAnalysis.graph.nodes} nodes / ${lastAnalysis.graph.edges} edges` : "") +
+        (lastAnalysis.scan ? `, ${lastAnalysis.scan.filesParsed} files parsed` : "")
+      : "ARCLUX: no analysis yet — start the daemon and run refresh.";
+    vscode.window.showInformationMessage(text);
+  }
 }
 
 export function activate(context: vscode.ExtensionContext): void {
   statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
+  statusBarItem.command = "arclux.menu";
   statusBarItem.show();
   context.subscriptions.push(statusBarItem);
 
   diagnosticCollection = vscode.languages.createDiagnosticCollection("arclux");
   context.subscriptions.push(diagnosticCollection);
 
-  const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (workspaceRoot) {
+  workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? null;
+
+  const setup = () => {
+    if (!workspaceRoot) {
+      setStatus("$(circle-slash) ARCLUX: no workspace open");
+      return;
+    }
     connect(workspaceRoot);
-  } else {
-    statusBarItem.text = "$(circle-slash) ARCLUX: no workspace open";
-  }
+
+    // Auto-connect: when a daemon endpoint appears/disappears later
+    // (daemon started after the editor, or stopped), react immediately
+    // instead of waiting for the next poll.
+    closeEndpointWatcher?.();
+    closeEndpointWatcher = watchEndpointsDir((endpoints) => {
+      const found = findDaemonEndpoint(workspaceRoot!);
+      if (found && !endpoint) {
+        connect(workspaceRoot!);
+      } else if (!found && endpoint) {
+        endpoint = null;
+        closeSse?.();
+        setStatus("$(circle-slash) ARCLUX: not running", "Run `arclux daemon --detach` in this repository's terminal");
+      }
+    });
+
+    // Keep the status bar fresh even if SSE never reconnects.
+    if (pollTimer) clearInterval(pollTimer);
+    pollTimer = setInterval(() => refreshAnalysis(), POLL_INTERVAL_MS);
+  };
+
+  setup();
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("arclux.connectDaemon", () => {
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? null;
+      setup();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("arclux.connect", () => {
       if (workspaceRoot) connect(workspaceRoot);
     })
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand("arclux.showAnalysis", () => {
-      vscode.window.showInformationMessage(statusBarItem.text);
-    })
+    vscode.commands.registerCommand("arclux.refresh", () => refreshAnalysis())
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("arclux.impact", () => commandImpact())
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("arclux.menu", () => commandMenu())
   );
 }
 
 export function deactivate(): void {
   closeSse?.();
+  closeEndpointWatcher?.();
+  if (pollTimer) clearInterval(pollTimer);
   diagnosticCollection?.dispose();
 }

--- a/packages/daemon/ArcluxDaemon.ts
+++ b/packages/daemon/ArcluxDaemon.ts
@@ -23,6 +23,7 @@ import { computeDaemonId } from "./DaemonProcess";
 import { NotificationManager } from "../notifications/NotificationManager";
 import type { NotificationChannel } from "../notifications/NotificationChannel";
 import { PlatformOrchestrator } from "../orchestration/PlatformOrchestrator";
+import { calculateAffectedFiles } from "../impact/calculateAffectedFiles";
 
 export interface ArcluxDaemonOptions {
   rootPath: string;
@@ -34,6 +35,18 @@ export interface ArcluxDaemonOptions {
    * and emits, just nobody receives notifications.
    */
   notificationChannels?: NotificationChannel[];
+}
+
+export interface ImpactQueryResult {
+  ok: boolean;
+  file: string;
+  moduleId?: string;
+  error?: string;
+  suggestions?: string[];
+  consumers?: string[];
+  directConsumers?: number;
+  affected?: { moduleId: string; filePath: string; distance: number }[];
+  totalAffected?: number;
 }
 
 export class ArcluxDaemon {
@@ -62,6 +75,44 @@ export class ArcluxDaemon {
   async getAnalysis() {
     if (!this.watcher) throw new Error("daemon not started");
     return this.watcher.getAnalysis();
+  }
+
+  /**
+   * Impact analysis for one file, computed live from the in-memory
+   * repository: direct consumers (importers) plus the transitive
+   * affected set (calculateAffectedFiles). Serves GET /impact?file=.
+   */
+  async getImpact(filePath: string): Promise<ImpactQueryResult> {
+    if (!this.watcher) throw new Error("daemon not started");
+    const result = await this.watcher.getAnalysis();
+    const repository = result.repository;
+
+    const module = repository
+      .getAllModules()
+      .find((m) => m.file.relativePath === filePath || m.file.relativePath.endsWith(`/${filePath}`));
+    if (!module) {
+      return {
+        ok: false,
+        file: filePath,
+        error: `module not found: ${filePath}`,
+        suggestions: repository
+          .getAllModules()
+          .map((m) => m.file.relativePath)
+          .filter((p) => p.toLowerCase().includes(filePath.toLowerCase()))
+          .slice(0, 5),
+      };
+    }
+
+    const impact = calculateAffectedFiles(repository, module.id);
+    return {
+      ok: true,
+      file: module.file.relativePath,
+      moduleId: module.id,
+      consumers: module.importedBy.map((id) => repository.getModule(id)?.file.relativePath ?? id),
+      directConsumers: module.importedBy.length,
+      affected: impact.affectedFiles,
+      totalAffected: impact.totalAffected,
+    };
   }
 
   start(): void {

--- a/packages/daemon/LocalBridgeServer.ts
+++ b/packages/daemon/LocalBridgeServer.ts
@@ -32,7 +32,8 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
 
 /**
  * Starts an HTTP server exposing:
- *   GET  /analysis     -- current analysis (moduleCount, meta), same data as `arclux analyze`
+ *   GET  /analysis     -- current analysis (moduleCount, meta, graph, scan), same data as `arclux analyze`
+ *   GET  /impact?file= -- impact analysis for one file: consumers + transitive affected set
  *   GET  /diagnostics   -- last diagnostics run (see packages/diagnostics/DiagnosticEngine.ts)
  *   GET  /events        -- SSE stream: emits "analysis" and "diagnostics" events as they happen
  * Listens on `port` (see packages/networking/PortManager.ts for how the
@@ -66,9 +67,33 @@ export function startLocalBridgeServer(daemon: ArcluxDaemon, port: number): Prom
     if (url === "/analysis") {
       try {
         const result = await daemon.getAnalysis();
-        sendJson(res, 200, { moduleCount: result.moduleCount, meta: result.meta });
+        sendJson(res, 200, {
+          moduleCount: result.moduleCount,
+          meta: result.meta,
+          graph: { nodes: result.graph.nodes.length, edges: result.graph.edges.length },
+          scan: {
+            filesScanned: result.scanSummary.filesScanned,
+            filesParsed: result.scanSummary.filesParsed,
+          },
+        });
       } catch (err) {
         sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) });
+      }
+      return;
+    }
+
+    if (url.startsWith("/impact")) {
+      try {
+        const query = new URL(url, "http://127.0.0.1").searchParams;
+        const file = query.get("file");
+        if (!file) {
+          sendJson(res, 400, { ok: false, error: "missing ?file=<relative path> query parameter" });
+          return;
+        }
+        const result = await daemon.getImpact(file);
+        sendJson(res, result.ok ? 200 : 404, result);
+      } catch (err) {
+        sendJson(res, 500, { ok: false, error: err instanceof Error ? err.message : String(err) });
       }
       return;
     }


### PR DESCRIPTION
**Daemon (packages/daemon):**
- GET /impact?file= — impact analysis for one file: direct consumers + transitive affected set (calculateAffectedFiles), 404 + suggestions on unknown files
- GET /analysis enriched: graph (nodes/edges) + scan (filesScanned/filesParsed)
- ArcluxDaemon.getImpact() — live query against the in-memory repository

**VS Code extension (apps/vscode-extension) — from minimal to hardened:**
- Auto-connect: watches ~/.arclux/endpoints/ so the extension connects when the daemon starts AFTER the editor, and disconnects when it stops
- SSE auto-reconnect with backoff (1s→30s), malformed-frame tolerance
- 30s poll of GET /analysis so status stays fresh even without SSE
- arclux.impact command: trace impact of the active file (or any relative path), quick-pick consumers/affected files → jump to file; right-click in editor
- arclux.menu (status bar click), arclux.refresh, arclux.connect
- Workspace folder change → reconnect; full cleanup in deactivate
- 3-severity diagnostics mapping (error/warning/info)

Verified: 83-module flask repo — /analysis returns graph+scan, /impact on flask/app.py = 6 direct consumers / 21 affected; missing file → 404 + suggestions; extension tsc build clean; full suite 641/641.