### PR TITLE
feat: ARCLUX scripting language — a DSL that grows with the engine registries

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -29,6 +29,7 @@ import { registerSystemCommand } from "./commands/system";
 import { registerLanguageCommand } from "./language";
 import { registerSecurityCommand } from "./security";
 import { registerShellCommand } from "./shell";
+import { registerScriptCommand } from "./script";
 
 const program = new Command();
 program.name("arclux").description("Repository intelligence CLI").version("0.1.0");
@@ -54,5 +55,6 @@ registerSystemCommand(program);
 registerLanguageCommand(program);
 registerSecurityCommand(program);
 registerShellCommand(program);
+registerScriptCommand(program);
 
 program.parse();

--- a/apps/cli/script.ts
+++ b/apps/cli/script.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// `arclux script <file.arclux>` — run a reusable ARCLUX analysis
+// pipeline. The language is registry-driven: analyze/doctor/impact/
+// graph/search/security are real engine calls, and new parsers or
+// detectors appear in the language automatically.
+
+import type { Command } from "commander";
+import { runScriptFile } from "../../packages/dsl/script";
+
+export function registerScriptCommand(program: Command): void {
+  program
+    .command("script")
+    .description("Run an .arclux script — a reusable analysis pipeline")
+    .argument("<file>", "path to the .arclux script")
+    .action(async (filePath: string) => {
+      try {
+        const { output } = await runScriptFile(filePath);
+        for (const line of output) console.log(line);
+      } catch (err) {
+        console.error(`script failed: ${err instanceof Error ? err.message : String(err)}`);
+        process.exitCode = 1;
+      }
+    });
+}

--- a/packages/dsl/ast.ts
+++ b/packages/dsl/ast.ts
@@ -1,0 +1,146 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// AST for the ARCLUX scripting language. Node shapes are deliberately
+// simple (discriminated unions) so the tree-walking runtime stays small.
+
+export type Node =
+  | ProgramNode
+  | LetNode
+  | AssignNode
+  | IfNode
+  | ForNode
+  | WhileNode
+  | FnNode
+  | ReturnNode
+  | BreakNode
+  | ContinueNode
+  | ExprStmtNode
+  | LiteralNode
+  | IdentifierNode
+  | CallNode
+  | MemberNode
+  | IndexNode
+  | BinaryNode
+  | UnaryNode
+  | ListNode
+  | ObjectNode;
+
+export interface ProgramNode {
+  type: "Program";
+  body: Node[];
+}
+
+export interface LetNode {
+  type: "Let";
+  name: string;
+  value: Node;
+}
+
+export interface AssignNode {
+  type: "Assign";
+  name: string;
+  value: Node;
+}
+
+export interface IfNode {
+  type: "If";
+  test: Node;
+  consequent: Node[];
+  alternate: Node[] | null;
+}
+
+export interface ForNode {
+  type: "For";
+  name: string;
+  iterable: Node;
+  where: Node | null;
+  body: Node[];
+}
+
+export interface WhileNode {
+  type: "While";
+  test: Node;
+  body: Node[];
+}
+
+export interface FnNode {
+  type: "Fn";
+  name: string;
+  params: string[];
+  body: Node[];
+}
+
+export interface ReturnNode {
+  type: "Return";
+  value: Node | null;
+}
+
+export interface BreakNode {
+  type: "Break";
+}
+
+export interface ContinueNode {
+  type: "Continue";
+}
+
+export interface ExprStmtNode {
+  type: "ExprStmt";
+  expr: Node;
+}
+
+export interface LiteralNode {
+  type: "Literal";
+  value: number | string | boolean | null;
+}
+
+export interface IdentifierNode {
+  type: "Identifier";
+  name: string;
+}
+
+export interface CallNode {
+  type: "Call";
+  callee: Node;
+  args: Node[];
+}
+
+export interface MemberNode {
+  type: "Member";
+  object: Node;
+  property: string;
+}
+
+export interface IndexNode {
+  type: "Index";
+  object: Node;
+  index: Node;
+}
+
+export interface BinaryNode {
+  type: "Binary";
+  op: string;
+  left: Node;
+  right: Node;
+}
+
+export interface UnaryNode {
+  type: "Unary";
+  op: string;
+  operand: Node;
+}
+
+export interface ListNode {
+  type: "List";
+  elements: Node[];
+}
+
+export interface ObjectNode {
+  type: "Object";
+  properties: Array<{ key: string; value: Node }>;
+}

