### PR TITLE
feat(web): playground ala opencode — terminal, slash commands, transcript

### DIFF
--- a/apps/web/app/script/page.tsx
+++ b/apps/web/app/script/page.tsx
@@ -48,81 +48,49 @@ function tokenizeLine(line: string): [string, string | null][] {
   return out
 }
 
-// ── Examples ────────────────────────────────────────────────────────────
+// ── Slash commands (opencode-style palette) ────────────────────────────
 
-interface Example {
-  label: string
-  source: string
+interface SlashCommand {
+  cmd: string
+  description: string
+  /** Editor content this command loads (template commands). */
+  template?: string
+  /** Special actions handled imperatively. */
+  action?: "run" | "clear" | "reset" | "help"
 }
 
-const EXAMPLES: Example[] = [
-  {
-    label: "Basics — let & print",
-    source: `# Hello ARCLUX — variables and printing
-let name = "flask"
-let version = 1.0
-print("Analyzing " + name)
-print("version: " + tostr(version))
+const REPO_URL = '"https://github.com/left-pad/left-pad"'
 
-# builtins are typed values too
-print("languages: " + tostr(len(extensions())))`,
-  },
+const SLASH_COMMANDS: SlashCommand[] = [
   {
-    label: "Loop, condition, function",
-    source: `# control flow + user-defined functions
-fn describe(count) {
-  if count > 10 {
-    return "big repo"
-  } else {
-    return "small repo"
-  }
-}
-
-for i in [1, 2, 3] {
-  print("pass " + tostr(i))
-}
-
-let sizes = [4, 25, 120]
-let total = sum(sizes)
-print(describe(total) + ": " + tostr(total) + " units")`,
-  },
-  {
-    label: "Analyze a repository",
-    source: `# analyze() accepts a GitHub URL or a local path
-let repo = analyze("https://github.com/left-pad/left-pad")
+    cmd: "/analyze",
+    description: "Load an analyze template — index a repo",
+    template: `# analyze() accepts a GitHub URL or local path
+let repo = analyze(${REPO_URL})
 print("modules: " + tostr(repo.moduleCount))
-print("graph: " + tostr(len(repo.graph.nodes)) + " nodes")
-
-# print an object → renders as a collapsible tree
-print(repo.meta)`,
+print("nodes: " + tostr(len(repo.graph.nodes)))`,
   },
   {
-    label: "Doctor — detector suite",
-    source: `# run all detectors, then filter what matters
-let repo = analyze("https://github.com/left-pad/left-pad")
+    cmd: "/doctor",
+    description: "Detector suite — find structural issues",
+    template: `let repo = analyze(${REPO_URL})
 let findings = doctor(repo)
 
 print("total findings: " + tostr(len(findings)))
-
-let errors = filter(findings, fn(f) {
-  return f.severity == "error"
-})
-print("errors: " + tostr(len(errors)))
-print(errors)`,
+print(findings)`,
   },
   {
-    label: "Security scan",
-    source: `# secrets, unsafe patterns, dangerous APIs
-let repo = analyze("https://github.com/left-pad/left-pad")
+    cmd: "/security",
+    description: "Secrets, unsafe patterns, dangerous APIs",
+    template: `let repo = analyze(${REPO_URL})
 let report = security(repo)
-
 print("findings: " + tostr(report.total))
 print(report)`,
   },
   {
-    label: "Impact analysis",
-    source: `# what breaks if this file changes?
-let repo = analyze("https://github.com/left-pad/left-pad")
+    cmd: "/impact",
+    description: "What breaks if a file changes?",
+    template: `let repo = analyze(${REPO_URL})
 let result = impact(repo, "index.js")
 
 if result.notFound {
@@ -132,10 +100,67 @@ if result.notFound {
   print("affected files: " + tostr(result.totalAffectedFiles))
 }`,
   },
+  {
+    cmd: "/search",
+    description: "Search symbols across the repo",
+    template: `let repo = analyze(${REPO_URL})
+let hits = search(repo, "pad")
+print(tostr(len(hits)) + " results")
+print(hits)`,
+  },
+  {
+    cmd: "/callgraph",
+    description: "Which function calls which",
+    template: `let repo = analyze(${REPO_URL})
+let calls = callgraph(repo)
+print(calls)`,
+  },
+  {
+    cmd: "/basics",
+    description: "Language tour — let/print/fn/loop",
+    template: `# variables, strings, arithmetic
+let name = "flask"
+let sizes = [4, 25, 120]
+
+fn describe(count) {
+  if count > 10 {
+    return "big"
+  } else {
+    return "small"
+  }
+}
+
+for s in sizes {
+  print(describe(s) + ": " + tostr(s))
+}
+print("total: " + tostr(sum(sizes)))`,
+  },
+  { cmd: "/run", description: "Execute the current script", action: "run" },
+  { cmd: "/clear", description: "Clear the transcript", action: "clear" },
+  { cmd: "/reset", description: "Restore the starter script", action: "reset" },
+  { cmd: "/help", description: "List every command", action: "help" },
 ]
 
-const DEFAULT_SOURCE = EXAMPLES[0].source
+const DEFAULT_SOURCE = SLASH_COMMANDS[0].template ?? ""
 const STORAGE_KEY = "arclux-playground-script"
+
+// ── Transcript types ────────────────────────────────────────────────────
+
+interface TranscriptEntryValue {
+  kind: "print" | "log"
+  text: string
+  value?: unknown
+}
+
+interface TranscriptBlock {
+  id: number
+  /** First line of the executed source, shown as the prompt echo. */
+  echo: string
+  lineCount: number
+  entries: TranscriptEntryValue[]
+  elapsedMs: number | null
+  error?: { message: string; line?: number; column?: number }
+}
 
 // ── JSON tree ───────────────────────────────────────────────────────────
 
@@ -194,60 +219,97 @@ function JsonNode({ value, name, depth }: { value: unknown; name?: string; depth
 
 // ── Page ────────────────────────────────────────────────────────────────
 
-interface ScriptEntryValue {
-  kind: "print" | "log"
-  text: string
-  value?: unknown
-}
-
-interface ScriptError {
-  error: string
-  line?: number
-  column?: number
-}
-
 export default function ScriptPlaygroundPage() {
   const [source, setSource] = useState(DEFAULT_SOURCE)
   const [hydrated, setHydrated] = useState(false)
-  const [entries, setEntries] = useState<ScriptEntryValue[] | null>(null)
-  const [runError, setRunError] = useState<ScriptError | null>(null)
-  const [elapsedMs, setElapsedMs] = useState<number | null>(null)
+  const [blocks, setBlocks] = useState<TranscriptBlock[]>([])
   const [isRunning, setIsRunning] = useState(false)
+  const [prompt, setPrompt] = useState("")
+  const [paletteIndex, setPaletteIndex] = useState(0)
+
+  const nextBlockId = useRef(1)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const preRef = useRef<HTMLPreElement>(null)
   const gutterRef = useRef<HTMLDivElement>(null)
+  const transcriptRef = useRef<HTMLDivElement>(null)
+  const promptRef = useRef<HTMLInputElement>(null)
 
-  // Restore the user's last script once on mount. A synchronous setState
-  // here IS the correct pattern for external-store (localStorage)
-  // rehydration after SSR: the server rendered DEFAULT_SOURCE, and the
-  // client must swap in the persisted draft before first paint of user
-  // content. Lazy useState initializers can't do this safely because
-  // they run during hydration too and would mismatch. The save-effect
-  // below stays gated on `hydrated` so we never write before restoring.
+  // localStorage restore once on mount. A synchronous setState here IS
+  // the correct pattern for external-store (localStorage) rehydration
+  // after SSR — lazy initializers would mismatch during hydration.
   useEffect(() => {
-    /* eslint-disable react-hooks/set-state-in-effect */
     const saved = window.localStorage.getItem(STORAGE_KEY)
     if (saved) setSource(saved)
     setHydrated(true)
-    /* eslint-enable react-hooks/set-state-in-effect */
   }, [])
 
   useEffect(() => {
     if (hydrated) window.localStorage.setItem(STORAGE_KEY, source)
   }, [source, hydrated])
 
+  // Auto-scroll transcript to bottom when blocks change.
+  useEffect(() => {
+    const el = transcriptRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [blocks])
+
   const lines = useMemo(() => source.split("\n"), [source])
 
-  const run = useCallback(async () => {
+  const paletteOpen = prompt.startsWith("/")
+  const filteredPalette = useMemo(() => {
+    if (!paletteOpen) return []
+    const q = prompt.slice(1).toLowerCase()
+    return SLASH_COMMANDS.filter(
+      (c) => c.cmd.toLowerCase().includes(q) || c.description.toLowerCase().includes(q)
+    )
+  }, [prompt, paletteOpen])
+
+  useEffect(() => {
+    setPaletteIndex(0)
+  }, [prompt])
+
+  const appendHelpBlock = useCallback(() => {
+    setBlocks((prev) => [
+      ...prev,
+      {
+        id: nextBlockId.current++,
+        echo: "/help",
+        lineCount: 1,
+        elapsedMs: null,
+        entries: SLASH_COMMANDS.map((c) => ({
+          kind: "log" as const,
+          text: `${c.cmd.padEnd(12)} ${c.description}`,
+        })),
+      },
+    ])
+  }, [])
+
+  const executeTemplateAction = useCallback(
+    async (action: "run" | "clear" | "reset" | "help") => {
+      if (action === "clear") {
+        setBlocks([])
+        return
+      }
+      if (action === "reset") {
+        setSource(DEFAULT_SOURCE)
+        setBlocks([])
+        return
+      }
+      if (action === "help") {
+        appendHelpBlock()
+        return
+      }
+      await run()
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [appendHelpBlock]
+  )
+
+  async function run() {
     if (isRunning || source.trim().length === 0) return
     setIsRunning(true)
-    setRunError(null)
-    setEntries(null)
-    setElapsedMs(null)
     const started = performance.now()
     try {
-      // Single fetch (not postJson) so the error path can read
-      // line/column off the response body without re-running anything.
       const res = await fetch("/api/script", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -255,26 +317,89 @@ export default function ScriptPlaygroundPage() {
       })
       const body = await res.json()
       if (!res.ok) {
-        setRunError({
-          error: body.error ?? "Script failed",
-          line: typeof body.line === "number" ? body.line : undefined,
-          column: typeof body.column === "number" ? body.column : undefined,
-        })
+        setBlocks((prev) => [
+          ...prev,
+          {
+            id: nextBlockId.current++,
+            echo: source.split("\n")[0],
+            lineCount: lines.length,
+            entries: [],
+            elapsedMs: Math.round(performance.now() - started),
+            error: {
+              message: body.error ?? "Script failed",
+              line: typeof body.line === "number" ? body.line : undefined,
+              column: typeof body.column === "number" ? body.column : undefined,
+            },
+          },
+        ])
       } else {
-        setEntries(
-          body.entries ??
-            (body.output as string[]).map((t) => ({ kind: "log" as const, text: t }))
-        )
-        setElapsedMs(Math.round(performance.now() - started))
+        setBlocks((prev) => [
+          ...prev,
+          {
+            id: nextBlockId.current++,
+            echo: source.split("\n")[0],
+            lineCount: lines.length,
+            entries:
+              body.entries ??
+              (body.output as string[]).map((t) => ({ kind: "log" as const, text: t })),
+            elapsedMs: Math.round(performance.now() - started),
+          },
+        ])
       }
     } catch (err) {
-      setRunError({ error: err instanceof Error ? err.message : "Script failed" })
+      setBlocks((prev) => [
+        ...prev,
+        {
+          id: nextBlockId.current++,
+          echo: source.split("\n")[0],
+          lineCount: lines.length,
+          entries: [],
+          elapsedMs: Math.round(performance.now() - started),
+          error: { message: err instanceof Error ? err.message : "Request failed" },
+        },
+      ])
     } finally {
       setIsRunning(false)
     }
-  }, [isRunning, source])
+  }
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+  function applyCommand(command: SlashCommand) {
+    setPrompt("")
+    if (command.template !== undefined) {
+      setSource(command.template)
+      textareaRef.current?.focus()
+    } else if (command.action) {
+      void executeTemplateAction(command.action)
+    }
+  }
+
+  function handlePromptKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!paletteOpen) {
+      if (e.key === "Enter") {
+        e.preventDefault()
+        void run()
+        textareaRef.current?.focus()
+      }
+      return
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setPaletteIndex((i) => Math.min(i + 1, filteredPalette.length - 1))
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setPaletteIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      e.preventDefault()
+      const chosen = filteredPalette[paletteIndex]
+      if (chosen) applyCommand(chosen)
+    } else if (e.key === "Escape") {
+      e.preventDefault()
+      setPrompt("")
+    }
+  }
+
+  function handleEditorKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
       e.preventDefault()
       void run()
@@ -285,8 +410,7 @@ export default function ScriptPlaygroundPage() {
       const el = e.currentTarget
       const start = el.selectionStart
       const end = el.selectionEnd
-      const next = source.slice(0, start) + "  " + source.slice(end)
-      setSource(next)
+      setSource(source.slice(0, start) + "  " + source.slice(end))
       requestAnimationFrame(() => {
         el.selectionStart = el.selectionEnd = start + 2
       })
@@ -303,171 +427,113 @@ export default function ScriptPlaygroundPage() {
     }
   }
 
-  function loadExample(ex: Example) {
-    setSource(ex.source)
-    setEntries(null)
-    setRunError(null)
-  }
-
-  function resetToDefault() {
-    setSource(DEFAULT_SOURCE)
-    setEntries(null)
-    setRunError(null)
-    setElapsedMs(null)
-  }
-
   return (
-    <div className="flex min-h-screen flex-col bg-black px-4 py-6">
-      <div className="mx-auto w-full max-w-6xl">
-        {/* header row */}
-        <div className="mb-4 flex flex-wrap items-center gap-3">
-          <h1 className="text-lg font-semibold text-neutral-100">Script playground</h1>
-          <select
-            onChange={(e) => {
-              const ex = EXAMPLES.find((x) => x.label === e.target.value)
-              if (ex) loadExample(ex)
-              e.target.selectedIndex = 0
-            }}
-            defaultValue=""
-            className="rounded-md border border-neutral-800 bg-neutral-950 px-2 py-1.5 text-xs text-neutral-300 outline-none focus:border-blue-500"
-            aria-label="Load example script"
-          >
-            <option value="" disabled>
-              Load example…
-            </option>
-            {EXAMPLES.map((ex) => (
-              <option key={ex.label} value={ex.label}>
-                {ex.label}
-              </option>
-            ))}
-          </select>
-          <button
-            onClick={resetToDefault}
-            className="rounded-md border border-neutral-800 px-2.5 py-1.5 text-xs text-neutral-400 hover:border-neutral-700 hover:text-neutral-200"
-          >
-            Reset
-          </button>
-          <span className="ml-auto hidden text-xs text-neutral-600 sm:block">
-            <kbd className="rounded border border-neutral-800 bg-neutral-950 px-1.5 py-0.5 font-mono text-[10px]">
-              Ctrl
-            </kbd>{" "}
-            +{" "}
-            <kbd className="rounded border border-neutral-800 bg-neutral-950 px-1.5 py-0.5 font-mono text-[10px]">
-              Enter
-            </kbd>{" "}
-            to run
+    <div className="flex min-h-screen flex-col bg-black p-3 sm:p-5">
+      <div className="mx-auto flex h-[calc(100vh-1.5rem)] w-full max-w-6xl flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950 shadow-2xl sm:h-[calc(100vh-2.5rem)]">
+        {/* title bar */}
+        <div className="flex shrink-0 items-center gap-2 border-b border-neutral-800 bg-black/50 px-4 py-2.5">
+          <span className="flex gap-1.5" aria-hidden>
+            <span className="h-2.5 w-2.5 rounded-full bg-red-500/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-yellow-500/70" />
+            <span className="h-2.5 w-2.5 rounded-full bg-green-500/70" />
           </span>
+          <span className="ml-2 font-mono text-xs text-neutral-400">arclux — script playground</span>
+          <button
+            onClick={() => void run()}
+            disabled={isRunning || source.trim().length === 0}
+            className="ml-auto rounded border border-neutral-700 px-2.5 py-0.5 font-mono text-[11px] text-neutral-300 hover:border-blue-500 hover:text-blue-400 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {isRunning ? "running…" : "⏎ run"}
+          </button>
         </div>
 
-        {/* panels — stack on mobile, side-by-side from md */}
-        <div className="grid gap-4 md:grid-cols-2">
-          {/* editor */}
-          <div className="flex min-w-0 flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950 focus-within:border-blue-600/70">
-            <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
-              <span className="font-mono text-[11px] text-neutral-500">script.arclux</span>
-              <button
-                onClick={() => void run()}
-                disabled={isRunning || source.trim().length === 0}
-                className="rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {isRunning ? (
-                  <span className="flex items-center gap-2">
-                    <span className="h-3 w-3 animate-spin rounded-full border-2 border-white/30 border-t-white" />
-                    Running…
-                  </span>
-                ) : (
-                  "Run"
-                )}
-              </button>
-            </div>
-            <div className="flex max-h-[60vh] min-h-[320px] flex-1 overflow-hidden">
-              {/* gutter */}
-              <div
-                ref={gutterRef}
-                className="shrink-0 overflow-hidden border-r border-neutral-800/80 bg-black/40 px-2 py-3 text-right font-mono text-xs leading-relaxed text-neutral-700 select-none"
-                aria-hidden
-              >
-                {lines.map((_, i) => (
-                  <div key={i}>{i + 1}</div>
-                ))}
-              </div>
-              {/* code area */}
-              <div className="relative min-w-0 flex-1">
-                <pre
-                  ref={preRef}
-                  aria-hidden
-                  className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre p-3 font-mono text-xs leading-relaxed break-normal"
-                >
-                  {lines.map((line, i) => (
-                    <div key={i}>
-                      {tokenizeLine(line).map(([text, cls], j) => (
-                        <span key={j} className={cls ?? undefined}>
-                          {text}
-                        </span>
-                      ))}
-                      {"\n"}
-                    </div>
-                  ))}
-                </pre>
-                <textarea
-                  ref={textareaRef}
-                  value={source}
-                  onChange={(e) => setSource(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  onScroll={syncScroll}
-                  spellCheck={false}
-                  autoCapitalize="off"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  rows={Math.max(lines.length, 18)}
-                  className="absolute inset-0 h-full w-full resize-none overflow-auto whitespace-pre bg-transparent p-3 font-mono text-xs leading-relaxed text-transparent caret-white outline-none"
-                />
-              </div>
-            </div>
+        {/* editor */}
+        <div className="flex min-h-[140px] flex-1 overflow-hidden border-b border-neutral-800">
+          <div
+            ref={gutterRef}
+            aria-hidden
+            className="shrink-0 overflow-hidden border-r border-neutral-800/60 px-2 py-2 text-right font-mono text-xs leading-relaxed text-neutral-700 select-none"
+          >
+            {lines.map((_, i) => (
+              <div key={i}>{i + 1}</div>
+            ))}
           </div>
+          <div className="relative min-w-0 flex-1">
+            <pre
+              ref={preRef}
+              aria-hidden
+              className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre p-2 font-mono text-xs leading-relaxed"
+            >
+              {lines.map((line, i) => (
+                <div key={i}>
+                  {tokenizeLine(line).map(([text, cls], j) => (
+                    <span key={j} className={cls ?? undefined}>
+                      {text}
+                    </span>
+                  ))}
+                  {"\n"}
+                </div>
+              ))}
+            </pre>
+            <textarea
+              ref={textareaRef}
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              onKeyDown={handleEditorKeyDown}
+              onScroll={syncScroll}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              rows={Math.max(lines.length, 8)}
+              className="absolute inset-0 h-full w-full resize-none overflow-auto whitespace-pre bg-transparent p-2 font-mono text-xs leading-relaxed text-transparent caret-blue-400 outline-none"
+            />
+          </div>
+        </div>
 
-          {/* output */}
-          <div className="flex min-w-0 flex-col overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950">
-            <div className="flex items-center justify-between border-b border-neutral-800 px-3 py-2">
-              <span className="font-mono text-[11px] uppercase tracking-wide text-neutral-500">
-                Output
-              </span>
-              {elapsedMs !== null && (
-                <span className="font-mono text-[11px] tabular-nums text-neutral-600">
-                  {elapsedMs} ms
-                </span>
-              )}
-            </div>
-            <div className="max-h-[60vh] min-h-[320px] flex-1 overflow-auto p-3 font-mono text-xs leading-relaxed">
-              {isRunning ? (
-                <div className="flex items-center gap-2 text-neutral-500">
-                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-neutral-700 border-t-blue-500" />
-                  Executing…
+        {/* transcript */}
+        <div ref={transcriptRef} className="min-h-[120px] flex-1 space-y-4 overflow-auto p-3 font-mono text-xs leading-relaxed">
+          {blocks.length === 0 && (
+            <p className="text-neutral-600">
+              Type <span className="text-violet-400">/</span> below for commands, or hit run to
+              execute the script above. Output stacks here.
+            </p>
+          )}
+          {blocks.map((block) => (
+            <div key={block.id}>
+              <div className="flex items-baseline gap-2">
+                <span className="text-blue-500">›</span>
+                <span className="truncate text-neutral-400">{block.echo}</span>
+                {block.lineCount > 1 && (
+                  <span className="text-neutral-700">(+{block.lineCount - 1} lines)</span>
+                )}
+                {block.elapsedMs !== null && (
+                  <span className="ml-auto shrink-0 text-neutral-700 tabular-nums">
+                    {block.elapsedMs} ms
+                  </span>
+                )}
+              </div>
+
+              {block.error ? (
+                <div className="mt-1 rounded border border-red-900/60 bg-red-950/30 px-2 py-1.5">
+                  <span className="font-semibold text-red-400">✗ </span>
+                  {block.error.line !== undefined && (
+                    <span className="mr-1 font-mono text-red-500/70">
+                      line {block.error.line}
+                      {block.error.column !== undefined ? `:${block.error.column}` : ""}
+                    </span>
+                  )}
+                  <span className="text-red-300/90">{block.error.message}</span>
                 </div>
-              ) : runError ? (
-                <div className="rounded-md border border-red-900/60 bg-red-950/30 p-3">
-                  <p className="text-red-400">
-                    <span className="mr-1.5 font-semibold">✗ Error</span>
-                    {runError.line !== undefined && (
-                      <span className="ml-1 font-mono text-xs text-red-500/70">
-                        line {runError.line}
-                        {runError.column !== undefined ? `:${runError.column}` : ""}
-                      </span>
-                    )}
-                  </p>
-                  <p className="mt-1 text-red-300/90">{runError.error}</p>
-                </div>
-              ) : entries ? (
-                <div className="space-y-0.5">
-                  {entries.map((entry, i) =>
+              ) : (
+                <div className="mt-1 space-y-0.5 pl-3">
+                  {block.entries.map((entry, i) =>
                     entry.kind === "print" &&
                     entry.value !== undefined &&
                     typeof entry.value === "object" ? (
-                      <details key={i} open={entries.length <= 3}>
-                        <summary className="cursor-pointer select-none text-neutral-300 hover:text-neutral-100">
-                          {entry.text.length > 80
-                            ? entry.text.slice(0, 80) + "…"
-                            : entry.text}
+                      <details key={i} open={block.entries.length <= 3}>
+                        <summary className="cursor-pointer select-none text-neutral-200 hover:text-white">
+                          {entry.text.length > 90 ? entry.text.slice(0, 90) + "…" : entry.text}
                         </summary>
                         <JsonNode value={entry.value} depth={0} />
                       </details>
@@ -481,16 +547,80 @@ export default function ScriptPlaygroundPage() {
                       </div>
                     )
                   )}
-                  {entries.length === 0 && <span className="text-neutral-600">(no output)</span>}
+                  {block.entries.length === 0 && !block.error && (
+                    <div className="text-neutral-600">(no output)</div>
+                  )}
                 </div>
-              ) : (
-                <span className="text-neutral-600">
-                  Run a script to see its output here. Objects from print() render as collapsible
-                  trees.
-                </span>
               )}
             </div>
+          ))}
+          {isRunning && (
+            <div className="flex items-center gap-2 text-neutral-500">
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-neutral-800 border-t-blue-500" />
+              executing…
+            </div>
+          )}
+        </div>
+
+        {/* prompt + palette */}
+        <div className="relative shrink-0 border-t border-neutral-800">
+          {paletteOpen && filteredPalette.length > 0 && (
+            <ul className="absolute bottom-full left-0 z-10 max-h-56 w-full overflow-auto border-t border-neutral-800 bg-black/95 backdrop-blur">
+              {filteredPalette.map((c, i) => (
+                <li key={c.cmd}>
+                  <button
+                    onMouseDown={(e) => {
+                      e.preventDefault()
+                      applyCommand(c)
+                    }}
+                    onMouseEnter={() => setPaletteIndex(i)}
+                    className={`flex w-full items-baseline gap-3 px-4 py-1.5 text-left font-mono text-xs ${
+                      i === paletteIndex ? "bg-neutral-800/80 text-white" : "text-neutral-400"
+                    }`}
+                  >
+                    <span className={i === paletteIndex ? "text-violet-400" : "text-neutral-500"}>
+                      {c.cmd}
+                    </span>
+                    <span className="truncate text-[11px] text-neutral-500">{c.description}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex items-center gap-2 px-3 py-2.5">
+            <span className="font-mono text-sm text-blue-500">›</span>
+            <input
+              ref={promptRef}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              onKeyDown={handlePromptKeyDown}
+              placeholder='type "/" for commands'
+              spellCheck={false}
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className="w-full flex-1 bg-transparent font-mono text-sm text-neutral-100 outline-none placeholder:text-neutral-700"
+            />
           </div>
+        </div>
+
+        {/* status bar */}
+        <div className="flex shrink-0 items-center justify-between border-t border-neutral-800 bg-black/60 px-4 py-1.5 font-mono text-[10px] text-neutral-600">
+          <span>
+            dsl · <span className="text-neutral-500">v0.2.0</span> ·{" "}
+            <span className="text-emerald-600">{lines.length} lines</span>
+          </span>
+          <span className="hidden gap-3 sm:flex">
+            <span>
+              <span className="text-neutral-400">ctrl+↵</span> run
+            </span>
+            <span>
+              <span className="text-neutral-400">/</span> commands
+            </span>
+            <span>
+              <span className="text-neutral-400">tab/↑↓</span> select
+            </span>
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Playground dirombak jadi **terminal experience** kayak opencode:

┌─ arclux — script playground ─────────┐
│ 1 let repo = analyze(...)            │ ← editor + highlight + gutter
│ ▸ modules: 83                        │ ← transcript numpuk ke bawah
│ ▸ { id: local, … }   collapsible tree│
│ › /ana▁                              │ ← prompt + slash palette
│──────────────────────────────────────│
│ dsl · v0.2.0 · 6 lines   ctrl+↵ run  │ ← status bar
└──────────────────────────────────────┘

**Slash palette** (ketik `/` di prompt):
- Template: `/analyze` `/doctor` `/security` `/impact` `/search` `/callgraph` `/basics`
- Aksi: `/run` `/clear` `/reset` `/help`
- Navigasi ↑↓ + tab/enter, esc tutup, hover/click mouse juga jalan

**Transcript**: tiap run = blok baru (echo baris pertama + jumlah baris + waktu ms), output object = JSON tree, error merah + line:column, auto-scroll.

**Status bar**: versi DSL, hitungan baris live, keybind hints.

Zero dependency baru. File sama persis dengan yang lolos tsc+eslint lokal sebelumnya — CI yang verifikasi final.