### PR TITLE
feat(web): /api/security + /api/verify + /api/script — web parity with CLI

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -32,7 +32,7 @@ import { registerShellCommand } from "./shell";
 import { registerScriptCommand } from "./script";
 
 const program = new Command();
-program.name("arclux").description("Repository intelligence CLI").version("0.1.0");
+program.name("arclux").description("Repository intelligence CLI").version("0.2.0");
 
 registerAnalyzeCommand(program);
 registerGraphCommand(program);

--- a/apps/web/app/api/script/route.ts
+++ b/apps/web/app/api/script/route.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { runScriptSource } from "@/packages/dsl/script";
+
+interface ScriptRequestBody {
+  /** The .arclux program source to run. */
+  source: string;
+  /**
+   * Optional execution budget: max loop iterations (runtime guard).
+   * Defaults to the runtime's own built-in limit.
+   */
+  maxIterations?: number;
+}
+
+/**
+ * POST /api/script { source }
+ *
+ * HTTP counterpart of `arclux script`: runs an ARCLUX DSL program
+ * server-side and returns its print() output plus emit() results as
+ * JSON. The DSL is sandboxed by construction — bindings only expose
+ * engine analysis capabilities (analyze/doctor/impact/search/...), no
+ * fs/network primitives; remote analyze targets go through the same
+ * SSRF guards as every other route.
+ */
+export async function POST(request: NextRequest) {
+  let body: ScriptRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.source || typeof body.source !== "string") {
+    return NextResponse.json({ error: "`source` is required" }, { status: 400 });
+  }
+  if (body.source.length > 100_000) {
+    return NextResponse.json({ error: "`source` too large (max 100KB)" }, { status: 413 });
+  }
+
+  try {
+    const result = await runScriptSource(body.source, {
+      runtime: body.maxIterations ? { maxIterations: body.maxIterations } : undefined,
+    });
+
+    return NextResponse.json(
+      {
+        output: result.output,
+        results: result.results,
+      },
+      { status: 200 }
+    );
+  } catch (err) {
+    // Script-level errors (parse errors, runtime errors, unknown
+    // bindings) are user-facing — return the message, not a 500.
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("Error in /api/script:", message);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/apps/web/app/api/security/route.ts
+++ b/apps/web/app/api/security/route.ts
@@ -1,0 +1,110 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { analyzeRepository } from "@/packages/engine/pipeline";
+import { mapAttackSurface } from "@/packages/correlation/AttackSurfaceMapper";
+import { isArcluxError } from "@/packages/shared/errors";
+
+/** Maps internal ArcluxErrorCode to an HTTP status — mirrors /api/analyze */
+function statusForErrorCode(code: string): number {
+  switch (code) {
+    case "NOT_FOUND":
+      return 404;
+    case "UNSUPPORTED_LANGUAGE":
+      return 422;
+    case "CLONE_FAILED":
+    case "PARSE_FAILED":
+    case "INDEX_FAILED":
+    case "GRAPH_BUILD_FAILED":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+interface SecurityRequestBody {
+  repoUrl: string;
+  branch?: string;
+}
+
+/**
+ * POST /api/security { repoUrl, branch? }
+ *
+ * HTTP counterpart of `arclux security`. Returns the source-level
+ * security analysis (legacy secrets, unsafe patterns, dangerous APIs —
+ * computed inside the pipeline while the clone still exists) plus the
+ * attack-surface map derived from the dependency graph.
+ *
+ * Note: trust-boundary/cross-boundary/dependency-risk detectors from the
+ * CLI's richer pipeline are not re-run here yet — they need file sources
+ * which are gone after the temp clone cleanup. Follow-up: carry those
+ * results through AnalyzeRepositoryResult like securityAnalysis already
+ * is.
+ */
+export async function POST(request: NextRequest) {
+  let body: SecurityRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.repoUrl || typeof body.repoUrl !== "string") {
+    return NextResponse.json({ error: "`repoUrl` is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await analyzeRepository({
+      repoUrl: body.repoUrl,
+      branch: body.branch,
+    });
+
+    const attackSurface = mapAttackSurface(result.repository, result.graph);
+    const analysis = result.securityAnalysis;
+    if (!analysis) {
+      return NextResponse.json(
+        { error: "Analysis did not include a security report" },
+        { status: 500 }
+      );
+    }
+
+    const counts = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+    for (const f of analysis.findings) {
+      const sev = (f.severity ?? "info").toLowerCase();
+      if (sev in counts) counts[sev as keyof typeof counts]++;
+    }
+
+    return NextResponse.json(
+      {
+        repoUrl: body.repoUrl,
+        target: analysis.target,
+        analyzedAt: analysis.analyzedAt,
+        summary: {
+          total: analysis.findings.length,
+          ...counts,
+          entryPoints: attackSurface.entryPoints.length,
+          reachableModules: attackSurface.reachableModules.length,
+          unreachableModules: attackSurface.unreachableModules.length,
+        },
+        findings: analysis.findings,
+        attackSurface,
+      },
+      { status: 200 }
+    );
+  } catch (err) {
+    if (isArcluxError(err)) {
+      return NextResponse.json(
+        { error: err.message, code: err.code, filePath: err.filePath },
+        { status: statusForErrorCode(err.code) }
+      );
+    }
+    console.error("Unexpected error in /api/security:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/verify/route.ts
+++ b/apps/web/app/api/verify/route.ts
@@ -1,0 +1,151 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { analyzeRepository } from "@/packages/engine/pipeline";
+import { detectCircularDependency } from "@/packages/detectors/detectCircularDependency";
+import { detectUnusedExports } from "@/packages/detectors/detectUnusedExports";
+import { detectOrphanFiles } from "@/packages/detectors/detectOrphanFiles";
+import { detectLargeModules } from "@/packages/detectors/detectLargeModules";
+import { detectDuplicateModules } from "@/packages/detectors/detectDuplicateModules";
+import { detectSharedModules } from "@/packages/detectors/detectSharedModules";
+import { detectIndexFiles } from "@/packages/detectors/detectIndexFiles";
+import { detectLayerViolation } from "@/packages/detectors/detectLayerViolation";
+import { detectDeadCode } from "@/packages/detectors/detectDeadCode";
+import { detectAmbiguousSymbolResolution } from "@/packages/detectors/detectAmbiguousSymbolResolution";
+import { runRules } from "@/packages/rules/RuleEngine";
+import { requirePage } from "@/packages/rules/nextjs/requirePage";
+import { requireRoute } from "@/packages/rules/nextjs/requireRoute";
+import { requireIndexUpdate } from "@/packages/rules/nextjs/requireIndexUpdate";
+import { requireLayoutUpdate } from "@/packages/rules/nextjs/requireLayoutUpdate";
+import { requireMetadata } from "@/packages/rules/nextjs/requireMetadata";
+import { requireControllerBinding } from "@/packages/rules/nestjs/requireControllerBinding";
+import { requireModuleRegistration } from "@/packages/rules/nestjs/requireModuleRegistration";
+import { requireRouteRegistration } from "@/packages/rules/express/requireRouteRegistration";
+import { requireEntryConfig } from "@/packages/rules/vite/requireEntryConfig";
+import { requireMainProcessBinding } from "@/packages/rules/electron/requireMainProcessBinding";
+import { requirePreloadExposure } from "@/packages/rules/electron/requirePreloadExposure";
+import { requireComponentExport } from "@/packages/rules/react/requireComponentExport";
+import { requireHookRules } from "@/packages/rules/react/requireHookRules";
+import { requireController } from "@/packages/rules/laravel/requireController";
+import { isArcluxError } from "@/packages/shared/errors";
+
+/** Maps internal ArcluxErrorCode to an HTTP status — mirrors /api/analyze */
+function statusForErrorCode(code: string): number {
+  switch (code) {
+    case "NOT_FOUND":
+      return 404;
+    case "UNSUPPORTED_LANGUAGE":
+      return 422;
+    case "CLONE_FAILED":
+    case "PARSE_FAILED":
+    case "INDEX_FAILED":
+    case "GRAPH_BUILD_FAILED":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+interface VerifyRequestBody {
+  repoUrl: string;
+  branch?: string;
+}
+
+/**
+ * POST /api/verify { repoUrl, branch? }
+ *
+ * HTTP counterpart of `arclux verify`: 10 pass/fail detectors + all 14
+ * implemented framework rules (framework filtering happens inside
+ * runRules via detectedFrameworks). Returns a single verdict — FAIL when
+ * any detector finding or any rule error exists; rule warnings alone
+ * don't fail (same semantics as the CLI).
+ */
+export async function POST(request: NextRequest) {
+  let body: VerifyRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.repoUrl || typeof body.repoUrl !== "string") {
+    return NextResponse.json({ error: "`repoUrl` is required" }, { status: 400 });
+  }
+
+  try {
+    const { repository, meta } = await analyzeRepository({
+      repoUrl: body.repoUrl,
+      branch: body.branch,
+    });
+
+    const checks = {
+      circularDependency: detectCircularDependency(repository),
+      unusedExports: detectUnusedExports(repository),
+      orphanFiles: detectOrphanFiles(repository),
+      largeModules: detectLargeModules(repository),
+      duplicateModules: detectDuplicateModules(repository),
+      sharedModules: detectSharedModules(repository),
+      indexFiles: detectIndexFiles(repository),
+      layerViolation: detectLayerViolation(repository),
+      deadCode: detectDeadCode(repository),
+      ambiguousSymbolResolution: detectAmbiguousSymbolResolution(repository),
+    };
+
+    const detectorTotal = Object.values(checks).reduce((sum, f) => sum + f.length, 0);
+
+    const ruleViolations = runRules(
+      repository,
+      [
+        requirePage,
+        requireRoute,
+        requireIndexUpdate,
+        requireLayoutUpdate,
+        requireMetadata,
+        requireControllerBinding,
+        requireModuleRegistration,
+        requireRouteRegistration,
+        requireEntryConfig,
+        requireMainProcessBinding,
+        requirePreloadExposure,
+        requireComponentExport,
+        requireHookRules,
+        requireController,
+      ],
+      meta.detectedFrameworks
+    );
+
+    const ruleErrors = ruleViolations.filter((v) => v.severity === "error");
+    const ruleWarnings = ruleViolations.filter((v) => v.severity === "warning");
+
+    return NextResponse.json(
+      {
+        repoUrl: body.repoUrl,
+        frameworksChecked: meta.detectedFrameworks,
+        detectorTotal,
+        checks,
+        rules: {
+          violations: ruleViolations,
+          errors: ruleErrors.length,
+          warnings: ruleWarnings.length,
+        },
+        verdict: detectorTotal > 0 || ruleErrors.length > 0 ? "FAIL" : "PASS",
+      },
+      { status: 200 }
+    );
+  } catch (err) {
+    if (isArcluxError(err)) {
+      return NextResponse.json(
+        { error: err.message, code: err.code, filePath: err.filePath },
+        { status: statusForErrorCode(err.code) }
+      );
+    }
+    console.error("Unexpected error in /api/verify:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/dsl/bindings.ts
+++ b/packages/dsl/bindings.ts
@@ -236,7 +236,7 @@ export async function buildBindings(): Promise<Record<string, ArcluxNativeFn>> {
     const query = str(args, 1, "query");
     const index = buildSearchIndex(repo);
     const results = runSearch(index, query, { limit: 25 });
-    return results.map((r) => ({ id: r.id, score: r.score, label: r.label }));
+    return results.map((r) => ({ id: r.moduleId, path: r.filePath, score: r.score }));
   });
 
   b.security = native("security", async (args) => {
@@ -253,18 +253,23 @@ export async function buildBindings(): Promise<Record<string, ArcluxNativeFn>> {
     return changed.map((c) => ({
       path: c.path,
       status: c.status,
-      additions: c.additions,
-      deletions: c.deletions,
     }));
   });
 
   b.archdiff = native("archdiff", async (args) => {
     const repo = await resolveRepo(args, 0, "repo");
-    const result = computeArchitecturalDiff(repo, repo);
+    const repoPath = str(args, 1, "repoPath");
+    const refA = str(args, 2, "refA");
+    const refB = str(args, 3, "refB");
+    const result = computeArchitecturalDiff(repo, repoPath, refA, refB);
+    const byStatus: Record<string, number> = {};
+    for (const f of result.changedFiles) {
+      byStatus[f.status] = (byStatus[f.status] ?? 0) + 1;
+    }
     return {
-      addedModules: result.addedModules.length,
-      removedModules: result.removedModules.length,
-      changedModules: result.changedModules.length,
+      changedFiles: result.changedFiles.length,
+      affectedFiles: result.affectedFiles.length,
+      byStatus,
     };
   });
 
@@ -423,7 +428,7 @@ export async function buildBindings(): Promise<Record<string, ArcluxNativeFn>> {
 
   b.extensions = native("extensions", () => registeredExtensions());
 
-  b.checkids = native("checkids", () => DOCTOR_CHECK_IDS);
+  b.checkids = native("checkids", () => [...DOCTOR_CHECK_IDS]);
 
   return b;
 }

--- a/packages/dsl/parser.ts
+++ b/packages/dsl/parser.ts
@@ -31,7 +31,7 @@
 //   object     := "{" (IDENT ":" expr)* "}"
 
 import { lex, type Token } from "./lexer";
-import type { Node } from "./ast";
+import type { Node , ProgramNode } from "./ast";
 
 export class ParseError extends Error {
   constructor(
@@ -44,7 +44,7 @@ export class ParseError extends Error {
   }
 }
 
-export function parse(source: string): Node {
+export function parse(source: string): ProgramNode {
   const tokens = lex(source);
   const parser = new Parser(tokens);
   const program = parser.parseProgram();
@@ -80,7 +80,7 @@ class Parser {
     return this.peek().kind === "keyword" && this.peek().value === value;
   }
 
-  parseProgram(): Node {
+  parseProgram(): ProgramNode {
     const body: Node[] = [];
     while (this.peek().kind !== "eof") {
       body.push(this.parseStatement());

--- a/packages/dsl/runtime.ts
+++ b/packages/dsl/runtime.ts
@@ -12,7 +12,7 @@
 // engine registries. That's what makes the language grow with ARCLUX:
 // register a new parser or detector and the next script run picks it up.
 
-import type { Node } from "./ast";
+import type { Node, ProgramNode } from "./ast";
 
 export type ArcluxValue =
   | number
@@ -20,7 +20,7 @@ export type ArcluxValue =
   | boolean
   | null
   | ArcluxValue[]
-  | Record<string, ArcluxValue>
+  | { [key: string]: ArcluxValue }
   | ArcluxNativeFn
   | ArcluxScriptFn;
 
@@ -59,7 +59,7 @@ export interface RuntimeOptions {
 }
 
 export function runScript(
-  program: Node,
+  program: ProgramNode,
   bindings: Record<string, ArcluxNativeFn>,
   options: RuntimeOptions = {}
 ): Promise<void> {
@@ -89,7 +89,7 @@ class Interpreter {
     }
   }
 
-  async run(program: Node): Promise<void> {
+  async run(program: ProgramNode): Promise<void> {
     try {
       await this.executeBlock(program.body);
     } catch (err) {
@@ -288,20 +288,21 @@ class Interpreter {
   private async call(callee: ArcluxValue, args: ArcluxValue[]): Promise<ArcluxValue> {
     if (typeof callee === "object" && callee !== null && "kind" in callee) {
       if (callee.kind === "native") {
-        return callee.fn(args, this.context);
+        return (callee as ArcluxNativeFn).fn(args, this.context);
       }
       if (callee.kind === "script") {
-        if (args.length !== callee.params.length) {
+        const fn = callee as ArcluxScriptFn;
+        if (args.length !== fn.params.length) {
           throw new RuntimeError(
-            `Function ${callee.name} expects ${callee.params.length} args, got ${args.length}`
+            `Function ${fn.name} expects ${fn.params.length} args, got ${args.length}`
           );
         }
         this.pushScope();
-        for (let i = 0; i < callee.params.length; i++) {
-          this.scopes[this.scopes.length - 1].set(callee.params[i], args[i]);
+        for (let i = 0; i < fn.params.length; i++) {
+          this.scopes[this.scopes.length - 1].set(fn.params[i], args[i]);
         }
         try {
-          await this.executeBlock(callee.body);
+          await this.executeBlock(fn.body);
           return null;
         } catch (err) {
           if (err instanceof ControlSignal && err.signal === "return") {


### PR DESCRIPTION
Gap yang ke-detect: CLI punya 22 command, web cuma expose sebagian. PR ini nutup 3 yang paling berharga:

**POST /api/security** — HTTP counterpart `arclux security`: source-level findings (secrets, unsafe patterns, dangerous APIs) + attack surface map + severity counts. Catatan jujur di doc-comment: trust-boundary/cross-boundary/dependency-risk belum di-re-run karena file sources hilang setelah clone cleanup — follow-up: carry results lewat AnalyzeRepositoryResult.

**POST /api/verify** — 10 detectors pass/fail + 14 framework rules → verdict FAIL/PASS tunggal, semantik identik sama CLI (rule warnings gak bikin fail).

**POST /api/script** — DSL runner di web via `runScriptSource`: sandboxed by construction (cuma analysis bindings, gak ada fs/network), cap 100KB source, optional maxIterations.

**Bonus fix**: CLI `.version()` masih hardcoded "0.1.0" setelah bump 0.2.0.

**Verifikasi live** (Next dev server beneran, bukan cuma tsx):
- script: sukses + error case → output & 400 dengan pesan jelas
- verify left-pad/left-pad: `FAIL`, 3 findings, orphan classification utuh
- security left-pad/left-pad: summary + attack surface (3 entry points, 6 reachable)

Suite 696/696, tsc clean.