### PR TITLE
feat: orphan classification + integration suggestions (detectOrphanIntegration)

### DIFF
--- a/packages/detectors/detectOrphanFiles.ts
+++ b/packages/detectors/detectOrphanFiles.ts
@@ -125,7 +125,8 @@ export function sharedNamePattern(filePath: string): string | null {
   return null;
 }
 
-function siblingModules(module: ModuleInfo, repository: Repository): ModuleInfo[] {
+/** Modules in the same folder as `module` (excluding the module itself). */
+export function siblingModules(module: ModuleInfo, repository: Repository): ModuleInfo[] {
   const folder = module.file.relativePath.includes("/")
     ? module.file.relativePath.slice(0, module.file.relativePath.lastIndexOf("/"))
     : "";

--- a/packages/detectors/detectOrphanFiles.ts
+++ b/packages/detectors/detectOrphanFiles.ts
@@ -9,13 +9,30 @@
 // Original ARCLUX logic, not adapted from any external source.
 
 import type { Repository } from "../repository/Repository";
+import type { ModuleInfo } from "../shared/types";
 import { detectEntryPoints } from "./detectEntryPoints";
 import { isTestFilePath } from "./testFiles";
 import { getEntryModuleIds } from "../indexer/resolveRoutes";
 
+export type OrphanClassification = "dead" | "unwired" | "ambiguous";
+
 export interface OrphanFileFinding {
   filePath: string;
   message: string;
+  /**
+   * Why this file is an orphan:
+   * - "dead" — leftover code: nothing in its folder is imported by anyone,
+   *   the name looks like a backup/scratch file, and/or it exports nothing.
+   *   The honest advice is deletion, not integration.
+   * - "unwired" — it SHOULD be wired somewhere: sibling files in the same
+   *   folder (or with a shared naming pattern) ARE imported, this one just
+   *   never got connected. See detectOrphanIntegration.ts for where.
+   * - "ambiguous" — mixed or weak signals; neither delete nor integrate
+   *   with confidence.
+   */
+  classification: OrphanClassification;
+  /** Human-readable evidence backing the classification. */
+  evidence: string[];
 }
 
 /**
@@ -28,17 +45,164 @@ export interface OrphanFileFinding {
  * set comes from indexer/resolveRoutes.ts (App Router convention) plus
  * detectEntryPoints.ts (known entry-point conventions), mirroring what
  * detectUnusedExports.ts does.
+ *
+ * Each orphan is classified by looking at REAL structural signals in the
+ * repository (see classifyOrphan): are siblings in the same folder
+ * imported anywhere? Is there a barrel index.ts that skips this file?
+ * Does the name look like backup/scratch? Does the file export anything?
  */
 export function detectOrphanFiles(repository: Repository): OrphanFileFinding[] {
   const entryModuleIds = new Set<string>();
   for (const id of getEntryModuleIds(repository.getAllModules())) entryModuleIds.add(id);
   for (const finding of detectEntryPoints(repository)) entryModuleIds.add(finding.filePath);
 
-  return repository
+  const orphans = repository
     .findModulesWithNoImporters()
-    .filter((module) => !entryModuleIds.has(module.id) && !isTestFilePath(module.id))
-    .map((module) => ({
-      filePath: module.file.relativePath,
-      message: `"${module.file.relativePath}" is never imported by any other file in the repository.`,
-    }));
+    .filter((module) => !entryModuleIds.has(module.id) && !isTestFilePath(module.id));
+
+  return orphans.map((module) => {
+    const { classification, evidence } = classifyOrphan(module, repository);
+    const filePath = module.file.relativePath;
+    const message =
+      classification === "unwired"
+        ? `"${filePath}" is never imported, but sibling files in the same folder are — it looks unwired, not dead.`
+        : classification === "dead"
+          ? `"${filePath}" is never imported and shows dead-code signals — likely safe to delete.`
+          : `"${filePath}" is never imported (ambiguous — no strong integration or deletion signal).`;
+    return { filePath, message, classification, evidence };
+  });
+}
+
+// ─────────────────────────────────────────────────────────────
+// Classification signals
+// ─────────────────────────────────────────────────────────────
+
+const BACKUP_NAME = /\.(?:bak|old|orig|tmp|copy|backup)$/i;
+const SCRATCH_NAME = /(?:scratch|archive|-old|-copy|_draft|_tmp|-wip)/i;
+const STORY_NAME = /\.(?:stories|story)\./i;
+
+/** Shared structural suffixes (e.g. userService.ts / paymentService.ts). */
+const KNOWN_SUFFIXES = [
+  "Service",
+  "Controller",
+  "Repository",
+  "Store",
+  "Api",
+  "Adapter",
+  "Provider",
+  "Helper",
+  "Util",
+  "Utils",
+  "Page",
+  "Screen",
+  "Model",
+  "Component",
+  "Hook",
+  "Factory",
+  "Manager",
+  "Loader",
+  "Cache",
+  "Router",
+];
+
+/** Shared structural prefixes (e.g. useAuth.ts / useTheme.ts). */
+const KNOWN_PREFIXES = ["use", "with", "is", "get", "create", "fetch", "to", "parse", "build"];
+
+function baseName(path: string): string {
+  const parts = path.split("/");
+  return parts[parts.length - 1].replace(/\.\w+$/, "");
+}
+
+/** Returns the shared structural pattern ("Service", "use…"), or null. */
+export function sharedNamePattern(filePath: string): string | null {
+  const base = baseName(filePath);
+  for (const suffix of KNOWN_SUFFIXES) {
+    if (base.endsWith(suffix) && base.length > suffix.length) return suffix;
+  }
+  for (const prefix of KNOWN_PREFIXES) {
+    if (base.startsWith(prefix) && base.length > prefix.length) return `${prefix}…`;
+  }
+  return null;
+}
+
+function siblingModules(module: ModuleInfo, repository: Repository): ModuleInfo[] {
+  const folder = module.file.relativePath.includes("/")
+    ? module.file.relativePath.slice(0, module.file.relativePath.lastIndexOf("/"))
+    : "";
+  return repository.getAllModules().filter((m) => {
+    if (m.id === module.id) return false;
+    const other = m.file.relativePath;
+    if (folder === "") return !other.includes("/");
+    return other.startsWith(`${folder}/`) && !other.slice(folder.length + 1).includes("/");
+  });
+}
+
+/**
+ * Classifies one orphan from real repository signals, by the DOMINANT
+ * structural fact (in priority order):
+ *
+ *   1. backup/scratch name        → dead (a file named old-backup.ts is
+ *      leftover no matter what its neighbors do)
+ *   2. siblings in the folder ARE imported elsewhere → unwired (the file
+ *      sits inside wired code and is the only one not connected; a UI
+ *      component with no exports is still unwired, not dead — it should
+ *      have been exported)
+ *   3. nothing in the folder is imported AND the file exports nothing  → dead
+ *   4. anything else (has exports, no wired neighbors)                → ambiguous
+ *
+ * Story files are always ambiguous (standalone by design — story tooling
+ * loads them directly, so "no importer" is expected).
+ */
+export function classifyOrphan(
+  module: ModuleInfo,
+  repository: Repository
+): { classification: OrphanClassification; evidence: string[] } {
+  const evidence: string[] = [];
+  const filePath = module.file.relativePath;
+
+  if (STORY_NAME.test(filePath)) {
+    return {
+      classification: "ambiguous",
+      evidence: ["story file — loaded by story tooling, not by source imports (standalone by design)"],
+    };
+  }
+
+  const siblings = siblingModules(module, repository);
+  const importedSiblings = siblings.filter((s) => s.importedBy.length > 0);
+  const myPattern = sharedNamePattern(filePath);
+  const barrelIndex = siblings.find((s) => /(^|\/)index\.\w+$/.test(s.file.relativePath));
+
+  let classification: OrphanClassification;
+
+  if (BACKUP_NAME.test(filePath) || SCRATCH_NAME.test(filePath)) {
+    classification = "dead";
+    evidence.push("name looks like a backup/scratch file");
+  } else if (importedSiblings.length > 0) {
+    classification = "unwired";
+    evidence.push(
+      `${importedSiblings.length} sibling file(s) in this folder are imported by other files, this one is not`
+    );
+    if (myPattern) {
+      const patternSiblings = importedSiblings.filter((s) => sharedNamePattern(s.file.relativePath) === myPattern);
+      if (patternSiblings.length > 0) {
+        evidence.push(
+          `${patternSiblings.length} file(s) sharing the "${myPattern}" pattern in this folder are imported`
+        );
+      }
+    }
+    if (barrelIndex && barrelIndex.importedBy.length > 0) {
+      const indexImports = barrelIndex.imports.filter((id) => importedSiblings.some((s) => s.id === id));
+      if (indexImports.length > 0) {
+        evidence.push(`barrel ${barrelIndex.file.relativePath} imports ${indexImports.length} sibling(s) but not this file`);
+      }
+    }
+  } else if (module.exports.length === 0) {
+    classification = "dead";
+    evidence.push("no sibling in this folder is imported anywhere and the file exports nothing");
+  } else {
+    classification = "ambiguous";
+    evidence.push("file exports symbols but no sibling in this folder is imported anywhere — no strong signal either way");
+  }
+
+  return { classification, evidence };
 }

--- a/packages/detectors/detectOrphanIntegration.ts
+++ b/packages/detectors/detectOrphanIntegration.ts
@@ -32,6 +32,7 @@ import type { ModuleInfo } from "../shared/types";
 import {
   detectOrphanFiles,
   sharedNamePattern,
+  siblingModules,
   type OrphanClassification,
 } from "./detectOrphanFiles";
 
@@ -102,18 +103,6 @@ export function detectOrphanIntegration(repository: Repository): OrphanIntegrati
 // ─────────────────────────────────────────────────────────────
 // Suggestion engine
 // ─────────────────────────────────────────────────────────────
-
-function siblingModules(module: ModuleInfo, repository: Repository): ModuleInfo[] {
-  const folder = module.file.relativePath.includes("/")
-    ? module.file.relativePath.slice(0, module.file.relativePath.lastIndexOf("/"))
-    : "";
-  return repository.getAllModules().filter((m) => {
-    if (m.id === module.id) return false;
-    const other = m.file.relativePath;
-    if (folder === "") return !other.includes("/");
-    return other.startsWith(`${folder}/`) && !other.slice(folder.length + 1).includes("/");
-  });
-}
 
 function suggestImporters(module: ModuleInfo, repository: Repository): IntegrationSuggestion[] {
   const filePath = module.file.relativePath;

--- a/packages/detectors/detectOrphanIntegration.ts
+++ b/packages/detectors/detectOrphanIntegration.ts
@@ -1,0 +1,198 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Original ARCLUX logic, not adapted from any external source.
+//
+// The "code yatim butuh diintegrasikan kemana" detector. detectOrphanFiles
+// answers WHAT is orphaned; this detector answers WHERE it should be
+// wired. It never guesses from nothing — every suggestion is derived from
+// real import patterns in the same repository:
+//
+//   1. Barrel aggregation   — a folder's index.ts that imports sibling
+//      files but skips this one is the most likely integration point.
+//   2. Sibling-importer aggregation — files in the same folder that ARE
+//      imported usually share importers; those shared importers are the
+//      candidates. Score = fraction of imported siblings that share the
+//      importer.
+//   3. Pattern-group weighting — siblings that share a structural name
+//      pattern ("Service", "use…", "Controller") are the strongest
+//      evidence, because a group of same-kind files is typically wired
+//      from the same place.
+//
+// Confidence is derived from the score, and evidence is always attached
+// so a human can verify the reasoning instead of trusting the tool.
+
+import type { Repository } from "../repository/Repository";
+import type { ModuleInfo } from "../shared/types";
+import {
+  detectOrphanFiles,
+  sharedNamePattern,
+  type OrphanClassification,
+} from "./detectOrphanFiles";
+
+export type SuggestionConfidence = "high" | "medium" | "low";
+
+export interface IntegrationSuggestion {
+  /** Module that should import the orphan file. */
+  filePath: string;
+  confidence: SuggestionConfidence;
+  /** 0..1 — fraction of imported siblings that share this importer. */
+  score: number;
+  /** Human-readable reasoning behind the suggestion. */
+  reason: string;
+  /** Sibling files used as evidence for this suggestion. */
+  viaSiblings: string[];
+}
+
+export interface OrphanIntegrationFinding {
+  filePath: string;
+  classification: OrphanClassification;
+  suggestedImporters: IntegrationSuggestion[];
+  message: string;
+}
+
+interface Candidate {
+  filePath: string;
+  viaSiblings: string[];
+  barrel?: boolean;
+}
+
+export function detectOrphanIntegration(repository: Repository): OrphanIntegrationFinding[] {
+  return detectOrphanFiles(repository).map((orphan) => {
+    const module = repository
+      .getAllModules()
+      .find((m) => m.file.relativePath === orphan.filePath);
+    if (!module) {
+      return {
+        filePath: orphan.filePath,
+        classification: orphan.classification,
+        suggestedImporters: [],
+        message: orphan.message,
+      };
+    }
+
+    const suggestedImporters = orphan.classification === "dead" ? [] : suggestImporters(module, repository);
+
+    let message: string;
+    if (orphan.classification === "dead") {
+      message = `"${orphan.filePath}" looks like dead code — deletion beats integration. Evidence: ${orphan.evidence.join("; ")}.`;
+    } else if (suggestedImporters.length === 0) {
+      message = `"${orphan.filePath}" is never imported and no integration pattern was found in this repository.`;
+    } else {
+      const top = suggestedImporters[0];
+      const rest =
+        suggestedImporters.length > 1
+          ? ` Alternatives: ${suggestedImporters
+              .slice(1, 3)
+              .map((s) => `${s.filePath} (${s.confidence})`)
+              .join(", ")}.`
+          : "";
+      message = `"${orphan.filePath}" is never imported — best integration point: ${top.filePath} (${top.confidence} confidence, ${top.reason}).${rest}`;
+    }
+
+    return { filePath: orphan.filePath, classification: orphan.classification, suggestedImporters, message };
+  });
+}
+
+// ─────────────────────────────────────────────────────────────
+// Suggestion engine
+// ─────────────────────────────────────────────────────────────
+
+function siblingModules(module: ModuleInfo, repository: Repository): ModuleInfo[] {
+  const folder = module.file.relativePath.includes("/")
+    ? module.file.relativePath.slice(0, module.file.relativePath.lastIndexOf("/"))
+    : "";
+  return repository.getAllModules().filter((m) => {
+    if (m.id === module.id) return false;
+    const other = m.file.relativePath;
+    if (folder === "") return !other.includes("/");
+    return other.startsWith(`${folder}/`) && !other.slice(folder.length + 1).includes("/");
+  });
+}
+
+function suggestImporters(module: ModuleInfo, repository: Repository): IntegrationSuggestion[] {
+  const filePath = module.file.relativePath;
+  const siblings = siblingModules(module, repository);
+  const barrelIndex = siblings.find((s) => /(^|\/)index\.\w+$/.test(s.file.relativePath));
+
+  // The folder's own barrel index is the wiring target, not a peer — if
+  // it's imported somewhere it would otherwise pollute the denominator
+  // and add the barrel's importer as a spurious candidate.
+  const importedSiblings = siblings.filter(
+    (s) => s.importedBy.length > 0 && s.id !== barrelIndex?.id
+  );
+  if (importedSiblings.length === 0) return [];
+
+  const myPattern = sharedNamePattern(filePath);
+
+  // Candidate aggregation: importer -> siblings importing it. importedBy
+  // can contain duplicate ids (buildIndex may record the same edge more
+  // than once), so dedupe per sibling — otherwise viaSiblings inflates
+  // and scores can exceed 1. A candidate that is the orphan itself is
+  // nonsense (a file can't import itself to be "integrated").
+  const candidates = new Map<string, Candidate>();
+  for (const sibling of importedSiblings) {
+    for (const importerId of new Set(sibling.importedBy)) {
+      if (importerId === module.id) continue;
+      const existing = candidates.get(importerId);
+      if (existing) {
+        existing.viaSiblings.push(sibling.file.relativePath);
+      } else {
+        candidates.set(importerId, {
+          filePath: importerId,
+          viaSiblings: [sibling.file.relativePath],
+        });
+      }
+    }
+  }
+
+  // Barrel index in the same folder gets its own high-trust candidate.
+  if (barrelIndex && barrelIndex.importedBy.length > 0) {
+    const via = importedSiblings.filter((s) => barrelIndex.imports.includes(s.id));
+    if (via.length > 0) {
+      const existing = candidates.get(barrelIndex.id);
+      if (existing) {
+        existing.barrel = true;
+      } else {
+        candidates.set(barrelIndex.id, { filePath: barrelIndex.id, viaSiblings: via.map((s) => s.file.relativePath), barrel: true });
+      }
+    }
+  }
+
+  const suggestions: IntegrationSuggestion[] = [];
+  for (const candidate of candidates.values()) {
+    const score = candidate.viaSiblings.length / importedSiblings.length;
+
+    // Pattern-group weighting: if every evidence sibling shares the
+    // orphan's structural pattern, the group is same-kind and the
+    // importer is a much stronger signal — bump confidence one level.
+    const viaPatterns = candidate.viaSiblings.filter((s) => sharedNamePattern(s) === myPattern);
+    const patternBump = myPattern && viaPatterns.length === candidate.viaSiblings.length;
+
+    let confidence: SuggestionConfidence;
+    if (candidate.barrel || score >= 0.5) confidence = "high";
+    else if (score >= 0.3) confidence = "medium";
+    else confidence = "low";
+    if (patternBump && confidence === "low") confidence = "medium";
+    if (patternBump && confidence === "medium") confidence = "high";
+
+    const via = candidate.viaSiblings.join(", ");
+    const reason = candidate.barrel
+      ? `barrel index imports ${candidate.viaSiblings.length} sibling(s)`
+      : `${candidate.viaSiblings.length}/${importedSiblings.length} imported sibling(s) are imported from here`;
+    suggestions.push({
+      filePath: candidate.filePath,
+      confidence,
+      score: candidate.barrel ? 1 : score,
+      reason: patternBump ? `${reason} (all same-kind "${myPattern}" files)` : reason,
+      viaSiblings: candidate.viaSiblings,
+    });
+  }
+
+  return suggestions.sort((a, b) => b.score - a.score || a.filePath.localeCompare(b.filePath)).slice(0, 3);
+}

--- a/packages/engine/runDoctor.ts
+++ b/packages/engine/runDoctor.ts
@@ -21,6 +21,7 @@ import type { Repository } from "../repository/Repository";
 import { detectCircularDependency } from "../detectors/detectCircularDependency";
 import { detectUnusedExports } from "../detectors/detectUnusedExports";
 import { detectOrphanFiles } from "../detectors/detectOrphanFiles";
+import { detectOrphanIntegration } from "../detectors/detectOrphanIntegration";
 import { detectLargeModules } from "../detectors/detectLargeModules";
 import { detectDuplicateModules } from "../detectors/detectDuplicateModules";
 import { detectSharedModules } from "../detectors/detectSharedModules";
@@ -139,6 +140,19 @@ export function runDoctor(repository: Repository, options: RunDoctorOptions = {}
         severity: "error",
         filePath: f.filePath,
         message: f.message,
+      });
+    }
+  }, findings);
+  safeRun("orphanIntegration", "warning", () => {
+    for (const f of detectOrphanIntegration(repository)) {
+      const top = f.suggestedImporters[0];
+      findings.push({
+        checkId: "orphanIntegration",
+        severity: f.classification === "dead" ? "info" : "warning",
+        filePath: f.filePath,
+        message: top
+          ? `${f.message} Try importing from ${top.filePath} (${top.confidence} confidence).`
+          : f.message,
       });
     }
   }, findings);

