### PR TITLE
docs: fix stale internal notes — audit shows db/cache wired, not stubs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -39,8 +39,9 @@ repoUrl), detectors (20 detector file, semua wired ke apps/cli/doctor.ts;
 unusedExports/orphanFiles sudah entry-point-aware issue #4), rules (14:
 nextjs/nestjs/express/vite/electron/react/laravel), search (SearchEngine/
 SearchIndex/SearchFilters + /api/search — issue #9), impact (8/8
-selesai), repository, db (0%), cache (3/5 wired: fileCache/repositoryCache/
-graphCache; CacheProvider+memoryCache stub), incremental/watcher (built,
+selesai), repository, db (client + schema v1 + 3 store CRUD lengkap,
+dipakai daemon), cache (CacheProvider+memoryCache+3 content cache,
+semua wired), incremental/watcher (built,
 watchRepository wraps pipeline API, belum ada consumer), dsl (lexer/ast/
 parser/runtime/bindings/script — `arclux script <file.arclux>`, registry-driven
 auto-discovery: extensions()/checkids() tumbuh sendiri saat parser/detector
@@ -95,19 +96,26 @@ hooks/useDebounce+useTheme+useClipboard+useCommandPalette+useMediaQuery
    kalau pindah ke npm/yarn.
 
 ## Prioritas aktif sekarang
-1. `packages/db/*` — 0%, belum ada persistence layer sama sekali
-2. `packages/cache/CacheProvider.ts` + `memoryCache.ts` — 2/5 masih stub
-   (3 content-hash cache udah wired; CacheProvider/memoryCache belum jelas
-   masih dibutuhin atau nggak)
-3. True per-file incremental — `packages/incremental` + `watcher` built
-   dan verified standalone, tapi `buildIndex` masih full rebuild tiap
-   kali (keputusan #6: coarse watchRepository dulu, per-file deferred)
-4. `apps/web/lib/api.ts`/`graph.ts` — beberapa komponen (ImpactSummary,
+1. True per-file incremental — `packages/incremental` (Cell/Database/Query,
+   reactive) + `watcher` built dan verified standalone, tapi `buildIndex`
+   masih full rebuild tiap kali; `watchRepository` udah dipakai daemon
+   via DaemonRepositoryWatcher (coarse dulu, per-file deferred — keputusan #6)
+2. `apps/web/lib/api.ts`/`graph.ts` — beberapa komponen (ImpactSummary,
    GlobalSearch) masih inline `fetch()`, belum consume `fetchJson()`
-5. (closed 08-14) Web page commit history/contributors — done:
-   /api/history + /[org]/[repo]/activity (lihat status-web.md)
-6. Docs sync — README/ABOUT/CONTEXT/docs-site harus ikut perubahan
-   parser (27 bahasa), DSL, dan fitur baru tiap PR besar
+3. Docs sync — README/ABOUT/CONTEXT/docs-site harus ikut perubahan
+   parser (27 bahasa), DSL, dan fitur baru tiap PR besar (sync besar
+   terakhir 08-21, PR #532)
+4. 5 packages masih header-only stub: observation, services,
+   package-manager, ui, web-intake — arah platform, belum ada konsumen
+
+## Yang udah wired (jangan dikira stub lagi — audit 08-21)
+- `packages/db` — client + schema v1 + 3 store (RepoStore/AnalysisStore/
+  IssueStore, CRUD lengkap), DIPAKAI daemon (`saveRepo`/`saveAnalysis`
+  per re-analysis, apps/cli/daemon.ts:21-22)
+- `packages/cache` — CacheProvider (getCacheStats/clearAllCaches) +
+  MemoryCache class implementasi beneran; fileCache/repositoryCache/
+  graphCache wired di pipeline
+- `packages/watcher` — watchRepository/changeQueue, dipakai daemon
 
 ## Kalau butuh detail lebih dalam
 `cat PROGRES.md progres/PROGRES-status-*.md progres/bugs.md progres/decisions.md progres/gotchas.md progres/collaborators.md`

--- a/packages/README.md
+++ b/packages/README.md
@@ -25,7 +25,9 @@ directly outside of `engine/`.
   produces these shapes.
 - **`parser`** — turns source files into a shared `ParsedFile` shape
   (imports/exports/warnings). One sub-folder per language
-  (`typescript/`, `python/`, `go/`, `java/`, ...), each implementing the
+  (`typescript/`, `python/`, 27 languages today — bash/c/dart/elixir/elm/
+kotlin/lua/objc/ocaml/rescript/ruby/rust/scala/solidity/swift/vue/zig
+included — via the shared tree-sitter loader or TS Compiler API), each implementing the
   `LanguageParser` interface so `engine/pipeline.ts` never has to know
   which language it's dealing with. Also contains manifest parsers
   (`go.mod`, `Cargo.toml`, `package.json`, ...) via the separate
@@ -43,7 +45,7 @@ directly outside of `engine/`.
   (path + file name + export names) and `applyFilters()`; consumed by
   `/api/search`. Framework-agnostic (no React — the React-facing hooks
   live in `apps/web`).
-- **`detectors`** — 19 independent checks that each take a `Repository`
+- **`detectors`** — 20 independent checks that each take a `Repository`
   and return findings: circular dependencies, dead code, unused exports,
   duplicate modules, orphan files, convention violations, and more.
   Entry points (App Router files, CLI entry) are filtered out of the
@@ -61,11 +63,25 @@ directly outside of `engine/`.
   incrementally re-index on file changes instead of doing a full rebuild.
 - **`incremental`** — the incremental re-index logic itself, consumed
   by `watcher`.
-- **`cache`**, **`db`**, **`ui`** — caching layer (file/repository/graph
-  content-hash caches, wired into buildIndex/pipeline), persistence, and
-  shared graph-rendering helpers used by `apps/web` (the color helper
-  lives in `apps/web/theme/graphColors.ts`; `packages/ui/*` is mostly
-  unstarted — see `progres/status-backlog.md`).
+- **`cache`**, **`db`** — caching layer (file/repository/graph
+  content-hash caches wired into buildIndex/pipeline, plus
+  `CacheProvider` stats/clear + `MemoryCache`) and persistence
+  (`client` + `schema v1` + `RepoStore`/`AnalysisStore`/`IssueStore`,
+  used by the daemon to persist every re-analysis).
+- **`dsl`** — the ARCLUX scripting language (`arclux script file.arclux`):
+  lexer/parser/runtime/bindings. Registry-driven — `extensions()` and
+  `checkids()` grow automatically when new parsers/detectors register.
+- **`security`, `security-analysis`** — secrets detection, unsafe
+  patterns, sensitive-data flow, trust boundaries, attack surface,
+  dependency risk.
+- **`daemon`, `watcher`, `incremental`** — always-on background analysis:
+  `watchRepository` feeds `DaemonRepositoryWatcher`, which re-analyzes on
+  change and persists via `db`. The HTTP+SSE bridge serves `/analysis`,
+  `/impact`, `/events`.
+- **`shell`** — interactive REPL (`arclux shell`): analyze once, then ask
+  impact/deps/doctor/graph/search with live watch mode.
+- **`ui`** — shared graph-rendering helpers (mostly unstarted — see
+  `progres/status-backlog.md`).
 - **`shared`** — types, `ArcluxError`, and small utilities
   (`hashContent`, `toPosixPath`, `createLogger`, etc.) every other
   package imports from. Read `shared/types.ts` first when exploring this

--- a/progres/README.md
+++ b/progres/README.md
@@ -7,7 +7,7 @@ file:
 | File | Isinya |
 |---|---|
 | `status-core.md` | Status pipeline: parser, indexer, graph, impact, incremental |
-| `status-detectors.md` | Status 18 detector (circular deps, dead code, dll) |
+| `status-detectors.md` | Status 20 detector (circular deps, dead code, dll) |
 | `status-web.md` | Status apps/web: dashboard, graph viewer, komponen UI |
 | `status-infra.md` | Status CLI, tooling collaborator, testing, cleanup |
 | `status-backlog.md` | Kerjaan yang belum diambil siapa-siapa |

--- a/progres/roadmap.md
+++ b/progres/roadmap.md
@@ -49,7 +49,7 @@ not just "here's a file with that name in it."
 ## Phase 2 — Architecture Health Score
 **Status: Not Started**
 
-19 detectors already exist. Right now they produce a flat list:
+20 detectors already exist. Right now they produce a flat list:
 "17 problems found." That's a report, not a diagnosis.
 
 Turn detector findings into a health view:


### PR DESCRIPTION
Audit 08-21 menemukan catatan internal basi yang bikin orang (dan AI collaborator) salah paham kondisi codebase:

**Yang ternyata SUDAH jalan (catatan lama bilang stub):**
- `packages/db` — bukan 0%: client + schema v1 + RepoStore/AnalysisStore/IssueStore CRUD lengkap, dipakai daemon (saveRepo/saveAnalysis per re-analysis)
- `packages/cache` — CacheProvider (getCacheStats/clearAllCaches) + MemoryCache implementasi beneran, semua wired

**Perbaikan:**
- CONTEXT.md: section baru "Yang udah wired (jangan dikira stub lagi)", priorities diurut ulang
- packages/README.md: 20 detectors, 27 bahasa, section dsl/security/daemon/shell
- progres index + roadmap: hitungan detector 18/19 → 20

Catatan historis di progres/decisions.md & status-backlog.md sengaja TIDAK diubah — itu arsip tertanggal.