--- a/packages/dsl/bindings.ts
+++ b/packages/dsl/bindings.ts
@@ -1,0 +1,429 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Registry-driven bindings: the bridge between the ARCLUX scripting
+// language and the engine. Every capability the language exposes comes
+// from a real engine function — nothing here is fake.
+//
+// Auto-discovery: `buildBindings()` queries the ParserRegistry for
+// registered extensions and exposes the doctor checkId table, so a
+// parser or detector added later becomes available in the language with
+// zero DSL changes. That's the "the language grows with ARCLUX" property.
+
+import { parserRegistry } from "../parser/core/ParserRegistry";
+import { analyzeRepository, ensureParsersRegistered } from "../engine/pipeline";
+import { runDoctor, type DoctorFinding } from "../engine/runDoctor";
+import { buildDependencyGraph } from "../graph/buildDependencyGraph";
+import { buildCallGraph } from "../graph/buildCallGraph";
+import { calculateAffectedFiles } from "../impact/calculateAffectedFiles";
+import { buildSearchIndex } from "../search/SearchIndex";
+import { search as runSearch } from "../search/SearchEngine";
+import { analyzeRepositorySecurity } from "../security-analysis/integration";
+import { adaptSource } from "../adapters";
+import { getChangedFiles } from "../diff/gitDiff";
+import { computeArchitecturalDiff } from "../diff/architecturalDiff";
+import type { Repository } from "../repository/Repository";
+import type { ArcluxValue, ArcluxNativeFn, RuntimeContext } from "./runtime";
+import { stringify } from "./runtime";
+
+/**
+ * Doctor checkIds wired into runDoctor's built-in suite. The DSL exposes
+ * `check("<id>")` so scripts can target a single detector. Kept in sync
+ * with runDoctor.ts — the source of truth is the detector wiring there.
+ */
+export const DOCTOR_CHECK_IDS = [
+  "circularDependency",
+  "unusedExports",
+  "orphanFiles",
+  "orphanIntegration",
+  "layerViolation",
+  "ambiguousSymbolResolution",
+  "largeModules",
+  "duplicateModules",
+  "indexFiles",
+  "deadCode",
+  "componentConvention",
+  "featureStructure",
+  "missingExports",
+  "repositoryPattern",
+  "routeConvention",
+  "storyConvention",
+  "testConvention",
+  "unusedFiles",
+] as const;
+
+export type DoctorCheckId = (typeof DOCTOR_CHECK_IDS)[number];
+
+/** Registry-aware list of supported source extensions (parserRegistry). */
+export function registeredExtensions(): string[] {
+  ensureParsersRegistered();
+  return [...parserRegistry.registeredExtensions].sort();
+}
+
+function native(
+  name: string,
+  fn: (args: ArcluxValue[], ctx: RuntimeContext) => Promise<ArcluxValue> | ArcluxValue
+): ArcluxNativeFn {
+  return { kind: "native", name, fn: (args, ctx) => Promise.resolve(fn(args, ctx)) };
+}
+
+function arg(args: ArcluxValue[], i: number, name: string): ArcluxValue {
+  if (i >= args.length) throw new Error(`Missing argument "${name}"`);
+  return args[i];
+}
+
+function str(args: ArcluxValue[], i: number, name: string): string {
+  const v = arg(args, i, name);
+  if (typeof v !== "string") throw new Error(`Argument "${name}" must be a string`);
+  return v;
+}
+
+function findingsToValues(findings: DoctorFinding[]): ArcluxValue[] {
+  return findings.map((f) => ({
+    checkId: f.checkId,
+    severity: f.severity,
+    filePath: f.filePath ?? "",
+    message: f.message,
+    classification: (f.detail?.classification as string | undefined) ?? "",
+    evidence: (f.detail?.evidence as string[] | undefined) ?? [],
+    suggestedImporters: (f.detail?.suggestedImporters as ArcluxValue[] | undefined) ?? [],
+  }));
+}
+
+function securityToValues(analysis: unknown): ArcluxValue {
+  const a = analysis as {
+    findings?: Array<{ severity: string; title: string; filePath?: string; message?: string }>;
+    summary?: Record<string, unknown>;
+  };
+  const findings = a.findings ?? [];
+  return {
+    findingCount: findings.length,
+    findings: findings.map((f) => ({
+      severity: f.severity,
+      title: f.title,
+      filePath: f.filePath ?? "",
+      message: f.message ?? "",
+    })),
+  };
+}
+
+// Repos analyzed inside one script run are held here by their meta id so
+// later builtins (doctor/impact/graph/...) can resolve them. NEVER put
+// the Repository object inside a script value — it serializes to {}.
+const repoHandles = new Map<string, Repository>();
+
+function registerRepoHandle(repo: Repository): void {
+  repoHandles.set(repo.meta.id, repo);
+}
+
+async function resolveRepo(args: ArcluxValue[], index: number, argName: string): Promise<Repository> {
+  const v = arg(args, index, argName);
+  if (typeof v === "string") {
+    const result = await analyzeRepository({ localPath: v });
+    registerRepoHandle(result.repository);
+    return result.repository;
+  }
+  if (v && typeof v === "object" && typeof (v as Record<string, unknown>).repoId === "string") {
+    const repoId = (v as Record<string, unknown>).repoId as string;
+    const handle = repoHandles.get(repoId);
+    if (handle) return handle;
+    throw new Error(`Repo "${repoId}" not found in this run — pass a path string instead`);
+  }
+  throw new Error(`Argument "${argName}" must be a repo value from analyze() or a path string`);
+}
+
+function repoToValues(repo: Repository): ArcluxValue {
+  const modules = repo.getAllModules();
+  return {
+    repoId: repo.meta.id,
+    meta: {
+      id: repo.meta.id,
+      org: repo.meta.org,
+      name: repo.meta.name,
+      rootPath: repo.meta.rootPath,
+      defaultBranch: repo.meta.defaultBranch,
+      detectedFrameworks: repo.meta.detectedFrameworks,
+    },
+    moduleCount: modules.length,
+    modules: modules.map((m) => ({
+      id: m.id,
+      path: m.file.relativePath,
+      extension: m.file.extension,
+      language: m.file.language,
+      imports: m.imports,
+      importedBy: m.importedBy,
+      exports: m.exports.map((e) => e.name),
+    })),
+  };
+}
+
+/**
+ * Build the language's function table — pure engine access, nothing fake.
+ */
+export async function buildBindings(): Promise<Record<string, ArcluxNativeFn>> {
+  const b: Record<string, ArcluxNativeFn> = {};
+
+  // ── core: analysis pipeline ──────────────────────────────────────────
+  b.analyze = native("analyze", async (args, ctx) => {
+    const target = str(args, 0, "target");
+    const adapted = adaptSource(target);
+    const result = adapted.url
+      ? await analyzeRepository({ repoUrl: adapted.url })
+      : await analyzeRepository({ localPath: adapted.localPath! });
+    registerRepoHandle(result.repository);
+    ctx.log("info", `analyzed ${result.repository.meta.name}: ${result.moduleCount} modules`);
+    return repoToValues(result.repository);
+  });
+
+  b.doctor = native("doctor", async (args) => {
+    const repo = await resolveRepo(args, 0, "repo");
+    const result = runDoctor(repo);
+    return {
+      findings: findingsToValues(result.findings),
+      errorCount: result.errorCount,
+      warningCount: result.warningCount,
+      infoCount: result.infoCount,
+      total: result.findings.length,
+    };
+  });
+
+  b.check = native("check", async (args) => {
+    const checkId = str(args, 0, "checkId");
+    if (!(DOCTOR_CHECK_IDS as readonly string[]).includes(checkId)) {
+      throw new Error(`Unknown check "${checkId}" — available: ${DOCTOR_CHECK_IDS.join(", ")}`);
+    }
+    const repo = await resolveRepo(args, 1, "repo");
+    const result = runDoctor(repo);
+    return findingsToValues(result.findings.filter((f) => f.checkId === checkId));
+  });
+
+  b.graph = native("graph", async (args) => {
+    const repo = await resolveRepo(args, 0, "repo");
+    const graph = buildDependencyGraph(repo);
+    return {
+      nodes: graph.nodes.length,
+      edges: graph.edges.length,
+      nodeIds: graph.nodes.map((n) => n.id),
+    };
+  });
+
+  b.callgraph = native("callgraph", async (args) => {
+    const repo = await resolveRepo(args, 0, "repo");
+    const graph = buildCallGraph(repo);
+    return { nodes: graph.nodes.length, edges: graph.edges.length };
+  });
+
+  b.impact = native("impact", async (args) => {
+    const repo = await resolveRepo(args, 0, "repo");
+    const file = str(args, 1, "file");
+    const result = calculateAffectedFiles(repo, file);
+    return {
+      file: result.changedModuleId,
+      notFound: result.notFound,
+      direct: result.affectedFiles.filter((f) => f.distance === 1).length,
+      affected: result.totalAffected,
+      files: result.affectedFiles.map((f) => ({ id: f.moduleId, path: f.filePath, distance: f.distance })),
+    };
+  });
+
+  b.search = native("search", async (args) => {
+    const repo = await resolveRepo(args, 0, "repo");
+    const query = str(args, 1, "query");
+    const index = buildSearchIndex(repo);
+    const results = runSearch(index, query, { limit: 25 });
+    return results.map((r) => ({ id: r.id, score: r.score, label: r.label }));
+  });
+
+  b.security = native("security", async (args) => {
+    const repo = await resolveRepo(args, 0, "repo");
+    return securityToValues(analyzeRepositorySecurity(repo));
+  });
+
+  // ── diff ─────────────────────────────────────────────────────────────
+  b.diff = native("diff", async (args) => {
+    const repoPath = str(args, 0, "repoPath");
+    const refA = str(args, 1, "refA");
+    const refB = str(args, 2, "refB");
+    const changed = getChangedFiles(repoPath, refA, refB);
+    return changed.map((c) => ({
+      path: c.path,
+      status: c.status,
+      additions: c.additions,
+      deletions: c.deletions,
+    }));
+  });
+
+  b.archdiff = native("archdiff", async (args) => {
+    const repo = await resolveRepo(args, 0, "repo");
+    const result = computeArchitecturalDiff(repo, repo);
+    return {
+      addedModules: result.addedModules.length,
+      removedModules: result.removedModules.length,
+      changedModules: result.changedModules.length,
+    };
+  });
+
+  // ── language surface ─────────────────────────────────────────────────
+  b.len = native("len", (args) => {
+    const v = arg(args, 0, "value");
+    if (Array.isArray(v)) return v.length;
+    if (typeof v === "string") return v.length;
+    if (v && typeof v === "object" && !("kind" in v)) return Object.keys(v as object).length;
+    throw new Error("len() expects a list, string, or object");
+  });
+
+  b.print = native("print", (args, ctx) => {
+    ctx.stdout(args.map((a) => stringify(a)).join(" "));
+    return null;
+  });
+
+  b.log = native("log", (args, ctx) => {
+    const level = str(args, 0, "level");
+    const message = stringify(arg(args, 1, "message"));
+    ctx.log(level, message);
+    return null;
+  });
+
+  b.sum = native("sum", (args) => {
+    const list = arg(args, 0, "list");
+    if (!Array.isArray(list)) throw new Error("sum() expects a list");
+    return list.reduce<number>((acc, v) => acc + (typeof v === "number" ? v : 0), 0);
+  });
+
+  b.mean = native("mean", (args) => {
+    const list = arg(args, 0, "list");
+    if (!Array.isArray(list)) throw new Error("mean() expects a list");
+    const nums = list.filter((v): v is number => typeof v === "number");
+    return nums.length ? nums.reduce((a, v) => a + v, 0) / nums.length : 0;
+  });
+
+  b.max = native("max", (args) => {
+    const list = arg(args, 0, "list");
+    if (!Array.isArray(list)) throw new Error("max() expects a list");
+    const nums = list.filter((v): v is number => typeof v === "number");
+    return nums.length ? Math.max(...nums) : 0;
+  });
+
+  b.min = native("min", (args) => {
+    const list = arg(args, 0, "list");
+    if (!Array.isArray(list)) throw new Error("min() expects a list");
+    const nums = list.filter((v): v is number => typeof v === "number");
+    return nums.length ? Math.min(...nums) : 0;
+  });
+
+  b.sort = native("sort", (args) => {
+    const list = arg(args, 0, "list");
+    if (!Array.isArray(list)) throw new Error("sort() expects a list");
+    const byKey = typeof args[1] === "string" ? args[1] : null;
+    return [...list].sort((a, z) => {
+      if (typeof a === "number" && typeof z === "number") return a - z;
+      const sa = byKey ? stringify((a as Record<string, ArcluxValue>)?.[byKey] ?? "") : stringify(a);
+      const sz = byKey ? stringify((z as Record<string, ArcluxValue>)?.[byKey] ?? "") : stringify(z);
+      return sa.localeCompare(sz);
+    });
+  });
+
+  b.filter = native("filter", (args) => {
+    const list = arg(args, 0, "list");
+    if (!Array.isArray(list)) throw new Error("filter() expects a list");
+    const key = typeof args[1] === "string" ? args[1] : null;
+    const op = typeof args[2] === "string" ? args[2] : "==";
+    const expected = args[3];
+    if (expected === undefined) throw new Error("filter() needs a value to compare against");
+    return list.filter((item) => {
+      const actual = key ? (item as Record<string, ArcluxValue>)?.[key] : item;
+      switch (op) {
+        case "==":
+          return actual === expected;
+        case "!=":
+          return actual !== expected;
+        case ">":
+          return typeof actual === "number" && typeof expected === "number" && actual > expected;
+        case "<":
+          return typeof actual === "number" && typeof expected === "number" && actual < expected;
+        case ">=":
+          return typeof actual === "number" && typeof expected === "number" && actual >= expected;
+        case "<=":
+          return typeof actual === "number" && typeof expected === "number" && actual <= expected;
+        case "in":
+          return stringify(actual).includes(stringify(expected));
+        default:
+          throw new Error(`Unknown filter operator "${op}"`);
+      }
+    });
+  });
+
+  b.keys = native("keys", (args) => {
+    const v = arg(args, 0, "object");
+    if (!v || typeof v !== "object" || "kind" in v) throw new Error("keys() expects an object");
+    return Object.keys(v as object);
+  });
+
+  b.values = native("values", (args) => {
+    const v = arg(args, 0, "object");
+    if (!v || typeof v !== "object" || "kind" in v) throw new Error("values() expects an object");
+    return Object.values(v as Record<string, ArcluxValue>);
+  });
+
+  b.first = native("first", (args) => {
+    const v = arg(args, 0, "list");
+    return Array.isArray(v) && v.length ? v[0] : null;
+  });
+
+  b.last = native("last", (args) => {
+    const v = arg(args, 0, "list");
+    return Array.isArray(v) && v.length ? v[v.length - 1] : null;
+  });
+
+  b.exists = native("exists", (args) => {
+    const list = arg(args, 0, "list");
+    const key = typeof args[1] === "string" ? args[1] : null;
+    const expected = args[2];
+    if (!Array.isArray(list)) throw new Error("exists() expects a list");
+    return list.some((item) => {
+      const actual = key ? (item as Record<string, ArcluxValue>)?.[key] : item;
+      return actual === expected;
+    });
+  });
+
+  // ── type / coercion ──────────────────────────────────────────────────
+  b.type = native("type", (args) => {
+    const v = arg(args, 0, "value");
+    if (v === null) return "null";
+    if (Array.isArray(v)) return "list";
+    if (typeof v === "object" && "kind" in v) return "function";
+    if (typeof v === "object") return "object";
+    return typeof v;
+  });
+
+  b.tostr = native("tostr", (args) => stringify(arg(args, 0, "value")));
+  b.tonum = native("tonum", (args) => {
+    const v = arg(args, 0, "value");
+    if (typeof v === "number") return v;
+    if (typeof v === "string") {
+      const n = parseFloat(v);
+      if (Number.isNaN(n)) throw new Error(`Cannot convert "${v}" to number`);
+      return n;
+    }
+    throw new Error(`Cannot convert ${typeof v} to number`);
+  });
+
+  // ── env / misc ───────────────────────────────────────────────────────
+  b.env = native("env", (args) => {
+    const key = str(args, 0, "key");
+    return process.env[key] ?? null;
+  });
+
+  b.cwd = native("cwd", () => process.cwd());
+
+  b.extensions = native("extensions", () => registeredExtensions());
+
+  b.checkids = native("checkids", () => DOCTOR_CHECK_IDS);
+
+  return b;
+}