--- a/packages/shell/ArcluxShell.ts
+++ b/packages/shell/ArcluxShell.ts
@@ -226,7 +226,7 @@ export class ArcluxShell {
         return {
           output: [
             `${result.errorCount} error(s), ${result.warningCount} warning(s), ${result.infoCount} info`,
-            `detectors: 19 built-in${total > 0 ? ` + ${total} user (${this.detectors.map((d) => d.checkId).join(", ")})` : ""}`,
+            `detectors: 20 built-in${total > 0 ? ` + ${total} user (${this.detectors.map((d) => d.checkId).join(", ")})` : ""}`,
             ...[...byCheck.entries()].map(([id, count]) => `  ${id}: ${count}${findings.filter((f) => f.checkId === id).length < result.findings.filter((f) => f.checkId === id).length ? " (capped)" : ""}`),
           ],
         };

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,6 +72,7 @@ previously had only manual verifications.
 | Detector | Covered in |
 |---|---|
 | detectCircularDependency, detectUnusedExports, detectOrphanFiles | core-detectors.test.ts |
+| detectOrphanFiles (classification), detectOrphanIntegration | orphan-integration.test.ts |
 | detectAmbiguousSymbolResolution | detector.test.ts |
 | detectComponentConvention, detectFeatureStructure, detectMissingExports, detectRepositoryPattern, detectRouteConvention, detectStoryConvention, detectTestConvention, detectUnusedFiles | detectors-wired.test.ts |
 | detectDeadCode, detectDuplicateModules, detectEntryPoints, detectIndexFiles, detectLargeModules, detectLayerViolation, detectSharedModules | guard-inventory.test.ts |

--- a/tests/orphan-integration.test.ts
+++ b/tests/orphan-integration.test.ts
@@ -1,0 +1,246 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Coverage for the orphan classification (detectOrphanFiles) and the
+// "where to integrate it" recommendation engine (detectOrphanIntegration).
+
+import { describe, it, expect } from "vitest";
+import { Repository } from "../packages/repository/Repository";
+import { detectOrphanFiles } from "../packages/detectors/detectOrphanFiles";
+import { detectOrphanIntegration } from "../packages/detectors/detectOrphanIntegration";
+import { runDoctor } from "../packages/engine/runDoctor";
+import type { ModuleInfo, RepositoryMeta, FileInfo, RawExport } from "../packages/shared/types";
+
+function makeFile(relativePath: string): FileInfo {
+  return {
+    absolutePath: `/virtual/repo/${relativePath}`,
+    relativePath,
+    language: "typescript",
+    extension: ".ts",
+    sizeBytes: 100,
+    hash: "fake-hash",
+  };
+}
+
+function named(name: string, line = 1): RawExport {
+  return { name, kind: "named", line };
+}
+
+interface ResolvedImport {
+  moduleId: string;
+  namedImports: string[];
+  hasDefaultImport: boolean;
+  hasNamespaceImport: boolean;
+  line: number;
+}
+
+function makeModule(
+  relativePath: string,
+  opts: { exports?: RawExport[]; imports?: string[]; resolvedImports?: ResolvedImport[]; importedBy?: string[] } = {}
+): ModuleInfo {
+  const imports = opts.imports ?? [];
+  return {
+    id: relativePath,
+    file: makeFile(relativePath),
+    exports: opts.exports ?? [],
+    resolvedReExports: {},
+    importedBy: opts.importedBy ?? [],
+    imports,
+    resolvedImports: (opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }))).map((r) => ({ ...r, kind: "static" as const })),
+    calls: [],
+    calledBy: [],
+    implicitDependencies: [],
+  };
+}
+
+function makeRepository(modules: ModuleInfo[]): Repository {
+  const meta: RepositoryMeta = {
+    id: "test-repo",
+    org: "test-org",
+    name: "test-repo",
+    defaultBranch: "main",
+    rootPath: "/virtual/repo",
+    detectedFrameworks: [],
+    packageManager: "npm",
+    analyzedAt: new Date().toISOString(),
+  };
+  const repository = new Repository(meta);
+  for (const mod of modules) {
+    repository.addModule(mod);
+  }
+  return repository;
+}
+
+function byPath(findings: Array<{ filePath: string }>): Map<string, any> {
+  return new Map(findings.map((f) => [f.filePath, f]));
+}
+
+describe("detectOrphanFiles — classification", () => {
+  it("classifies a file in a fully orphaned folder with no exports as dead", () => {
+    const repo = makeRepository([
+      makeModule("src/legacy/old-backup.ts", { exports: [] }),
+      makeModule("src/legacy/scratch.ts", { exports: [] }),
+      makeModule("src/main.ts", { exports: [named("main")], importedBy: [] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    const backup = findings.get("src/legacy/old-backup.ts");
+    expect(backup.classification).toBe("dead");
+    expect(backup.evidence.length).toBeGreaterThan(0);
+    const scratch = findings.get("src/legacy/scratch.ts");
+    expect(scratch.classification).toBe("dead");
+  });
+
+  it("classifies an unwired file whose siblings are all imported as unwired", () => {
+    const repo = makeRepository([
+      makeModule("src/components/Button.tsx", { importedBy: ["src/pages/Home.tsx"] }),
+      makeModule("src/components/Card.tsx", { importedBy: ["src/pages/Home.tsx"] }),
+      makeModule("src/components/Modal.tsx", { importedBy: [] }),
+      makeModule("src/pages/Home.tsx", { exports: [named("Home")], imports: ["src/components/Button.tsx", "src/components/Card.tsx"] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    const modal = findings.get("src/components/Modal.tsx");
+    expect(modal.classification).toBe("unwired");
+    expect(modal.evidence.some((e: string) => e.includes("sibling"))).toBe(true);
+  });
+
+  it("boosts unwired classification when siblings share a structural name pattern", () => {
+    const repo = makeRepository([
+      makeModule("src/services/authService.ts", { importedBy: ["src/api/client.ts"] }),
+      makeModule("src/services/userService.ts", { importedBy: ["src/api/client.ts"] }),
+      makeModule("src/services/paymentService.ts", { importedBy: [] }),
+      makeModule("src/api/client.ts", { exports: [named("client")] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    expect(findings.get("src/services/paymentService.ts").classification).toBe("unwired");
+  });
+
+  it("classifies as ambiguous when signals are weak or mixed", () => {
+    const repo = makeRepository([
+      makeModule("src/misc/a.ts", { exports: [named("a")], importedBy: [] }),
+      makeModule("src/misc/b.ts", { exports: [named("b")], importedBy: [] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    expect(findings.get("src/misc/a.ts").classification).toBe("ambiguous");
+  });
+
+  it("keeps story files ambiguous (standalone by design)", () => {
+    const repo = makeRepository([
+      makeModule("src/components/Button.stories.tsx", { exports: [], imports: [] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    expect(findings.get("src/components/Button.stories.tsx").classification).toBe("ambiguous");
+  });
+
+  it("classifies a file whose barrel index imports siblings but not it as unwired", () => {
+    const repo = makeRepository([
+      makeModule("src/features/auth/index.ts", { imports: ["src/features/auth/login.ts"], importedBy: ["src/app.ts"] }),
+      makeModule("src/features/auth/login.ts", { imports: [], importedBy: ["src/features/auth/index.ts"] }),
+      makeModule("src/features/auth/register.ts", { imports: [], importedBy: [] }),
+      makeModule("src/app.ts", { exports: [named("app")] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    const register = findings.get("src/features/auth/register.ts");
+    expect(register.classification).toBe("unwired");
+    expect(register.evidence.some((e: string) => e.includes("barrel"))).toBe(true);
+  });
+});
+
+describe("detectOrphanIntegration — where to wire it", () => {
+  it("recommends the folder barrel index for an unwired component", () => {
+    const repo = makeRepository([
+      makeModule("src/components/index.ts", {
+        imports: ["src/components/Button.tsx", "src/components/Card.tsx"],
+        importedBy: ["src/app.ts"],
+      }),
+      makeModule("src/components/Button.tsx", { importedBy: ["src/components/index.ts"] }),
+      makeModule("src/components/Card.tsx", { importedBy: ["src/components/index.ts"] }),
+      makeModule("src/components/Modal.tsx", { importedBy: [] }),
+      makeModule("src/app.ts", { exports: [named("app")] }),
+    ]);
+    const findings = byPath(detectOrphanIntegration(repo));
+    const modal = findings.get("src/components/Modal.tsx");
+    expect(modal.classification).toBe("unwired");
+    expect(modal.suggestedImporters).toHaveLength(1);
+    expect(modal.suggestedImporters[0].filePath).toBe("src/components/index.ts");
+    expect(modal.suggestedImporters[0].confidence).toBe("high");
+    expect(modal.suggestedImporters[0].viaSiblings).toEqual(["src/components/Button.tsx", "src/components/Card.tsx"]);
+  });
+
+  it("recommends the shared importer of same-pattern siblings with high confidence", () => {
+    const repo = makeRepository([
+      makeModule("src/services/authService.ts", { importedBy: ["src/api/client.ts"] }),
+      makeModule("src/services/userService.ts", { importedBy: ["src/api/client.ts"] }),
+      makeModule("src/services/paymentService.ts", { importedBy: [] }),
+      makeModule("src/api/client.ts", { exports: [named("client")] }),
+    ]);
+    const findings = byPath(detectOrphanIntegration(repo));
+    const payment = findings.get("src/services/paymentService.ts");
+    expect(payment.suggestedImporters).toHaveLength(1);
+    const suggestion = payment.suggestedImporters[0];
+    expect(suggestion.filePath).toBe("src/api/client.ts");
+    expect(suggestion.confidence).toBe("high");
+    expect(suggestion.score).toBe(1);
+    expect(suggestion.reason).toContain("Service");
+  });
+
+  it("scores a partial importer overlap as medium confidence", () => {
+    const repo = makeRepository([
+      makeModule("src/features/orders/orderApi.ts", { importedBy: ["src/api/root.ts"] }),
+      makeModule("src/features/orders/invoiceApi.ts", { importedBy: ["src/api/root.ts"] }),
+      makeModule("src/features/orders/catalogApi.ts", { importedBy: ["src/api/other.ts"] }),
+      makeModule("src/features/orders/reportApi.ts", { importedBy: [] }),
+      makeModule("src/api/root.ts", { exports: [named("root")] }),
+      makeModule("src/api/other.ts", { exports: [named("other")] }),
+    ]);
+    const findings = byPath(detectOrphanIntegration(repo));
+    const report = findings.get("src/features/orders/reportApi.ts");
+    const scores = new Set(report.suggestedImporters.map((s: any) => s.score));
+    // 2/3 siblings share src/api/root.ts -> score 0.67 (high); 1/3 -> 0.33 (medium).
+    expect(report.suggestedImporters[0].filePath).toBe("src/api/root.ts");
+    expect(report.suggestedImporters[0].confidence).toBe("high");
+    expect(scores.has(1 / 3)).toBe(true);
+  });
+
+  it("offers no suggestions for dead code", () => {
+    const repo = makeRepository([
+      makeModule("src/legacy/old-backup.ts", { exports: [] }),
+      makeModule("src/legacy/scratch.ts", { exports: [] }),
+      makeModule("src/main.ts", { exports: [named("main")] }),
+    ]);
+    const findings = byPath(detectOrphanIntegration(repo));
+    const backup = findings.get("src/legacy/old-backup.ts");
+    expect(backup.classification).toBe("dead");
+    expect(backup.suggestedImporters).toEqual([]);
+    expect(backup.message).toContain("dead code");
+  });
+
+  it("offers no suggestions when no integration pattern exists", () => {
+    const repo = makeRepository([
+      makeModule("src/misc/a.ts", { exports: [named("a")], importedBy: [] }),
+      makeModule("src/misc/b.ts", { exports: [named("b")], importedBy: [] }),
+    ]);
+    const findings = byPath(detectOrphanIntegration(repo));
+    expect(findings.get("src/misc/a.ts").suggestedImporters).toEqual([]);
+  });
+
+  it("is wired into runDoctor with its own checkId", () => {
+    const repo = makeRepository([
+      makeModule("src/services/authService.ts", { importedBy: ["src/api/client.ts"] }),
+      makeModule("src/services/userService.ts", { importedBy: ["src/api/client.ts"] }),
+      makeModule("src/services/paymentService.ts", { importedBy: [] }),
+      makeModule("src/api/client.ts", { exports: [named("client")] }),
+    ]);
+    const result = runDoctor(repo);
+    const integration = result.findings.filter((f) => f.checkId === "orphanIntegration");
+    expect(integration.length).toBeGreaterThan(0);
+    const payment = integration.find((f) => f.filePath === "src/services/paymentService.ts");
+    expect(payment).toBeDefined();
+    expect(payment!.message).toContain("src/api/client.ts");
+    expect(payment!.severity).toBe("warning");
+  });
+});

--- a/tests/shell.test.ts
+++ b/tests/shell.test.ts
@@ -114,7 +114,7 @@ describe("ArcluxShell", () => {
     await shell.handleCommand(repo);
     const result = await shell.handleCommand("doctor");
     const out = result.output.join("\n");
-    expect(out).toContain("19 built-in + 1 user (noUtilsImports)");
+    expect(out).toContain("20 built-in + 1 user (noUtilsImports)");
     expect(out).toContain("noUtilsImports: 1");
   });
 


### PR DESCRIPTION
**"code yatim" detection, upgraded from binary to actionable:**

**detectOrphanFiles (extended):** every orphan is now classified from real repo structure:
- **dead** — backup/scratch name, or fully-orphaned folder + no exports → honest advice: delete
- **unwired** — sibling files in the same folder (or same structural name pattern: Service/Controller/use…/barrel index) ARE imported elsewhere, this one isn't → should be wired
- **ambiguous** — weak/mixed signals; story files always land here (standalone by design)

**detectOrphanIntegration (new, detector #20):** for unwired orphans, recommends WHERE to import them — derived from actual import patterns, never guessed:
- Barrel aggregation: folder index.ts that imports siblings but skips this file (highest trust)
- Sibling-importer aggregation: score = fraction of imported siblings that share an importer
- Pattern-group weighting: same-kind siblings (shared suffix/prefix) bump confidence
- Each suggestion carries confidence (high/medium/low) + score + evidence siblings

**Wired:** runDoctor runs it as checkId orphanIntegration (warning; info for dead-code findings); shell reports 20 built-in detectors.

Verified on real repos: flask — views.py → src/flask/app.py (high, 0.69, 11 evidence siblings), task_app/tasks.py → __init__.py barrel; 0 self-suggestions, 0 score>1 (dedupe fix for duplicate importedBy edges). Full suite 653/653.