### PR TITLE
feat(web): Security + Verify workspace tabs, /script DSL playground

### DIFF
--- a/apps/web/app/script/page.tsx
+++ b/apps/web/app/script/page.tsx
@@ -1,0 +1,98 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useState } from "react"
+import { postJson } from "@/lib/api"
+
+interface ScriptResponse {
+  output: string[]
+  results: Record<string, unknown>
+}
+
+const DEFAULT_SCRIPT = `# ARCLUX DSL — analyze a repository from a script
+# analyze() accepts a local path or a GitHub URL
+let repo = analyze("https://github.com/left-pad/left-pad")
+print("modules: " + tostr(repo.moduleCount))
+
+let issues = doctor(repo)
+print("doctor findings: " + tostr(len(issues)))
+`
+
+/**
+ * /script — browser playground for the ARCLUX DSL. Runs the program
+ * server-side via POST /api/script (runScriptSource) and shows print()
+ * output plus emit() results. The sandbox is structural: bindings expose
+ * engine analysis only, no fs/network primitives.
+ */
+export default function ScriptPlaygroundPage() {
+  const [source, setSource] = useState(DEFAULT_SCRIPT)
+  const [output, setOutput] = useState<string[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isRunning, setIsRunning] = useState(false)
+
+  async function handleRun() {
+    setIsRunning(true)
+    setError(null)
+    setOutput(null)
+    try {
+      const result = await postJson<ScriptResponse>("/api/script", { source })
+      setOutput(result.output.length > 0 ? result.output : ["(no output)"])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Script failed")
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen flex-col bg-black px-4 py-6">
+      <div className="mx-auto w-full max-w-5xl">
+        <div className="mb-4 flex items-baseline gap-3">
+          <h1 className="text-lg font-semibold text-neutral-100">Script playground</h1>
+          <span className="text-xs text-neutral-500">
+            .arclux programs run server-side — analysis bindings only
+          </span>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="flex flex-col">
+            <textarea
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              spellCheck={false}
+              rows={18}
+              className="w-full flex-1 resize-none rounded-md border border-neutral-800 bg-neutral-950 p-3 font-mono text-xs leading-relaxed text-neutral-200 outline-none focus:border-blue-500"
+            />
+            <button
+              onClick={handleRun}
+              disabled={isRunning || source.trim().length === 0}
+              className="mt-2 w-fit rounded-md bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isRunning ? "Running..." : "Run script"}
+            </button>
+          </div>
+
+          <div className="rounded-md border border-neutral-800 bg-neutral-950">
+            <div className="border-b border-neutral-800 px-3 py-2 text-[10px] uppercase tracking-wide text-neutral-500">
+              Output
+            </div>
+            <pre className="max-h-[420px] overflow-auto p-3 font-mono text-xs leading-relaxed text-neutral-300">
+              {error
+                ? `Error: ${error}`
+                : output
+                  ? output.join("\n")
+                  : "Run a script to see its print() output here."}
+            </pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -61,6 +61,12 @@ export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = 
         <Link href="/" className="px-2 text-sm font-semibold tracking-tight shrink-0">
           Arclux
         </Link>
+        <Link
+          href="/script"
+          className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          Script
+        </Link>
         {breadcrumbs && breadcrumbs.length > 0 && (
           <>
             <span className="text-muted-foreground/40">/</span>

--- a/apps/web/components/workspace/Workspace.tsx
+++ b/apps/web/components/workspace/Workspace.tsx
@@ -14,6 +14,8 @@ import { WorkspaceCommand } from "@/components/workspace/WorkspaceCommand"
 import { FilesPanel } from "@/components/workspace/panels/FilesPanel"
 import { ImpactPanel } from "@/components/workspace/panels/ImpactPanel"
 import { IssuesPanel } from "@/components/workspace/panels/IssuesPanel"
+import { SecurityPanel } from "@/components/workspace/panels/SecurityPanel"
+import { VerifyPanel } from "@/components/workspace/panels/VerifyPanel"
 import { SplitPane } from "@/components/layout/SplitPane"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
@@ -78,12 +80,20 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
               <TabsList className="mx-4 mt-2 w-fit">
                 <TabsTrigger value="impact">Impact</TabsTrigger>
                 <TabsTrigger value="issues">Issues</TabsTrigger>
+                <TabsTrigger value="security">Security</TabsTrigger>
+                <TabsTrigger value="verify">Verify</TabsTrigger>
               </TabsList>
               <TabsContent value="impact" className="flex-1 overflow-auto">
                 <ImpactPanel repoUrl={repoUrl} moduleId={selectedModuleId} branch={activeBranch} />
               </TabsContent>
               <TabsContent value="issues" className="flex-1 overflow-auto">
                 <IssuesPanel repoUrl={repoUrl} branch={activeBranch} />
+              </TabsContent>
+              <TabsContent value="security" className="flex-1 overflow-auto">
+                <SecurityPanel repoUrl={repoUrl} branch={activeBranch} />
+              </TabsContent>
+              <TabsContent value="verify" className="flex-1 overflow-auto">
+                <VerifyPanel repoUrl={repoUrl} branch={activeBranch} />
               </TabsContent>
             </Tabs>
           }

--- a/apps/web/components/workspace/panels/SecurityPanel.tsx
+++ b/apps/web/components/workspace/panels/SecurityPanel.tsx
@@ -1,0 +1,171 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { postJson } from "@/lib/api"
+import { LoadingState } from "@/components/patterns/LoadingState"
+import { ErrorState } from "@/components/patterns/ErrorState"
+import { EmptyState } from "@/components/patterns/EmptyState"
+
+interface SecurityFinding {
+  id: string
+  ruleId: string
+  title: string
+  description: string
+  severity: "critical" | "high" | "medium" | "low"
+  confidence: string
+  location: { filePath: string; line?: number }
+  cwe?: string[]
+}
+
+interface SecurityResponse {
+  repoUrl: string
+  analyzedAt: string
+  summary: {
+    total: number
+    critical: number
+    high: number
+    medium: number
+    low: number
+    entryPoints: number
+    reachableModules: number
+    unreachableModules: number
+  }
+  findings: SecurityFinding[]
+}
+
+const SEVERITY_DOT: Record<SecurityFinding["severity"], string> = {
+  critical: "bg-red-500",
+  high: "bg-orange-500",
+  medium: "bg-yellow-500",
+  low: "bg-neutral-500",
+}
+
+function FindingRow({ finding }: { finding: SecurityFinding }) {
+  return (
+    <li className="flex items-start gap-2 rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2">
+      <span
+        className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${SEVERITY_DOT[finding.severity]}`}
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <code className="text-xs text-neutral-400">{finding.ruleId}</code>
+          <span className="text-[10px] uppercase tracking-wide text-neutral-600">
+            {finding.severity}
+          </span>
+          <code className="truncate font-mono text-xs text-neutral-300">
+            {finding.location.filePath}
+            {finding.location.line !== undefined && `:${finding.location.line}`}
+          </code>
+        </div>
+        <p className="mt-0.5 text-xs text-neutral-400">{finding.title}</p>
+        {finding.cwe && finding.cwe.length > 0 && (
+          <p className="mt-0.5 font-mono text-[10px] text-neutral-600">
+            {finding.cwe.join(" · ")}
+          </p>
+        )}
+      </div>
+    </li>
+  )
+}
+
+/**
+ * Workspace Security tab: source-level security findings (secrets, unsafe
+ * patterns, dangerous APIs) + attack-surface counts from POST /api/security.
+ * Same loading/error/retry contract as IssuesPanel.
+ */
+export function SecurityPanel({ repoUrl, branch }: SecurityPanelProps) {
+  const [data, setData] = useState<SecurityResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const result = await postJson<SecurityResponse>("/api/security", { repoUrl, branch })
+        if (!cancelled) setData(result)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to run security analysis")
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [repoUrl, branch, retryCount])
+
+  if (isLoading) return <LoadingState label="Running security analysis..." />
+  if (error || !data) {
+    return (
+      <ErrorState
+        title="Could not run security analysis"
+        message={error ?? "No data returned from /api/security."}
+        onRetry={() => setRetryCount((count) => count + 1)}
+      />
+    )
+  }
+
+  const { summary, findings } = data
+  const order: SecurityFinding["severity"][] = ["critical", "high", "medium", "low"]
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-4 border-b border-neutral-800 px-4 py-2.5 text-sm">
+        <span className="font-medium">
+          {summary.total} finding{summary.total === 1 ? "" : "s"}
+        </span>
+        {order.map((sev) =>
+          summary[sev] > 0 ? (
+            <span key={sev} className="flex items-center gap-1.5 text-xs text-neutral-400">
+              <span className={`h-2 w-2 rounded-full ${SEVERITY_DOT[sev]}`} aria-hidden />
+              {summary[sev]} {sev}
+            </span>
+          ) : null
+        )}
+        <span className="ml-auto text-xs text-neutral-500">
+          attack surface: {summary.entryPoints} entry · {summary.reachableModules} reachable ·{" "}
+          {summary.unreachableModules} unreachable
+        </span>
+      </div>
+      {findings.length === 0 ? (
+        <div className="p-6">
+          <EmptyState
+            title="No security findings"
+            message="Source-level checks (secrets, unsafe patterns, dangerous APIs) ran clean."
+          />
+        </div>
+      ) : (
+        <ul className="flex-1 space-y-2 overflow-auto p-4">
+          {order.flatMap((sev) =>
+            findings
+              .filter((f) => f.severity === sev)
+              .map((f) => <FindingRow key={f.id} finding={f} />)
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+interface SecurityPanelProps {
+  repoUrl: string
+  branch?: string
+}

--- a/apps/web/components/workspace/panels/VerifyPanel.tsx
+++ b/apps/web/components/workspace/panels/VerifyPanel.tsx
@@ -1,0 +1,179 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { postJson } from "@/lib/api"
+import { LoadingState } from "@/components/patterns/LoadingState"
+import { ErrorState } from "@/components/patterns/ErrorState"
+
+interface RuleViolation {
+  ruleId: string
+  filePath: string
+  message: string
+  severity: string
+}
+
+interface CheckFindings {
+  [checkId: string]: { checkId?: string; filePath?: string; message: string }[]
+}
+
+interface VerifyResponse {
+  repoUrl: string
+  frameworksChecked: string[]
+  detectorTotal: number
+  checks: CheckFindings
+  rules: {
+    violations: RuleViolation[]
+    errors: number
+    warnings: number
+  }
+  verdict: "PASS" | "FAIL"
+}
+
+/**
+ * Workspace Verify tab: the CI gate as a panel — POST /api/verify returns
+ * a single PASS/FAIL verdict over 10 detectors + all implemented framework
+ * rules (framework filtering happens server-side via detectedFrameworks).
+ */
+export function VerifyPanel({ repoUrl, branch }: VerifyPanelProps) {
+  const [data, setData] = useState<VerifyResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const result = await postJson<VerifyResponse>("/api/verify", { repoUrl, branch })
+        if (!cancelled) setData(result)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to run verify")
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [repoUrl, branch, retryCount])
+
+  if (isLoading) return <LoadingState label="Running verify gate..." />
+  if (error || !data) {
+    return (
+      <ErrorState
+        title="Could not run verify"
+        message={error ?? "No data returned from /api/verify."}
+        onRetry={() => setRetryCount((count) => count + 1)}
+      />
+    )
+  }
+
+  const pass = data.verdict === "PASS"
+  const nonEmptyChecks = Object.entries(data.checks).filter(([, findings]) => findings.length > 0)
+
+  return (
+    <div className="flex h-full flex-col">
+      <div
+        className={`flex items-center gap-3 border-b px-4 py-3 ${
+          pass ? "border-green-900 bg-green-950/40" : "border-red-900 bg-red-950/40"
+        }`}
+      >
+        <span
+          className={`rounded px-2 py-0.5 text-sm font-bold tracking-wide ${
+            pass ? "bg-green-800 text-green-200" : "bg-red-800 text-red-200"
+          }`}
+        >
+          {data.verdict}
+        </span>
+        <span className="text-xs text-neutral-400">
+          {data.detectorTotal} detector issue{data.detectorTotal === 1 ? "" : "s"} ·{" "}
+          {data.rules.errors} rule error{data.rules.errors === 1 ? "" : "s"} ·{" "}
+          {data.rules.warnings} warning{data.rules.warnings === 1 ? "" : "s"}
+        </span>
+        {data.frameworksChecked.length > 0 && (
+          <span className="ml-auto text-xs text-neutral-500">
+            frameworks: {data.frameworksChecked.join(", ")}
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 space-y-4 overflow-auto p-4">
+        {nonEmptyChecks.length > 0 && (
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              Detector findings
+            </h3>
+            <ul className="space-y-1.5">
+              {nonEmptyChecks.map(([checkId, findings]) => (
+                <li
+                  key={checkId}
+                  className="flex items-baseline gap-2 rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2 text-xs"
+                >
+                  <code className="text-neutral-400">{checkId}</code>
+                  <span className="text-neutral-300">{findings.length} finding(s)</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {data.rules.violations.length > 0 && (
+          <section>
+            <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+              Rule violations
+            </h3>
+            <ul className="space-y-1.5">
+              {data.rules.violations.map((v, i) => (
+                <li
+                  key={`${v.ruleId}-${v.filePath}-${i}`}
+                  className="rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2"
+                >
+                  <div className="flex flex-wrap items-baseline gap-x-2">
+                    <code className="text-xs text-neutral-400">{v.ruleId}</code>
+                    <span
+                      className={`text-[10px] uppercase tracking-wide ${
+                        v.severity === "error" ? "text-red-400" : "text-yellow-500"
+                      }`}
+                    >
+                      {v.severity}
+                    </span>
+                    <code className="truncate font-mono text-xs text-neutral-300">
+                      {v.filePath}
+                    </code>
+                  </div>
+                  <p className="mt-0.5 text-xs text-neutral-400">{v.message}</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {pass && nonEmptyChecks.length === 0 && data.rules.violations.length === 0 && (
+          <p className="text-sm text-neutral-400">
+            Clean — every detector and framework rule passed.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface VerifyPanelProps {
+  repoUrl: string
+  branch?: string
+}


### PR DESCRIPTION
Lanjutan #536: routes-nya udah ada, sekarang UI-nya. Sidebar/panels web tinggal diisi barang — ini barangnya:

**SecurityPanel** (tab baru di Workspace)
- Severity-grouped findings (critical/high/medium/low) + CWE refs
- Attack-surface summary: entry points / reachable / unreachable
- Kontrak loading/error/retry sama persis dengan IssuesPanel

**VerifyPanel** (tab baru di Workspace)
- Badge verdict PASS/FAIL (hijau/merah)
- Detector totals + rule violations per-file
- Frameworks checked ditampilkan

**/script playground** (halaman global, link di Navbar)
- Textarea DSL + Run button → POST /api/script server-side
- Default script siap-edit (analyze + doctor), output panel monospace

Live-verified di dev server beneran:
- /script → 200; search binding return 25 hasil nyata untuk 'app' di flask; diff binding baca git HEAD~1..HEAD asli
- Suite 21/21 dsl, tsc clean