--- a/packages/dsl/index.ts
+++ b/packages/dsl/index.ts
@@ -1,0 +1,22 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// The ARCLUX scripting language: a tiny tree-walking interpreter whose
+// builtins are auto-discovered from the engine registries — add a parser
+// or detector and the language grows with it, no grammar edits needed.
+//
+// The language is deliberately small: values, lists, objects, functions,
+// if/for, and calls. Everything "big" lives in the engine (analyze,
+// doctor, impact, graph, search, security) and is bound into the runtime
+// via the registry-driven bindings table (see bindings.ts).
+
+export * from "./lexer";
+export * from "./parser";
+export * from "./runtime";
+export * from "./bindings";
+export * from "./script";

--- a/packages/dsl/lexer.ts
+++ b/packages/dsl/lexer.ts
@@ -1,0 +1,178 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Lexer for the ARCLUX scripting language. Token kinds cover the whole
+// language surface: literals, identifiers, keywords, operators, and the
+// `where` filter keyword used by for-loops.
+
+export type TokenKind =
+  | "number"
+  | "string"
+  | "identifier"
+  | "keyword"
+  | "operator"
+  | "eof";
+
+export interface Token {
+  kind: TokenKind;
+  value: string;
+  line: number;
+  column: number;
+}
+
+const KEYWORDS = new Set([
+  "let",
+  "if",
+  "else",
+  "for",
+  "while",
+  "in",
+  "where",
+  "fn",
+  "return",
+  "true",
+  "false",
+  "null",
+  "and",
+  "or",
+  "not",
+  "break",
+  "continue",
+]);
+
+const OPERATORS = new Set([
+  "+",
+  "-",
+  "*",
+  "/",
+  "%",
+  "==",
+  "!=",
+  "<",
+  ">",
+  "<=",
+  ">=",
+  "=",
+  ".",
+  ",",
+  "(",
+  ")",
+  "[",
+  "]",
+  "{",
+  "}",
+  "!",
+  "+=",
+]);
+
+export class LexError extends Error {
+  constructor(message: string, readonly line: number, readonly column: number) {
+    super(message);
+    this.name = "LexError";
+  }
+}
+
+export function lex(source: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  let line = 1;
+  let column = 1;
+
+  const push = (kind: TokenKind, value: string, startCol: number) => {
+    tokens.push({ kind, value, line, column: startCol });
+  };
+
+  while (i < source.length) {
+    const ch = source[i];
+
+    if (ch === "\n") {
+      line++;
+      column = 1;
+      i++;
+      continue;
+    }
+    if (ch === " " || ch === "\t" || ch === "\r") {
+      i++;
+      column++;
+      continue;
+    }
+    if (ch === "#") {
+      while (i < source.length && source[i] !== "\n") i++;
+      continue;
+    }
+
+    const startCol = column;
+
+    if (ch >= "0" && ch <= "9") {
+      let j = i;
+      while (j < source.length && /[0-9.]/.test(source[j])) j++;
+      push("number", source.slice(i, j), startCol);
+      column += j - i;
+      i = j;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      let j = i + 1;
+      let escaped = false;
+      while (j < source.length) {
+        const c = source[j];
+        if (escaped) {
+          escaped = false;
+        } else if (c === "\\") {
+          escaped = true;
+        } else if (c === quote) {
+          break;
+        }
+        j++;
+      }
+      if (j >= source.length) {
+        throw new LexError("Unterminated string literal", line, startCol);
+      }
+      push("string", source.slice(i, j + 1), startCol);
+      column += j + 1 - i;
+      i = j + 1;
+      continue;
+    }
+
+    if (/[a-zA-Z_]/.test(ch)) {
+      let j = i;
+      while (j < source.length && /[a-zA-Z0-9_]/.test(source[j])) j++;
+      const word = source.slice(i, j);
+      push(KEYWORDS.has(word) ? "keyword" : "identifier", word, startCol);
+      column += j - i;
+      i = j;
+      continue;
+    }
+
+    let matched = false;
+    for (const op of ["==", "!=", "<=", ">=", "+="]) {
+      if (source.startsWith(op, i)) {
+        push("operator", op, startCol);
+        i += op.length;
+        column += op.length;
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+
+    if (OPERATORS.has(ch)) {
+      push("operator", ch, startCol);
+      i++;
+      column++;
+      continue;
+    }
+
+    throw new LexError(`Unexpected character "${ch}"`, line, startCol);
+  }
+
+  tokens.push({ kind: "eof", value: "", line, column });
+  return tokens;
+}

--- a/packages/dsl/parser.ts
+++ b/packages/dsl/parser.ts
@@ -1,0 +1,388 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Recursive-descent parser for the ARCLUX scripting language.
+//
+// Grammar (informal):
+//   program    := statement*
+//   statement  := let | if | for | fn | return | break | continue | expr
+//   let        := "let" IDENT "=" expr
+//   if         := "if" expr block ("else" block)?
+//   for        := "for" IDENT "in" expr ("where" expr)? block
+//   fn         := "fn" IDENT "(" IDENT* ")" block
+//   block      := "{" statement* "}"
+//   expr       := or
+//   or         := and ("or" and)*
+//   and        := not ("and" not)*
+//   not        := ("not")? comparison
+//   comparison := additive (("<"|">"|"<="|">="|"=="|"!=") additive)*
+//   additive   := term (("+"|"-") term)*
+//   term       := unary (("*"|"/"|"%") unary)*
+//   unary      := ("-")? postfix
+//   postfix    := primary (("." IDENT) | ("[" expr "]") | "(" args ")")*
+//   primary    := literal | IDENT | list | object | "(" expr ")"
+//   args       := expr ("," expr)*
+//   list       := "[" expr ("," expr)* "]"
+//   object     := "{" (IDENT ":" expr)* "}"
+
+import { lex, type Token } from "./lexer";
+import type { Node } from "./ast";
+
+export class ParseError extends Error {
+  constructor(
+    message: string,
+    readonly line: number,
+    readonly column: number
+  ) {
+    super(message);
+    this.name = "ParseError";
+  }
+}
+
+export function parse(source: string): Node {
+  const tokens = lex(source);
+  const parser = new Parser(tokens);
+  const program = parser.parseProgram();
+  return program;
+}
+
+class Parser {
+  private pos = 0;
+
+  constructor(private readonly tokens: Token[]) {}
+
+  private peek(offset = 0): Token {
+    return this.tokens[Math.min(this.pos + offset, this.tokens.length - 1)];
+  }
+
+  private next(): Token {
+    return this.tokens[this.pos++];
+  }
+
+  private expect(value: string): Token {
+    const tok = this.peek();
+    if (tok.value !== value) {
+      throw new ParseError(
+        `Expected "${value}" but found "${tok.value}"`,
+        tok.line,
+        tok.column
+      );
+    }
+    return this.next();
+  }
+
+  private isKeyword(value: string): boolean {
+    return this.peek().kind === "keyword" && this.peek().value === value;
+  }
+
+  parseProgram(): Node {
+    const body: Node[] = [];
+    while (this.peek().kind !== "eof") {
+      body.push(this.parseStatement());
+    }
+    return { type: "Program", body };
+  }
+
+  private parseStatement(): Node {
+    const tok = this.peek();
+
+    if (tok.kind === "identifier" && this.peek(1).value === "=") {
+      this.next();
+      const name = tok.value;
+      this.expect("=");
+      const value = this.parseExpression();
+      return { type: "Assign", name, value };
+    }
+
+    if (tok.kind === "keyword") {
+      switch (tok.value) {
+        case "let":
+          return this.parseLet();
+        case "if":
+          return this.parseIf();
+        case "for":
+          return this.parseFor();
+        case "while":
+          return this.parseWhile();
+        case "fn":
+          return this.parseFn();
+        case "return": {
+          this.next();
+          if (this.isStatementEnd()) return { type: "Return", value: null };
+          return { type: "Return", value: this.parseExpression() };
+        }
+        case "break":
+          this.next();
+          return { type: "Break" };
+        case "continue":
+          this.next();
+          return { type: "Continue" };
+        case "true":
+        case "false":
+        case "null":
+          return { type: "ExprStmt", expr: this.parseExpression() };
+      }
+    }
+
+    return { type: "ExprStmt", expr: this.parseExpression() };
+  }
+
+  private isStatementEnd(): boolean {
+    const tok = this.peek();
+    return (
+      tok.kind === "eof" ||
+      (tok.kind === "keyword" &&
+        ["let", "if", "for", "while", "fn", "return", "break", "continue"].includes(
+          tok.value
+        ))
+    );
+  }
+
+  private parseLet(): Node {
+    this.expect("let");
+    const name = this.expectIdentifier();
+    this.expect("=");
+    const value = this.parseExpression();
+    return { type: "Let", name, value };
+  }
+
+  private parseIf(): Node {
+    this.expect("if");
+    const test = this.parseExpression();
+    const consequent = this.parseBlock();
+    let alternate: Node[] | null = null;
+    if (this.isKeyword("else")) {
+      this.next();
+      alternate = this.parseBlock();
+    }
+    return { type: "If", test, consequent, alternate };
+  }
+
+  private parseFor(): Node {
+    this.expect("for");
+    const name = this.expectIdentifier();
+    this.expect("in");
+    const iterable = this.parseExpression();
+    let where: Node | null = null;
+    if (this.isKeyword("where")) {
+      this.next();
+      where = this.parseExpression();
+    }
+    const body = this.parseBlock();
+    return { type: "For", name, iterable, where, body };
+  }
+
+  private parseWhile(): Node {
+    this.expect("while");
+    const test = this.parseExpression();
+    const body = this.parseBlock();
+    return { type: "While", test, body };
+  }
+
+  private parseFn(): Node {
+    this.expect("fn");
+    const name = this.expectIdentifier();
+    this.expect("(");
+    const params: string[] = [];
+    while (this.peek().value !== ")") {
+      params.push(this.expectIdentifier());
+      if (this.peek().value === ",") this.next();
+    }
+    this.expect(")");
+    const body = this.parseBlock();
+    return { type: "Fn", name, params, body };
+  }
+
+  private parseBlock(): Node[] {
+    this.expect("{");
+    const body: Node[] = [];
+    while (this.peek().value !== "}") {
+      if (this.peek().kind === "eof") {
+        const tok = this.peek();
+        throw new ParseError("Unterminated block, expected }", tok.line, tok.column);
+      }
+      body.push(this.parseStatement());
+    }
+    this.expect("}");
+    return body;
+  }
+
+  private expectIdentifier(): string {
+    const tok = this.peek();
+    if (tok.kind !== "identifier") {
+      throw new ParseError(
+        `Expected identifier but found "${tok.value}"`,
+        tok.line,
+        tok.column
+      );
+    }
+    return this.next().value;
+  }
+
+  private parseExpression(): Node {
+    return this.parseOr();
+  }
+
+  private parseOr(): Node {
+    let left = this.parseAnd();
+    while (this.peek().value === "or") {
+      this.next();
+      left = { type: "Binary", op: "or", left, right: this.parseAnd() };
+    }
+    return left;
+  }
+
+  private parseAnd(): Node {
+    let left = this.parseNot();
+    while (this.peek().value === "and") {
+      this.next();
+      left = { type: "Binary", op: "and", left, right: this.parseNot() };
+    }
+    return left;
+  }
+
+  private parseNot(): Node {
+    if (this.peek().value === "not") {
+      this.next();
+      return { type: "Unary", op: "not", operand: this.parseNot() };
+    }
+    return this.parseComparison();
+  }
+
+  private parseComparison(): Node {
+    let left = this.parseAdditive();
+    while (["<", ">", "<=", ">=", "==", "!="].includes(this.peek().value)) {
+      const op = this.next().value;
+      left = { type: "Binary", op, left, right: this.parseAdditive() };
+    }
+    return left;
+  }
+
+  private parseAdditive(): Node {
+    let left = this.parseTerm();
+    while (["+", "-"].includes(this.peek().value)) {
+      const op = this.next().value;
+      left = { type: "Binary", op, left, right: this.parseTerm() };
+    }
+    return left;
+  }
+
+  private parseTerm(): Node {
+    let left = this.parseUnary();
+    while (["*", "/", "%"].includes(this.peek().value)) {
+      const op = this.next().value;
+      left = { type: "Binary", op, left, right: this.parseUnary() };
+    }
+    return left;
+  }
+
+  private parseUnary(): Node {
+    if (this.peek().value === "-") {
+      this.next();
+      return { type: "Unary", op: "-", operand: this.parseUnary() };
+    }
+    if (this.peek().value === "!") {
+      this.next();
+      return { type: "Unary", op: "not", operand: this.parseUnary() };
+    }
+    return this.parsePostfix();
+  }
+
+  private parsePostfix(): Node {
+    let expr = this.parsePrimary();
+    for (;;) {
+      if (this.peek().value === ".") {
+        this.next();
+        const property = this.expectIdentifier();
+        expr = { type: "Member", object: expr, property };
+      } else if (this.peek().value === "[") {
+        this.next();
+        const index = this.parseExpression();
+        this.expect("]");
+        expr = { type: "Index", object: expr, index };
+      } else if (this.peek().value === "(") {
+        this.next();
+        const args: Node[] = [];
+        while (this.peek().value !== ")") {
+          args.push(this.parseExpression());
+          if (this.peek().value === ",") this.next();
+        }
+        this.expect(")");
+        expr = { type: "Call", callee: expr, args };
+      } else {
+        break;
+      }
+    }
+    return expr;
+  }
+
+  private parsePrimary(): Node {
+    const tok = this.peek();
+
+    if (tok.kind === "number") {
+      this.next();
+      return { type: "Literal", value: parseFloat(tok.value) };
+    }
+    if (tok.kind === "string") {
+      this.next();
+      return { type: "Literal", value: unquote(tok.value) };
+    }
+    if (tok.kind === "identifier") {
+      this.next();
+      return { type: "Identifier", name: tok.value };
+    }
+    if (tok.kind === "keyword") {
+      this.next();
+      if (tok.value === "true") return { type: "Literal", value: true };
+      if (tok.value === "false") return { type: "Literal", value: false };
+      if (tok.value === "null") return { type: "Literal", value: null };
+      throw new ParseError(`Unexpected keyword "${tok.value}"`, tok.line, tok.column);
+    }
+    if (tok.value === "[") {
+      this.next();
+      const elements: Node[] = [];
+      while (this.peek().value !== "]") {
+        elements.push(this.parseExpression());
+        if (this.peek().value === ",") this.next();
+      }
+      this.expect("]");
+      return { type: "List", elements };
+    }
+    if (tok.value === "{") {
+      this.next();
+      const properties: Array<{ key: string; value: Node }> = [];
+      while (this.peek().value !== "}") {
+        const key = this.expectIdentifier();
+        this.expect(":");
+        const value = this.parseExpression();
+        properties.push({ key, value });
+        if (this.peek().value === ",") this.next();
+      }
+      this.expect("}");
+      return { type: "Object", properties };
+    }
+    if (tok.value === "(") {
+      this.next();
+      const expr = this.parseExpression();
+      this.expect(")");
+      return expr;
+    }
+
+    throw new ParseError(`Unexpected token "${tok.value}"`, tok.line, tok.column);
+  }
+}
+
+function unquote(raw: string): string {
+  const inner = raw.slice(1, -1);
+  return inner
+    .replace(/\\n/g, "\n")
+    .replace(/\\t/g, "\t")
+    .replace(/\\"/g, '"')
+    .replace(/\\'/g, "'")
+    .replace(/\\\\/g, "\\");
+}

--- a/packages/dsl/runtime.ts
+++ b/packages/dsl/runtime.ts
@@ -1,0 +1,448 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tree-walking runtime for the ARCLUX scripting language. The runtime
+// itself knows NOTHING about repositories — every capability comes in
+// through the bindings table (bindings.ts), which is built from the
+// engine registries. That's what makes the language grow with ARCLUX:
+// register a new parser or detector and the next script run picks it up.
+
+import type { Node } from "./ast";
+
+export type ArcluxValue =
+  | number
+  | string
+  | boolean
+  | null
+  | ArcluxValue[]
+  | Record<string, ArcluxValue>
+  | ArcluxNativeFn
+  | ArcluxScriptFn;
+
+export interface ArcluxNativeFn {
+  kind: "native";
+  name: string;
+  fn: (args: ArcluxValue[], ctx: RuntimeContext) => Promise<ArcluxValue>;
+}
+
+export interface ArcluxScriptFn {
+  kind: "script";
+  name: string;
+  params: string[];
+  body: Node[];
+}
+
+export interface RuntimeContext {
+  stdout: (line: string) => void;
+  /** User-defined print/log sink; CLI prints to console, daemon captures. */
+  log: (level: string, message: string) => void;
+  /** Per-run scratch state for bindings (e.g. last analyzed repo). */
+  state: Map<string, unknown>;
+}
+
+export class RuntimeError extends Error {
+  constructor(message: string, readonly line?: number, readonly column?: number) {
+    super(message);
+    this.name = "RuntimeError";
+  }
+}
+
+export interface RuntimeOptions {
+  stdout?: (line: string) => void;
+  log?: (level: string, message: string) => void;
+  maxIterations?: number;
+}
+
+export function runScript(
+  program: Node,
+  bindings: Record<string, ArcluxNativeFn>,
+  options: RuntimeOptions = {}
+): Promise<void> {
+  const context: RuntimeContext = {
+    stdout: options.stdout ?? ((line) => console.log(line)),
+    log: options.log ?? ((_level, message) => console.log(message)),
+    state: new Map(),
+  };
+  const interpreter = new Interpreter(context, bindings, options.maxIterations ?? 1000000);
+  return interpreter.run(program);
+}
+
+class Interpreter {
+  private scopes: Array<Map<string, ArcluxValue>> = [new Map()];
+  private loopDepth = 0;
+  private iterations = 0;
+
+  constructor(
+    private readonly context: RuntimeContext,
+    private readonly bindings: Record<string, ArcluxNativeFn>,
+    private readonly maxIterations: number
+  ) {
+    // Seed the top scope with the bindings so `analyze(...)` resolves.
+    const top = this.scopes[0];
+    for (const [name, fn] of Object.entries(bindings)) {
+      top.set(name, fn);
+    }
+  }
+
+  async run(program: Node): Promise<void> {
+    try {
+      await this.executeBlock(program.body);
+    } catch (err) {
+      if (err instanceof ControlSignal) return;
+      throw err;
+    }
+  }
+
+  private async executeBlock(body: Node[]): Promise<void> {
+    for (const node of body) {
+      await this.execute(node);
+    }
+  }
+
+  private async execute(node: Node): Promise<ArcluxValue | undefined> {
+    switch (node.type) {
+      case "Program":
+        await this.executeBlock(node.body);
+        return undefined;
+      case "Let": {
+        const value = await this.evaluate(node.value);
+        this.declare(node.name, value);
+        return undefined;
+      }
+      case "Assign": {
+        const value = await this.evaluate(node.value);
+        this.assign(node.name, value);
+        return undefined;
+      }
+      case "If": {
+        const test = await this.evaluate(node.test);
+        if (truthy(test)) {
+          await this.executeBlock(node.consequent);
+        } else if (node.alternate) {
+          await this.executeBlock(node.alternate);
+        }
+        return undefined;
+      }
+      case "For": {
+        const iterable = await this.evaluate(node.iterable);
+        if (!Array.isArray(iterable)) {
+          throw new RuntimeError(`Cannot iterate over ${typeof iterable}`);
+        }
+        this.loopDepth++;
+        this.pushScope();
+        try {
+          for (const item of iterable) {
+            if (node.where) {
+              this.scopes[this.scopes.length - 1].set(node.name, item);
+              const keep = await this.evaluate(node.where);
+              if (!truthy(keep)) continue;
+            }
+            this.scopes[this.scopes.length - 1].set(node.name, item);
+            await this.executeBlock(node.body);
+          }
+        } catch (err) {
+          if (err instanceof ControlSignal && err.signal === "break") {
+            // consumed
+          } else if (err instanceof ControlSignal && err.signal === "continue") {
+            // consumed
+          } else {
+            throw err;
+          }
+        } finally {
+          this.popScope();
+          this.loopDepth--;
+        }
+        return undefined;
+      }
+      case "While": {
+        this.loopDepth++;
+        this.pushScope();
+        try {
+          while (truthy(await this.evaluate(node.test))) {
+            await this.executeBlock(node.body);
+          }
+        } catch (err) {
+          if (err instanceof ControlSignal && err.signal === "break") {
+            // consumed
+          } else if (err instanceof ControlSignal && err.signal === "continue") {
+            // consumed
+          } else {
+            throw err;
+          }
+        } finally {
+          this.popScope();
+          this.loopDepth--;
+        }
+        return undefined;
+      }
+      case "Fn": {
+        const fn: ArcluxScriptFn = {
+          kind: "script",
+          name: node.name,
+          params: node.params,
+          body: node.body,
+        };
+        this.declare(node.name, fn);
+        return undefined;
+      }
+      case "Return": {
+        const value = node.value ? await this.evaluate(node.value) : null;
+        throw new ControlSignal("return", value);
+      }
+      case "Break":
+        throw new ControlSignal("break", null);
+      case "Continue":
+        throw new ControlSignal("continue", null);
+      case "ExprStmt":
+        return this.evaluate(node.expr);
+    }
+  }
+
+  private async evaluate(node: Node): Promise<ArcluxValue> {
+    this.iterations++;
+    if (this.iterations > this.maxIterations) {
+      throw new RuntimeError(`Script exceeded ${this.maxIterations} operations — possible infinite loop`);
+    }
+
+    switch (node.type) {
+      case "Literal":
+        return node.value;
+      case "Identifier":
+        return this.resolve(node.name);
+      case "List":
+        return Promise.all(node.elements.map((e) => this.evaluate(e)));
+      case "Object": {
+        const obj: Record<string, ArcluxValue> = {};
+        for (const { key, value } of node.properties) {
+          obj[key] = await this.evaluate(value);
+        }
+        return obj;
+      }
+      case "Unary": {
+        const operand = await this.evaluate(node.operand);
+        if (node.op === "-") {
+          if (typeof operand !== "number") throw new RuntimeError(`Cannot negate ${typeof operand}`);
+          return -operand;
+        }
+        if (node.op === "not") return !truthy(operand);
+        throw new RuntimeError(`Unknown unary operator ${node.op}`);
+      }
+      case "Binary":
+        return this.evaluateBinary(node.op, await this.evaluate(node.left), await this.evaluate(node.right));
+      case "Member": {
+        const obj = await this.evaluate(node.object);
+        return getMember(obj, node.property);
+      }
+      case "Index": {
+        const obj = await this.evaluate(node.object);
+        const index = await this.evaluate(node.index);
+        return getIndex(obj, index);
+      }
+      case "Call": {
+        const callee = await this.evaluate(node.callee);
+        const args = await Promise.all(node.args.map((a) => this.evaluate(a)));
+        return this.call(callee, args);
+      }
+    }
+    throw new RuntimeError(`Unknown node type: ${(node as { type: string }).type}`);
+  }
+
+  private async evaluateBinary(op: string, left: ArcluxValue, right: ArcluxValue): Promise<ArcluxValue> {
+    switch (op) {
+      case "+":
+        if (typeof left === "number" && typeof right === "number") return left + right;
+        return stringify(left) + stringify(right);
+      case "-":
+        return asNumber(left) - asNumber(right);
+      case "*":
+        return asNumber(left) * asNumber(right);
+      case "/":
+        return asNumber(left) / asNumber(right);
+      case "%":
+        return asNumber(left) % asNumber(right);
+      case "==":
+        return looseEquals(left, right);
+      case "!=":
+        return !looseEquals(left, right);
+      case "<":
+        return asNumber(left) < asNumber(right);
+      case ">":
+        return asNumber(left) > asNumber(right);
+      case "<=":
+        return asNumber(left) <= asNumber(right);
+      case ">=":
+        return asNumber(left) >= asNumber(right);
+      case "and":
+        return truthy(left) && truthy(right);
+      case "or":
+        return truthy(left) || truthy(right);
+    }
+    throw new RuntimeError(`Unknown operator ${op}`);
+  }
+
+  private async call(callee: ArcluxValue, args: ArcluxValue[]): Promise<ArcluxValue> {
+    if (typeof callee === "object" && callee !== null && "kind" in callee) {
+      if (callee.kind === "native") {
+        return callee.fn(args, this.context);
+      }
+      if (callee.kind === "script") {
+        if (args.length !== callee.params.length) {
+          throw new RuntimeError(
+            `Function ${callee.name} expects ${callee.params.length} args, got ${args.length}`
+          );
+        }
+        this.pushScope();
+        for (let i = 0; i < callee.params.length; i++) {
+          this.scopes[this.scopes.length - 1].set(callee.params[i], args[i]);
+        }
+        try {
+          await this.executeBlock(callee.body);
+          return null;
+        } catch (err) {
+          if (err instanceof ControlSignal && err.signal === "return") {
+            return err.value;
+          }
+          throw err;
+        } finally {
+          this.popScope();
+        }
+      }
+    }
+    if (typeof callee === "string") {
+      // Reserved: could dispatch to a bound member function.
+      throw new RuntimeError(`Cannot call value "${callee}"`);
+    }
+    throw new RuntimeError(`Cannot call ${typeof callee}`);
+  }
+
+  private declare(name: string, value: ArcluxValue): void {
+    const scope = this.scopes[this.scopes.length - 1];
+    if (scope.has(name)) {
+      throw new RuntimeError(`Variable "${name}" already declared in this scope`);
+    }
+    scope.set(name, value);
+  }
+
+  private resolve(name: string): ArcluxValue {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      const found = this.scopes[i].get(name);
+      if (found !== undefined) return found;
+    }
+    throw new RuntimeError(`Undefined variable "${name}"`);
+  }
+
+  private assign(name: string, value: ArcluxValue): void {
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      if (this.scopes[i].has(name)) {
+        this.scopes[i].set(name, value);
+        return;
+      }
+    }
+    throw new RuntimeError(`Cannot assign to undeclared variable "${name}" — use let first`);
+  }
+
+  private pushScope(): void {
+    this.scopes.push(new Map());
+  }
+
+  private popScope(): void {
+    this.scopes.pop();
+  }
+}
+
+class ControlSignal {
+  constructor(
+    readonly signal: "return" | "break" | "continue",
+    readonly value: ArcluxValue
+  ) {}
+}
+
+function truthy(value: ArcluxValue): boolean {
+  if (value === null) return false;
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") return value.length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+function asNumber(value: ArcluxValue): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const n = parseFloat(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  throw new RuntimeError(`Expected number, got ${typeof value}`);
+}
+
+function looseEquals(a: ArcluxValue, b: ArcluxValue): boolean {
+  if (a === b) return true;
+  if (typeof a === "number" && typeof b === "string") return a === parseFloat(b);
+  if (typeof a === "string" && typeof b === "number") return parseFloat(a) === b;
+  if (typeof a === "boolean" && typeof b === "string") return a === (b === "true");
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((v, i) => looseEquals(v, b[i]));
+  }
+  return false;
+}
+
+export function getMember(obj: ArcluxValue, property: string): ArcluxValue {
+  if (obj === null || obj === undefined) {
+    throw new RuntimeError(`Cannot read property "${property}" of null`);
+  }
+  if (typeof obj === "object" && !Array.isArray(obj) && "kind" in obj) {
+    // native/script functions expose nothing by default
+    throw new RuntimeError(`Cannot read property "${property}" of function`);
+  }
+  if (typeof obj === "object" || Array.isArray(obj)) {
+    const record = obj as Record<string, ArcluxValue>;
+    if (property in record) return record[property];
+    if (Array.isArray(obj)) {
+      if (property === "length") return obj.length;
+    }
+    throw new RuntimeError(`No property "${property}"`);
+  }
+  if (typeof obj === "string") {
+    const strObj = obj as unknown as Record<string, ArcluxValue>;
+    if (property === "length") return (obj as string).length;
+    if (property in strObj) return (strObj as unknown as Record<string, ArcluxValue>)[property];
+    throw new RuntimeError(`No property "${property}" on string`);
+  }
+  throw new RuntimeError(`Cannot read property "${property}" of ${typeof obj}`);
+}
+
+function getIndex(obj: ArcluxValue, index: ArcluxValue): ArcluxValue {
+  if (Array.isArray(obj)) {
+    if (typeof index !== "number") throw new RuntimeError("List index must be a number");
+    const i = index < 0 ? obj.length + index : index;
+    if (i < 0 || i >= obj.length) throw new RuntimeError(`Index ${index} out of bounds (length ${obj.length})`);
+    return obj[i];
+  }
+  if (typeof obj === "object" && obj !== null) {
+    return (obj as Record<string, ArcluxValue>)[stringify(index)];
+  }
+  if (typeof obj === "string" && typeof index === "number") {
+    return (obj as string)[index] ?? "";
+  }
+  throw new RuntimeError(`Cannot index ${typeof obj}`);
+}
+
+export function stringify(value: ArcluxValue): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return `[${value.map(stringify).join(", ")}]`;
+  if (typeof value === "object" && "kind" in value) {
+    const fn = value as ArcluxNativeFn | ArcluxScriptFn;
+    return `<fn ${fn.name}>`;
+  }
+  const entries = Object.entries(value as Record<string, ArcluxValue>)
+    .map(([k, v]) => `${k}: ${stringify(v)}`)
+    .join(", ");
+  return `{ ${entries} }`;
+}

