### PR TITLE
fix(web): wrap Explorer with GraphProvider

### DIFF
--- a/apps/web/components/explorer/Explorer.tsx
+++ b/apps/web/components/explorer/Explorer.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { FileDetails, type DiagnosticMarker } from "./FileDetails";
 import { DependencyList } from "./DependencyList";
 import { ImpactSummary } from "./ImpactSummary";
+import { GraphProvider } from "../graph/GraphProvider";
 
 type ExplorerTab = "file" | "dependencies" | "impact";
 
@@ -99,6 +100,7 @@ export function Explorer({ repoUrl, moduleId, branch, onClose }: ExplorerProps) 
   );
 
   return (
+    <GraphProvider repoUrl={repoUrl} branch={branch}>
     <div className="flex h-full flex-col bg-background">
       <div className="flex items-center justify-between bg-muted/20 px-4 py-2">
         <p className="truncate font-mono text-xs text-muted-foreground">{moduleId}</p>
@@ -140,5 +142,6 @@ export function Explorer({ repoUrl, moduleId, branch, onClose }: ExplorerProps) 
         )}
       </div>
     </div>
+    </GraphProvider>
   );
 }


### PR DESCRIPTION
DependencyList (and other graph-context consumers rendered inside Explorer) call useGraphContext(), but Explorer never rendered a <GraphProvider> wrapper — the comment at line 52 incorrectly assumed one was already present higher in the tree. This crashed the Dependencies tab with 'useGraphContext must be used within a <GraphProvider>' as soon as the web dashboard was actually run. Fixed by wrapping Explorer's return JSX with <GraphProvider repoUrl={repoUrl} branch={branch}>.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
