### PR TITLE
fix(acquisition): allowedHosts empty must deny-all, not skip host che…

### DIFF
--- a/packages/acquisition/AcquisitionPolicy.ts
+++ b/packages/acquisition/AcquisitionPolicy.ts
@@ -60,7 +60,12 @@ export function assertSourceAllowed(source: string, policy: AcquisitionPolicy): 
   if (!["http:", "https:", "ssh:", "git:", "ftp:"].includes(url.protocol)) {
     throw new Error(`Remote protocol is not allowed: ${url.protocol}`);
   }
-  if (policy.allowedHosts.length > 0 && !policy.allowedHosts.includes(url.hostname)) {
+  // allowedHosts empty by default = deny-all for remote hosts, NOT
+  // unrestricted. Callers MUST explicitly populate allowedHosts before
+  // any remote acquisition is permitted. (Third fix of this exact
+  // regression — see progres/bugs.md; this file has reverted twice.
+  // If you're touching this file, do NOT remove this check.)
+  if (!policy.allowedHosts.includes(url.hostname)) {
     throw new Error(`Remote host is not allowed: ${url.hostname}`);
   }
 }


### PR DESCRIPTION
…ck (3rd time)

Third occurrence of the exact same regression. assertSourceAllowed() had reverted to skipping the host check when allowedHosts was empty, which is the default policy. This time the risk surface is larger: apps/web/app/api/script/route.ts exposes this same AcquisitionPolicy as the only guard on a public HTTP endpoint that accepts arbitrary .arclux DSL source and can call analyze(<any-url>) -- meaning this bug, if deployed publicly, is an unauthenticated SSRF vector reachable from any browser, not just from CLI/terminal access.

Added an inline comment warning future editors not to remove this check again. A regression test should follow.

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