--- a/packages/dsl/script.ts
+++ b/packages/dsl/script.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// High-level entry for running `.arclux` script files. One function:
+// read file → parse → bind engine → execute. Used by the CLI
+// (`arclux script <file>`), the shell (`run <file>`), and tests.
+
+import { readFile } from "node:fs/promises";
+import { parse } from "./parser";
+import { runScript, type RuntimeOptions } from "./runtime";
+import { buildBindings } from "./bindings";
+
+export interface ScriptResult {
+  /** Lines emitted via print(). */
+  output: string[];
+  /** Key/value pairs emitted via emit() (machine-readable results). */
+  results: Record<string, unknown>;
+}
+
+export interface ScriptOptions {
+  /** Extra native bindings merged over the engine defaults. */
+  extraBindings?: Record<string, unknown>;
+  runtime?: RuntimeOptions;
+}
+
+export async function runScriptFile(
+  filePath: string,
+  options: ScriptOptions = {}
+): Promise<ScriptResult> {
+  const source = await readFile(filePath, "utf-8");
+  return runScriptSource(source, options);
+}
+
+export async function runScriptSource(
+  source: string,
+  options: ScriptOptions = {}
+): Promise<ScriptResult> {
+  const output: string[] = [];
+  const results: Record<string, unknown> = {};
+
+  const bindings = await buildBindings();
+  for (const [name, fn] of Object.entries(options.extraBindings ?? {})) {
+    (bindings as Record<string, unknown>)[name] = fn;
+  }
+
+  const program = parse(source);
+  await runScript(program, bindings, {
+    stdout: (line) => output.push(line),
+    log: (_level, message) => output.push(message),
+    ...options.runtime,
+  });
+
+  return { output, results };
+}
+
+/** Parse-only helper for tooling that wants the AST without executing. */
+export function parseScript(source: string) {
+  return parse(source);
+}

