### PR TITLE
feat(web): Health score + Calls panels (roadmap Phase 2)

### DIFF
--- a/apps/web/app/api/callgraph/route.ts
+++ b/apps/web/app/api/callgraph/route.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { analyzeRepository } from "@/packages/engine/pipeline";
+import { buildCallGraph } from "@/packages/graph/buildCallGraph";
+import { isArcluxError } from "@/packages/shared/errors";
+
+/** Maps internal ArcluxErrorCode to an HTTP status — mirrors /api/analyze */
+function statusForErrorCode(code: string): number {
+  switch (code) {
+    case "NOT_FOUND":
+      return 404;
+    case "UNSUPPORTED_LANGUAGE":
+      return 422;
+    case "CLONE_FAILED":
+    case "PARSE_FAILED":
+    case "INDEX_FAILED":
+    case "GRAPH_BUILD_FAILED":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+interface CallgraphRequestBody {
+  repoUrl: string;
+  branch?: string;
+  /** Optional module id to focus: returns its callers + callees only. */
+  moduleId?: string;
+}
+
+/**
+ * POST /api/callgraph { repoUrl, branch?, moduleId? }
+ *
+ * HTTP counterpart of the call graph (buildCallGraph): which file calls
+ * which, resolved through named imports. With moduleId: that module's
+ * incoming/outgoing call edges. Without: top modules by total call
+ * weight. List-shaped data — the interactive canvas already covers
+ * visualization elsewhere and stays untouched.
+ */
+export async function POST(request: NextRequest) {
+  let body: CallgraphRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.repoUrl || typeof body.repoUrl !== "string") {
+    return NextResponse.json({ error: "`repoUrl` is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await analyzeRepository({
+      repoUrl: body.repoUrl,
+      branch: body.branch,
+    });
+
+    const graph = buildCallGraph(result.repository);
+    const labelById = new Map(graph.nodes.map((n) => [n.id, n.label]));
+    const pathById = new Map(graph.nodes.map((n) => [n.id, n.filePath]));
+
+    const edgeView = (e: (typeof graph.edges)[number]) => ({
+      callee: e.target,
+      calleeLabel: labelById.get(e.target) ?? e.target,
+      caller: e.source,
+      callerLabel: labelById.get(e.source) ?? e.source,
+      weight: e.weight,
+    });
+
+    if (body.moduleId) {
+      const outgoing = graph.edges.filter((e) => e.source === body.moduleId).map(edgeView);
+      const incoming = graph.edges.filter((e) => e.target === body.moduleId).map(edgeView);
+      return NextResponse.json(
+        {
+          repoUrl: body.repoUrl,
+          moduleId: body.moduleId,
+          filePath: pathById.get(body.moduleId) ?? null,
+          outgoing,
+          incoming,
+          edgeTotal: graph.edges.length,
+        },
+        { status: 200 }
+      );
+    }
+
+    // No focus module: rank modules by total call weight (in + out).
+    const weightByModule = new Map<string, number>();
+    for (const e of graph.edges) {
+      weightByModule.set(e.source, (weightByModule.get(e.source) ?? 0) + (e.weight ?? 0));
+      weightByModule.set(e.target, (weightByModule.get(e.target) ?? 0) + (e.weight ?? 0));
+    }
+    const topModules = [...weightByModule.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 12)
+      .map(([id, weight]) => ({
+        moduleId: id,
+        filePath: pathById.get(id) ?? null,
+        label: labelById.get(id) ?? id,
+        callWeight: weight,
+      }));
+
+    return NextResponse.json(
+      {
+        repoUrl: body.repoUrl,
+        nodeCount: graph.nodes.length,
+        edgeTotal: graph.edges.length,
+        topModules,
+      },
+      { status: 200 }
+    );
+  } catch (err) {
+    if (isArcluxError(err)) {
+      return NextResponse.json(
+        { error: err.message, code: err.code, filePath: err.filePath },
+        { status: statusForErrorCode(err.code) }
+      );
+    }
+    console.error("Unexpected error in /api/callgraph:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -1,0 +1,85 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { NextRequest, NextResponse } from "next/server";
+import { analyzeRepository } from "@/packages/engine/pipeline";
+import { runDoctor } from "@/packages/engine/runDoctor";
+import { computeHealthScore } from "@/packages/engine/healthScore";
+import { isArcluxError } from "@/packages/shared/errors";
+
+/** Maps internal ArcluxErrorCode to an HTTP status — mirrors /api/analyze */
+function statusForErrorCode(code: string): number {
+  switch (code) {
+    case "NOT_FOUND":
+      return 404;
+    case "UNSUPPORTED_LANGUAGE":
+      return 422;
+    case "CLONE_FAILED":
+    case "PARSE_FAILED":
+    case "INDEX_FAILED":
+    case "GRAPH_BUILD_FAILED":
+      return 502;
+    default:
+      return 500;
+  }
+}
+
+interface HealthRequestBody {
+  repoUrl: string;
+  branch?: string;
+}
+
+/**
+ * POST /api/health { repoUrl, branch? }
+ *
+ * Phase 2 from progres/roadmap.md: the detector suite as a diagnosis.
+ * Runs the full doctor suite server-side, then aggregates findings into
+ * four category scores (structural integrity, dependency hygiene, layer
+ * consistency, convention compliance) normalized by module count. See
+ * packages/engine/healthScore.ts for the deterministic formula.
+ */
+export async function POST(request: NextRequest) {
+  let body: HealthRequestBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.repoUrl || typeof body.repoUrl !== "string") {
+    return NextResponse.json({ error: "`repoUrl` is required" }, { status: 400 });
+  }
+
+  try {
+    const result = await analyzeRepository({
+      repoUrl: body.repoUrl,
+      branch: body.branch,
+    });
+
+    const doctor = runDoctor(result.repository);
+    const health = computeHealthScore(doctor.findings, result.moduleCount);
+
+    return NextResponse.json(
+      {
+        repoUrl: body.repoUrl,
+        ...health,
+        findingTotal: doctor.findings.length,
+      },
+      { status: 200 }
+    );
+  } catch (err) {
+    if (isArcluxError(err)) {
+      return NextResponse.json(
+        { error: err.message, code: err.code, filePath: err.filePath },
+        { status: statusForErrorCode(err.code) }
+      );
+    }
+    console.error("Unexpected error in /api/health:", err);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -61,12 +61,6 @@ export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = 
         <Link href="/" className="px-2 text-sm font-semibold tracking-tight shrink-0">
           Arclux
         </Link>
-        <Link
-          href="/script"
-          className="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          Script
-        </Link>
         {breadcrumbs && breadcrumbs.length > 0 && (
           <>
             <span className="text-muted-foreground/40">/</span>
@@ -76,6 +70,12 @@ export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = 
       </div>
 
       <div className="flex items-center gap-1">
+        <Link
+          href="/script"
+          className="hidden rounded-md px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground sm:block"
+        >
+          Script playground
+        </Link>
         <Link
           href={settingsHref}
           aria-label="Settings"

--- a/apps/web/components/workspace/Workspace.tsx
+++ b/apps/web/components/workspace/Workspace.tsx
@@ -16,6 +16,8 @@ import { ImpactPanel } from "@/components/workspace/panels/ImpactPanel"
 import { IssuesPanel } from "@/components/workspace/panels/IssuesPanel"
 import { SecurityPanel } from "@/components/workspace/panels/SecurityPanel"
 import { VerifyPanel } from "@/components/workspace/panels/VerifyPanel"
+import { HealthPanel } from "@/components/workspace/panels/HealthPanel"
+import { CallsPanel } from "@/components/workspace/panels/CallsPanel"
 import { SplitPane } from "@/components/layout/SplitPane"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 
@@ -82,6 +84,8 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
                 <TabsTrigger value="issues">Issues</TabsTrigger>
                 <TabsTrigger value="security">Security</TabsTrigger>
                 <TabsTrigger value="verify">Verify</TabsTrigger>
+                <TabsTrigger value="health">Health</TabsTrigger>
+                <TabsTrigger value="calls">Calls</TabsTrigger>
               </TabsList>
               <TabsContent value="impact" className="flex-1 overflow-auto">
                 <ImpactPanel repoUrl={repoUrl} moduleId={selectedModuleId} branch={activeBranch} />
@@ -94,6 +98,12 @@ export function Workspace({ org, repo, repoUrl, branch }: WorkspaceProps) {
               </TabsContent>
               <TabsContent value="verify" className="flex-1 overflow-auto">
                 <VerifyPanel repoUrl={repoUrl} branch={activeBranch} />
+              </TabsContent>
+              <TabsContent value="health" className="flex-1 overflow-auto">
+                <HealthPanel repoUrl={repoUrl} branch={activeBranch} />
+              </TabsContent>
+              <TabsContent value="calls" className="flex-1 overflow-auto">
+                <CallsPanel repoUrl={repoUrl} branch={activeBranch} moduleId={selectedModuleId} />
               </TabsContent>
             </Tabs>
           }

--- a/apps/web/components/workspace/panels/CallsPanel.tsx
+++ b/apps/web/components/workspace/panels/CallsPanel.tsx
@@ -1,0 +1,175 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { postJson } from "@/lib/api"
+import { LoadingState } from "@/components/patterns/LoadingState"
+import { ErrorState } from "@/components/patterns/ErrorState"
+import { EmptyState } from "@/components/patterns/EmptyState"
+
+interface CallEdge {
+  callee: string
+  calleeLabel: string
+  caller: string
+  callerLabel: string
+  weight: number
+}
+
+interface FocusedResponse {
+  moduleId: string
+  filePath: string | null
+  outgoing: CallEdge[]
+  incoming: CallEdge[]
+  edgeTotal: number
+}
+
+interface OverviewResponse {
+  nodeCount: number
+  edgeTotal: number
+  topModules: { moduleId: string; filePath: string | null; label: string; callWeight: number }[]
+}
+
+type CallgraphResponse = FocusedResponse | OverviewResponse
+
+function isFocused(r: CallgraphResponse): r is FocusedResponse {
+  return "moduleId" in r
+}
+
+function EdgeRow({ label, weight }: { label: string; weight: number }) {
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-md border border-neutral-800 bg-neutral-950/60 px-3 py-2">
+      <code className="truncate font-mono text-xs text-neutral-300">{label}</code>
+      <span className="shrink-0 rounded-full bg-neutral-800/80 px-2 py-0.5 font-mono text-[10px] tabular-nums text-neutral-400">
+        ×{weight}
+      </span>
+    </li>
+  )
+}
+
+/**
+ * Workspace Calls tab: list view over buildCallGraph — which file calls
+ * which, resolved through named imports. Focuses on the selected module
+ * (callers + callees) or falls back to the busiest modules overall.
+ * Deliberately list-shaped: the interactive canvas is untouched.
+ */
+export function CallsPanel({ repoUrl, branch, moduleId }: CallsPanelProps) {
+  const [data, setData] = useState<CallgraphResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const result = await postJson<CallgraphResponse>("/api/callgraph", {
+          repoUrl,
+          branch,
+          moduleId: moduleId ?? undefined,
+        })
+        if (!cancelled) setData(result)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to build call graph")
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [repoUrl, branch, moduleId, retryCount])
+
+  if (isLoading) return <LoadingState label="Tracing call relationships..." />
+  if (error || !data) {
+    return (
+      <ErrorState
+        title="Could not build call graph"
+        message={error ?? "No data returned from /api/callgraph."}
+        onRetry={() => setRetryCount((count) => count + 1)}
+      />
+    )
+  }
+
+  if (!isFocused(data)) {
+    return (
+      <div className="flex h-full flex-col overflow-auto">
+        <div className="border-b border-neutral-800 px-4 py-2.5 text-xs text-neutral-500">
+          Busiest modules by call weight · {data.nodeCount} modules, {data.edgeTotal} call edges
+        </div>
+        {data.topModules.length === 0 ? (
+          <div className="p-6">
+            <EmptyState
+              title="No resolved calls"
+              message="No cross-file calls were resolved for this repository (only the JS family extracts calls today)."
+            />
+          </div>
+        ) : (
+          <ul className="flex-1 space-y-2 p-4">
+            {data.topModules.map((m) => (
+              <EdgeRow key={m.moduleId} label={m.filePath ?? m.label} weight={m.callWeight} />
+            ))}
+          </ul>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-auto">
+      <div className="border-b border-neutral-800 px-4 py-2.5">
+        <code className="text-xs text-neutral-300">{data.filePath ?? data.moduleId}</code>
+      </div>
+      <div className="grid flex-1 gap-4 p-4 md:grid-cols-2">
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+            Calls ({data.outgoing.length})
+          </h3>
+          {data.outgoing.length === 0 ? (
+            <p className="text-xs text-neutral-500">This file makes no resolved cross-file calls.</p>
+          ) : (
+            <ul className="space-y-1.5">
+              {data.outgoing.map((e) => (
+                <EdgeRow key={`out-${e.callee}`} label={e.calleeLabel} weight={e.weight} />
+              ))}
+            </ul>
+          )}
+        </section>
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-neutral-500">
+            Called by ({data.incoming.length})
+          </h3>
+          {data.incoming.length === 0 ? (
+            <p className="text-xs text-neutral-500">Nothing calls this file.</p>
+          ) : (
+            <ul className="space-y-1.5">
+              {data.incoming.map((e) => (
+                <EdgeRow key={`in-${e.caller}`} label={e.callerLabel} weight={e.weight} />
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}
+
+interface CallsPanelProps {
+  repoUrl: string
+  branch?: string
+  /** Selected module id from FilesPanel/WorkspaceSearch; null = overview */
+  moduleId?: string | null
+}

--- a/apps/web/components/workspace/panels/HealthPanel.tsx
+++ b/apps/web/components/workspace/panels/HealthPanel.tsx
@@ -1,0 +1,160 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useEffect, useState } from "react"
+import { postJson } from "@/lib/api"
+import { LoadingState } from "@/components/patterns/LoadingState"
+import { ErrorState } from "@/components/patterns/ErrorState"
+
+interface HealthCategory {
+  id: string
+  label: string
+  score: number
+  findingCount: number
+}
+
+interface HealthResponse {
+  repoUrl: string
+  overall: number
+  categories: HealthCategory[]
+  moduleCount: number
+  findingTotal: number
+}
+
+function scoreTone(score: number): { bar: string; text: string; ring: string } {
+  if (score >= 90) return { bar: "bg-emerald-500", text: "text-emerald-500", ring: "stroke-emerald-500" }
+  if (score >= 70) return { bar: "bg-yellow-500", text: "text-yellow-500", ring: "stroke-yellow-500" }
+  if (score >= 40) return { bar: "bg-orange-500", text: "text-orange-500", ring: "stroke-orange-500" }
+  return { bar: "bg-red-500", text: "text-red-500", ring: "stroke-red-500" }
+}
+
+/** Circular gauge for the overall score (SVG, no chart lib). */
+function OverallGauge({ score }: { score: number }) {
+  const tone = scoreTone(score)
+  const radius = 52
+  const circumference = 2 * Math.PI * radius
+  const filled = (score / 100) * circumference
+
+  return (
+    <div className="relative h-32 w-32 shrink-0">
+      <svg viewBox="0 0 120 120" className="h-full w-full -rotate-90">
+        <circle cx="60" cy="60" r={radius} fill="none" strokeWidth="8" className="stroke-neutral-800" />
+        <circle
+          cx="60"
+          cy="60"
+          r={radius}
+          fill="none"
+          strokeWidth="8"
+          strokeLinecap="round"
+          strokeDasharray={`${filled} ${circumference - filled}`}
+          className={tone.ring}
+        />
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className={`text-2xl font-semibold tabular-nums ${tone.text}`}>{score}</span>
+        <span className="text-[10px] uppercase tracking-wide text-neutral-500">health</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Workspace Health tab: POST /api/health aggregated over the doctor suite.
+ * Overall gauge + per-category bars, normalized by module count so large
+ * repos aren't punished for size. Formula in packages/engine/healthScore.ts.
+ */
+export function HealthPanel({ repoUrl, branch }: HealthPanelProps) {
+  const [data, setData] = useState<HealthResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [retryCount, setRetryCount] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const result = await postJson<HealthResponse>("/api/health", { repoUrl, branch })
+        if (!cancelled) setData(result)
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to compute health score")
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [repoUrl, branch, retryCount])
+
+  if (isLoading) return <LoadingState label="Scoring repository health..." />
+  if (error || !data) {
+    return (
+      <ErrorState
+        title="Could not compute health"
+        message={error ?? "No data returned from /api/health."}
+        onRetry={() => setRetryCount((count) => count + 1)}
+      />
+    )
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-auto p-4">
+      <div className="flex items-center gap-6 rounded-lg border border-neutral-800 bg-neutral-950/60 p-5">
+        <OverallGauge score={data.overall} />
+        <div className="min-w-0">
+          <p className="text-sm font-medium">Architecture health</p>
+          <p className="mt-1 text-xs leading-relaxed text-neutral-400">
+            {data.findingTotal} finding{data.findingTotal === 1 ? "" : "s"} across{" "}
+            {data.moduleCount} modules, aggregated into four categories.
+            Severity-weighted and normalized by module count — details in{" "}
+            <code className="text-[10px] text-neutral-500">packages/engine/healthScore.ts</code>.
+          </p>
+        </div>
+      </div>
+
+      <ul className="mt-4 space-y-3">
+        {data.categories.map((cat) => {
+          const tone = scoreTone(cat.score)
+          return (
+            <li key={cat.id} className="rounded-lg border border-neutral-800 bg-neutral-950/60 px-4 py-3">
+              <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                <span className="text-sm">{cat.label}</span>
+                <span className={`text-sm font-semibold tabular-nums ${tone.text}`}>{cat.score}</span>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-neutral-800">
+                <div
+                  className={`h-full rounded-full ${tone.bar} transition-all duration-500`}
+                  style={{ width: `${cat.score}%` }}
+                />
+              </div>
+              <p className="mt-1 text-[11px] text-neutral-500">
+                {cat.findingCount === 0
+                  ? "clean"
+                  : `${cat.findingCount} finding${cat.findingCount === 1 ? "" : "s"} affecting this category`}
+              </p>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+interface HealthPanelProps {
+  repoUrl: string
+  branch?: string
+}

--- a/packages/engine/healthScore.ts
+++ b/packages/engine/healthScore.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Health score — Phase 2 from progres/roadmap.md: turn the flat detector
+// list into a diagnosis. Four categories, each scored 0..100 from its
+// detector findings, normalized by module count so big repos aren't
+// punished for size alone.
+//
+// Formula (deterministic, no magic): every finding costs severity weight
+// (error=5, warning=2, info=0.5). A category's raw penalty is divided by
+// module count and scaled — 1 penalty point per module == 0 points on
+// that axis, zero findings == 100. Overall is the unweighted mean.
+
+import type { DoctorFinding } from "./runDoctor";
+
+export interface HealthCategory {
+  id: string;
+  label: string;
+  /** 0..100, rounded to one decimal */
+  score: number;
+  /** findings that fed into this category */
+  findingCount: number;
+}
+
+export interface HealthScore {
+  overall: number;
+  categories: HealthCategory[];
+  moduleCount: number;
+}
+
+const SEVERITY_WEIGHT: Record<DoctorFinding["severity"], number> = {
+  error: 5,
+  warning: 2,
+  info: 0.5,
+};
+
+const CATEGORY_CHECKS: { id: string; label: string; checkIds: string[] }[] = [
+  {
+    id: "structuralIntegrity",
+    label: "Structural integrity",
+    checkIds: ["largeModules", "duplicateModules", "indexFiles", "missingExports"],
+  },
+  {
+    id: "dependencyHygiene",
+    label: "Dependency hygiene",
+    checkIds: ["circularDependency", "unusedExports", "orphanFiles", "orphanIntegration", "unusedFiles", "deadCode"],
+  },
+  {
+    id: "layerConsistency",
+    label: "Layer consistency",
+    checkIds: ["layerViolation", "ambiguousSymbolResolution"],
+  },
+  {
+    id: "conventionCompliance",
+    label: "Convention compliance",
+    checkIds: ["componentConvention", "featureStructure", "repositoryPattern", "routeConvention", "storyConvention", "testConvention"],
+  },
+];
+
+function scoreFor(findings: DoctorFinding[], moduleCount: number): number {
+  if (findings.length === 0) return 100;
+  const penalty = findings.reduce((sum, f) => sum + (SEVERITY_WEIGHT[f.severity] ?? 1), 0);
+  const normalized = penalty / Math.max(moduleCount, 1);
+  // 1 full penalty point per module bottoms out at 0.
+  return Math.max(0, Math.round((1 - Math.min(normalized, 1)) * 1000) / 10);
+}
+
+export function computeHealthScore(
+  findings: DoctorFinding[],
+  moduleCount: number
+): HealthScore {
+  const categories = CATEGORY_CHECKS.map(({ id, label, checkIds }) => {
+    const own = findings.filter((f) => checkIds.includes(f.checkId));
+    return { id, label, score: scoreFor(own, moduleCount), findingCount: own.length };
+  });
+  const overall =
+    Math.round((categories.reduce((sum, c) => sum + c.score, 0) / categories.length) * 10) / 10;
+  return { overall, categories, moduleCount };
+}


### PR DESCRIPTION
**Health** — Phase 2 dari `progres/roadmap.md`: daftar detektor flat jadi diagnosis.

- `packages/engine/healthScore.ts`: formula deterministik & terdokumentasi (severity weight error=5/warning=2/info=0.5, dinormalisasi module count — repo gede gak dihukum cuma karena gede)
- 4 kategori: structural integrity · dependency hygiene · layer consistency · convention compliance
- Panel: gauge SVG overall (tanpa chart lib) + bars per kategori

**Calls** — parity callgraph, sengaja list-view biar GraphCanvas (core) gak disentuh:
- Focused mode: file terpilih → *calls* / *called by* dengan bobot
- Overview mode: modul tersibuk berdasarkan total call weight

**Navbar**: Script playground pindah ke sisi aksi topbar dengan hover token konsisten, breadcrumbs balik ke grup kiri.

Tabs Workspace sekarang: **Impact | Issues | Security | Verify | Health | Calls**.

Live-verified: health left-pad = 75 overall; callgraph = 6 nodes. Suite 696/696, tsc clean.