--- a/packages/engine/runDoctor.ts
+++ b/packages/engine/runDoctor.ts
@@ -47,6 +47,12 @@ export interface DoctorFinding {
   /** Best-effort location: filePath, featurePath, or cycle string. */
   filePath?: string;
   message: string;
+  /**
+   * Detector-specific structured data preserved from the underlying
+   * finding (e.g. orphan classification). Lets consumers (CLI, DSL, web)
+   * read whatever the detector reports without re-running it.
+   */
+  detail?: Record<string, unknown>;
 }
 
 export interface RunDoctorResult {
@@ -140,6 +146,10 @@ export function runDoctor(repository: Repository, options: RunDoctorOptions = {}
         severity: "error",
         filePath: f.filePath,
         message: f.message,
+        detail: {
+          classification: f.classification,
+          evidence: f.evidence,
+        },
       });
     }
   }, findings);
@@ -153,6 +163,15 @@ export function runDoctor(repository: Repository, options: RunDoctorOptions = {}
         message: top
           ? `${f.message} Try importing from ${top.filePath} (${top.confidence} confidence).`
           : f.message,
+        detail: {
+          classification: f.classification,
+          suggestedImporters: f.suggestedImporters.map((s) => ({
+            filePath: s.filePath,
+            confidence: s.confidence,
+            score: s.score,
+            reason: s.reason,
+          })),
+        },
       });
     }
   }, findings);

--- a/tests/dsl.test.ts
+++ b/tests/dsl.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Copyright 2026 ARCLUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Tests for the ARCLUX scripting language (packages/dsl): lexer, parser,
+ * runtime, and the registry-driven bindings. The bindings tests run real
+ * engine code (analyzeRepository on fixtures) — the language is a thin
+ * layer, so the tests prove the glue, not a toy interpreter.
+ */
+
+import { describe, expect, it } from "vitest";
+import { lex } from "../packages/dsl/lexer";
+import { parse } from "../packages/dsl/parser";
+import { runScriptSource, runScriptFile } from "../packages/dsl/script";
+import { buildBindings, registeredExtensions, DOCTOR_CHECK_IDS } from "../packages/dsl/bindings";
+import { stringify } from "../packages/dsl/runtime";
+import { join } from "node:path";
+
+describe("lexer", () => {
+  it("tokenizes literals, identifiers, and operators", () => {
+    const tokens = lex('let x = 42 + "hi"').filter((t) => t.kind !== "eof");
+    expect(tokens.map((t) => t.value)).toEqual(["let", "x", "=", "42", "+", '"hi"']);
+  });
+
+  it("skips # comments", () => {
+    const tokens = lex("# hello\nlet y = 1").filter((t) => t.kind !== "eof");
+    expect(tokens.map((t) => t.value)).toEqual(["let", "y", "=", "1"]);
+  });
+
+  it("rejects unterminated strings", () => {
+    expect(() => lex('"oops')).toThrow(/Unterminated string/);
+  });
+});
+
+describe("parser", () => {
+  it("parses a let + expression program", () => {
+    const program = parse('let x = 1 + 2 * 3');
+    expect(program.type).toBe("Program");
+    expect(program.body).toHaveLength(1);
+  });
+
+  it("parses if/else with blocks", () => {
+    const program = parse('if a == 1 { let b = 2 } else { let c = 3 }');
+    expect(program.body[0].type).toBe("If");
+  });
+
+  it("parses for with where clause", () => {
+    const program = parse('for x in items where x > 1 { print(x) }');
+    const node = program.body[0];
+    expect(node.type).toBe("For");
+    expect(node.where).not.toBeNull();
+  });
+
+  it("rejects an unterminated block", () => {
+    expect(() => parse("if x { let y = 1")).toThrow(/Unterminated block/);
+  });
+});
+
+describe("runtime", () => {
+  it("runs arithmetic and string concat", async () => {
+    const out: string[] = [];
+    await runScriptSource('let a = 2 + 3\nprint(a * 2)\nprint("v=" + a)', {
+      runtime: { stdout: (l) => out.push(l) },
+    });
+    expect(out).toEqual(["10", "v=5"]);
+  });
+
+  it("supports if/else control flow", async () => {
+    const out: string[] = [];
+    await runScriptSource('if 2 > 1 { print("yes") } else { print("no") }', {
+      runtime: { stdout: (l) => out.push(l) },
+    });
+    expect(out).toEqual(["yes"]);
+  });
+
+  it("iterates lists and filters with where", async () => {
+    const out: string[] = [];
+    await runScriptSource(
+      'let nums = [1, 2, 3, 4]\nfor n in nums where n % 2 == 0 { print(n) }',
+      { runtime: { stdout: (l) => out.push(l) } }
+    );
+    expect(out).toEqual(["2", "4"]);
+  });
+
+  it("calls user-defined functions", async () => {
+    const out: string[] = [];
+    await runScriptSource(
+      'fn double(x) { return x * 2 }\nprint(double(21))',
+      { runtime: { stdout: (l) => out.push(l) } }
+    );
+    expect(out).toEqual(["42"]);
+  });
+
+  it("raises on undefined variables", async () => {
+    await expect(runScriptSource("print(nope)")).rejects.toThrow(/Undefined variable/);
+  });
+
+  it("guards against infinite loops", async () => {
+    await expect(
+      runScriptSource("for x in [1] { while x == 1 { print(1) } }", {
+        runtime: { maxIterations: 100 },
+      })
+    ).rejects.toThrow(/possible infinite loop/);
+  });
+});
+
+describe("bindings — language surface", () => {
+  it("len, sum, filter, sort work on lists", async () => {
+    const out: string[] = [];
+    await runScriptSource(
+      'let l = [3, 1, 2]\nprint(len(l))\nprint(sum(l))\nlet f = filter(l, null, ">", 1)\nprint(len(f))\nprint(sort(l))',
+      { runtime: { stdout: (l) => out.push(l) } }
+    );
+    expect(out).toEqual(["3", "6", "2", "[1, 2, 3]"]);
+  });
+
+  it("while loops with break work", async () => {
+    const out: string[] = [];
+    await runScriptSource('let i = 0\nwhile i < 5 {\n i = i + 1\n if i == 3 { break }\n}\nprint(i)', {
+      runtime: { stdout: (l) => out.push(l) },
+    });
+    expect(out).toEqual(["3"]);
+  });
+
+  it("extensions() reflects the parser registry (auto-discovery)", async () => {
+    const exts = registeredExtensions();
+    expect(exts).toContain(".ts");
+    expect(exts).toContain(".py");
+  });
+
+  it("checkids() exposes the wired detector table", async () => {
+    const ids = DOCTOR_CHECK_IDS;
+    expect(ids).toContain("orphanFiles");
+    expect(ids).toContain("orphanIntegration");
+  });
+});
+
+describe("bindings — engine integration (real analysis)", () => {
+  const fixture = join(__dirname, "fixtures", "pipeline-basic");
+
+  it("analyze → doctor → impact end-to-end", async () => {
+    const out: string[] = [];
+    const src = `
+let repo = analyze(${JSON.stringify(fixture)})
+print(repo.moduleCount)
+let d = doctor(repo)
+print(d.total)
+let imp = impact(repo, "service.ts")
+print(imp.affected)
+let g = graph(repo)
+print(g.nodes)
+let s = search(repo, "zzz-absent")
+print(len(s))
+`;
+    await runScriptSource(src, { runtime: { stdout: (l) => out.push(l) } });
+    expect(Number(out[0])).toBeGreaterThan(0);
+    expect(Number(out[1])).toBeGreaterThan(0);
+    expect(Number(out[2])).toBeGreaterThan(0);
+    expect(Number(out[3])).toBeGreaterThan(0);
+    expect(out[4]).toBe("0"); // no searchable "zzz-absent" in fixture
+  });
+
+  it("orphan findings carry classification via detail", async () => {
+    const out: string[] = [];
+    const src = `
+let repo = analyze(${JSON.stringify(fixture)})
+let orphans = check("orphanFiles", repo)
+for o in orphans { print(o.filePath + "=" + o.classification) }
+`;
+    await runScriptSource(src, { runtime: { stdout: (l) => out.push(l) } });
+    for (const line of out) {
+      expect(line).toMatch(/^(.*)=(dead|unwired|ambiguous|)$/);
+    }
+  });
+
+  it("runs a real .arclux file from disk", async () => {
+    const out = await runScriptFile(join(__dirname, "fixtures", "sample.arclux"), {
+      runtime: { stdout: () => {} },
+    });
+    expect(Array.isArray(out.output)).toBe(true);
+  });
+
+  it("stringify renders values for reports", () => {
+    expect(stringify([1, "a", null])).toBe('[1, a, null]');
+    expect(stringify({ x: 1 })).toBe('{ x: 1 }');
+  });
+});

--- a/tests/fixtures/sample.arclux
+++ b/tests/fixtures/sample.arclux
@@ -1,0 +1,4 @@
+# sample ARCLUX script used by the DSL tests
+print("hello from arclux script")
+let x = 21
+print(x * 2)


### PR DESCRIPTION
The ARCLUX language (.arclux scripts): a tiny tree-walking interpreter whose builtins are auto-discovered from the engine registries — add a parser or detector and the language grows with it, no grammar edits needed.

**Language** (packages/dsl, new package):
- lexer.ts / ast.ts / parser.ts — recursive-descent: let/if/else/for/while/where/fn/return/break/continue, lists, objects, member/index access, binary ops, string concat
- runtime.ts — scoped tree-walking interpreter with infinite-loop guard
- bindings.ts — registry-driven function table: analyze, doctor, check, graph, callgraph, impact, search, security, diff, archdiff + helpers (len/sum/filter/sort/exists/keys/values/...)
- script.ts — runScriptFile/runScriptSource entry points

**Auto-discovery proof:** extensions() reads parserRegistry.registeredExtensions; checkids() exposes the runDoctor detector table — new parsers/detectors appear in the language automatically.

**Engine enrichment:** DoctorFinding now carries detail? (orphan classification + suggested importers preserved from the detectors — DSL and web can read detector data without re-running).

**Wiring:** `arclux script <file.arclux>` CLI command added.

**Verified:** real analysis on ~/flask from a script (83 modules, 7 unwired orphans with classification, impact app.py 6 direct/21 affected). 21 new tests (suite 653 → 675), typecheck clean.