### PR TITLE
feat(web): AUDIT THEATER — stream × focus × graph

### DIFF
--- a/apps/web/components/script/AuditWorkspace.tsx
+++ b/apps/web/components/script/AuditWorkspace.tsx
@@ -11,25 +11,23 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { AuditGraphPane, type AuditFocusTarget } from "@/components/script/AuditGraphPane"
 
-interface SecurityFindingItem {
+// ── Data shapes (mirror /api/audit response verbatim) ──────────────────
+
+/** Loose structural view of either finding family as /api/audit emits
+ * them (route spreads originals + adds `source`). Kept flat on purpose —
+ * an intersection of the two interfaces narrows `severity` wrongly. */
+interface AuditItem {
+  source: "doctor" | "security"
+  severity: string
   id?: string
   ruleId?: string
   title?: string
   description?: string
-  severity: string
-  location?: { filePath: string; line?: number }
   cwe?: string[]
-}
-
-interface DoctorFindingItem {
-  checkId: string
-  severity: "error" | "warning" | "info"
-  message: string
+  location?: { filePath: string; line?: number }
+  checkId?: string
+  message?: string
   filePath?: string
-}
-
-type AuditItem = SecurityFindingItem & DoctorFindingItem & {
-  source: "doctor" | "security"
 }
 
 interface AuditChapter {
@@ -57,82 +55,70 @@ interface AuditResponse {
   chapters: AuditChapter[]
 }
 
-const BOOT_LINES = [
-  "ARCLUX ▸ inisialisasi pemindaian struktural…",
-  "ARCLUX ▸ 27 parser siap · 20 detektor dimuat",
-  "ARCLUX ▸ mengkloning & mengindeks repositori…",
-  "ARCLUX ▸ memetakan permukaan serangan…",
+// ── Stream types ────────────────────────────────────────────────────────
+
+type Tone = "dim" | "accent" | "ok" | "warn" | "bad"
+
+interface StreamLine {
+  text: string
+  tone: Tone
+}
+
+const TONE_CLASS: Record<Tone, string> = {
+  dim: "text-neutral-600",
+  accent: "text-cyan-400",
+  ok: "text-emerald-400",
+  warn: "text-yellow-400",
+  bad: "text-red-400",
+}
+
+function sevTone(sev: string): Tone {
+  if (sev === "critical") return "bad"
+  if (sev === "high" || sev === "error") return "warn"
+  return "dim"
+}
+
+const BOOT_LINES: StreamLine[] = [
+  { text: 'init.parsers[27]        → ok', tone: "accent" },
+  { text: 'init.detectors[20]      → ok', tone: "accent" },
+  { text: 'load.rules[14]          → ok', tone: "accent" },
+  { text: 'clone(repo)             …', tone: "dim" },
 ]
 
-function severityDot(sev: string): string {
-  if (sev === "critical" || sev === "error") return "bg-red-500"
-  if (sev === "high") return "bg-orange-500"
-  if (sev === "warning" || sev === "medium") return "bg-yellow-500"
-  return "bg-neutral-500"
+/** Build the scan script from REAL audit output. Capped so a 2k-finding
+ * repo streams fast instead of rendering forever — the FOCUS panel holds
+ * every item, the stream is the show. */
+function buildStreamScript(data: AuditResponse): StreamLine[] {
+  const out: StreamLine[] = []
+  const repoShort = data.repoUrl.replace(/^https?:\/\/github\.com\//, "")
+  out.push({ text: `analyze("${repoShort}") → ${data.moduleCount} modules`, tone: "ok" })
+  out.push({
+    text: `surface.map() → ${data.attackSurface.entryPoints} entry · ${data.attackSurface.reachableModules} reachable`,
+    tone: "accent",
+  })
+
+  const PER_CHAPTER_CAP = 24
+  for (const ch of data.chapters) {
+    out.push({ text: `── sweep "${ch.label.toLowerCase()}" · ${ch.count}`, tone: "dim" })
+    for (const it of ch.items.slice(0, PER_CHAPTER_CAP)) {
+      const file = it.location?.filePath ?? it.filePath ?? "?"
+      const line = it.location?.line
+      const rule = it.ruleId ?? it.checkId ?? "finding"
+      out.push({
+        text: `${rule}(${file}${line !== undefined ? `:${line}` : ""}) [${it.severity}]`,
+        tone: sevTone(it.severity),
+      })
+    }
+    if (ch.items.length > PER_CHAPTER_CAP) {
+      out.push({ text: `… +${ch.items.length - PER_CHAPTER_CAP} more → FOCUS panel`, tone: "dim" })
+    }
+  }
+
+  out.push({ text: `ARCLUX: ${data.findingTotal} anomali terdeteksi · health ${data.overallHealth}/100`, tone: "ok" })
+  return out
 }
 
-function FindingRow({
-  item,
-  onOpenFile,
-}: {
-  item: AuditItem
-  onOpenFile: (path: string, line?: number) => void
-}) {
-  const title =
-    (item.source === "security" ? item.title : undefined) ??
-    (item.checkId ? `${item.checkId}` : "finding")
-  const detail =
-    item.source === "security"
-      ? item.description ?? ""
-      : item.message
-  const loc = item.location?.filePath ?? item.filePath
-  const line = item.location?.line
-
-  return (
-    <li className="rounded border border-neutral-800/80 bg-neutral-950/70 px-2.5 py-1.5">
-      <div className="flex flex-wrap items-baseline gap-x-2">
-        <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${severityDot(item.severity)}`} aria-hidden />
-        {item.source === "security" && item.ruleId && (
-          <code className="text-[11px] text-neutral-400">{item.ruleId}</code>
-        )}
-        {item.source === "doctor" && (
-          <code className="text-[11px] text-neutral-400">{item.checkId}</code>
-        )}
-        <span className="text-[10px] uppercase tracking-wide text-neutral-600">{item.severity}</span>
-        {loc && (
-          <code className="truncate font-mono text-[11px] text-neutral-500">
-            {loc}
-            {line !== undefined && `:${line}`}
-          </code>
-        )}
-      </div>
-      {detail && <p className="mt-0.5 pl-3.5 text-xs text-neutral-300">{detail}</p>}
-      {item.cwe && item.cwe.length > 0 && (
-        <p className="pl-3.5 font-mono text-[10px] text-neutral-700">{item.cwe.join(" · ")}</p>
-      )}
-      {(loc || item.filePath) && (
-        <button
-          onClick={() =>
-            onOpenFile((loc ?? item.filePath) as string, line)
-          }
-          className="ml-auto shrink-0 rounded border border-neutral-800 px-1.5 py-0.5 font-mono text-[10px] text-neutral-400 hover:border-blue-600 hover:text-blue-400"
-        >
-          lihat file ↗
-        </button>
-      )}
-      <span className="hidden">{title}</span>
-    </li>
-  )
-}
-
-/**
- * Audit mode inside the script playground terminal: press run → boot
- * sequence plays while /api/audit composes doctor + security + attack
- * surface → real numbers land → chapters reveal staggered. Deterministic
- * theater over existing engine output — no AI, no fake findings.
- */
-
-// ── File preview overlay (raw.githubusercontent via /api/file) ──────────
+// ── File preview overlay (unchanged behavior, raw.githubusercontent) ───
 
 interface PreviewState {
   path: string
@@ -187,22 +173,19 @@ function FilePreviewOverlay({
     return () => window.removeEventListener("keydown", onKey)
   }, [onClose])
 
-  // Scroll the finding's line into view once content renders.
   useEffect(() => {
     if (preview.content === null || !target.line) return
     const el = preRef.current?.querySelector(`[data-line="${target.line}"]`)
     el?.scrollIntoView({ block: "center" })
   }, [preview.content, target.line])
 
-  const lines = useMemo(
-    () => (preview.content ?? "").split("\n"),
-    [preview.content]
-  )
+  const lines = useMemo(() => (preview.content ?? "").split("\n"), [preview.content])
 
   return (
-    <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/70 p-4 backdrop-blur-sm">
-      <div className="flex h-full max-h-[85%] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-neutral-700 bg-neutral-950">
+    <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm">
+      <div className="flex h-full max-h-[85%] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-emerald-900/50 bg-neutral-950">
         <div className="flex shrink-0 items-center gap-2 border-b border-neutral-800 px-3 py-2">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-emerald-500">file</span>
           <code className="truncate font-mono text-xs text-neutral-300">{target.path}</code>
           {target.line !== undefined && (
             <span className="font-mono text-[10px] text-red-400">:{target.line}</span>
@@ -214,7 +197,7 @@ function FilePreviewOverlay({
             esc ✕
           </button>
         </div>
-        <pre ref={preRef} className="min-h-0 flex-1 overflow-auto p-0 font-mono text-xs leading-relaxed">
+        <pre ref={preRef} className="min-h-0 flex-1 overflow-auto font-mono text-xs leading-relaxed">
           {preview.error ? (
             <div className="p-3 text-red-400">{preview.error}</div>
           ) : preview.content === null ? (
@@ -226,7 +209,7 @@ function FilePreviewOverlay({
                 data-line={i + 1}
                 className={
                   target.line === i + 1
-                    ? "bg-red-950/60 border-l-2 border-red-500 px-2 text-red-200"
+                    ? "border-l-2 border-red-500 bg-red-950/60 px-2 text-red-200"
                     : "px-2 text-neutral-400 hover:bg-neutral-900"
                 }
               >
@@ -243,8 +226,9 @@ function FilePreviewOverlay({
   )
 }
 
+// ── Main component ──────────────────────────────────────────────────────
+
 export interface AuditWorkspaceProps {
-  /** Prefilled repository (standalone page passes org/repo from the URL). */
   initialRepoUrl?: string
   branch?: string
 }
@@ -253,50 +237,52 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
   const [repoInput, setRepoInput] = useState(
     initialRepoUrl ?? "https://github.com/left-pad/left-pad"
   )
-  const [phase, setPhase] = useState<"idle" | "booting" | "done">("idle")
+  const [phase, setPhase] = useState<"idle" | "booting" | "streaming" | "done">("idle")
   const [bootVisible, setBootVisible] = useState(0)
-  const [revealedChapters, setRevealedChapters] = useState(0)
+  const [streamLines, setStreamLines] = useState<StreamLine[]>([])
+  const [streamProgress, setStreamProgress] = useState(0)
   const [data, setData] = useState<AuditResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [elapsedMs, setElapsedMs] = useState<number | null>(null)
-  /** Flat cursor over all chapter items; -1 = nothing focused yet. */
   const [cursor, setCursor] = useState(-1)
   const [openFile, setOpenFile] = useState<{ path: string; line?: number } | null>(null)
-  const chapterRefs = useRef<(HTMLElement | null)[]>([])
+
   const timersRef = useRef<ReturnType<typeof setTimeout>[]>([])
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    return () => timersRef.current.forEach(clearTimeout)
-  }, [])
-
-  useEffect(() => {
-    const el = scrollRef.current
-    if (el) el.scrollTop = el.scrollHeight
-  }, [bootVisible, revealedChapters, phase])
 
   function clearTimers() {
     timersRef.current.forEach(clearTimeout)
     timersRef.current = []
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
   }
 
+  useEffect(() => () => clearTimers(), [])
+
+  // Auto-scroll the stream.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el) el.scrollTop = el.scrollHeight
+  }, [streamLines, bootVisible])
+
   async function startAudit() {
-    if (phase === "booting") return
+    if (phase === "booting" || phase === "streaming") return
     const repoUrl = repoInput.trim()
     if (!repoUrl) return
 
     clearTimers()
     setPhase("booting")
     setBootVisible(0)
-    setRevealedChapters(0)
-    setCursor(-1)
+    setStreamLines([])
+    setStreamProgress(0)
     setData(null)
     setError(null)
-    setElapsedMs(null)
+    setCursor(-1)
 
-    // Staged boot lines (~650ms apart) while the single fetch runs.
     BOOT_LINES.forEach((_, i) => {
-      timersRef.current.push(setTimeout(() => setBootVisible(i + 1), i * 650))
+      timersRef.current.push(setTimeout(() => setBootVisible(i + 1), i * 550))
     })
 
     const started = performance.now()
@@ -308,103 +294,122 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
       })
       const body = await res.json()
       if (!res.ok) {
-        setError(body.error ?? "Audit failed")
-        setPhase("done")
         clearTimers()
         setBootVisible(BOOT_LINES.length)
+        setError(body.error ?? "Audit gagal")
+        setPhase("done")
         return
       }
-      const elapsed = Math.round(performance.now() - started)
-      const result = body as AuditResponse
 
-      // Land the summary exactly when the data is real.
       clearTimers()
-      setBootVisible(BOOT_LINES.length)
-      timersRef.current.push(
-        setTimeout(() => {
+      const result = body as AuditResponse
+      void started
+      const script = buildStreamScript(result)
+
+      // Summary lands as the first streamed line, then the rain begins.
+      setPhase("streaming")
+      let idx = 0
+      setStreamLines([{ text: script[0].text, tone: "ok" }])
+      idx = 1
+      intervalRef.current = setInterval(() => {
+        if (idx >= script.length) {
+          if (intervalRef.current) clearInterval(intervalRef.current)
+          intervalRef.current = null
           setData(result)
-          setElapsedMs(elapsed)
           setPhase("done")
-          // Staggered chapter reveal after the summary line.
-          result.chapters.forEach((_, i) => {
-            timersRef.current.push(setTimeout(() => setRevealedChapters(i + 1), 350 * (i + 1)))
-          })
-        }, 450)
-      )
+          return
+        }
+        const line = script[idx]
+        setStreamLines((prev) => [...prev.slice(-260), line])
+        setStreamProgress(Math.round(((idx + 1) / script.length) * 100))
+        idx++
+      }, 55)
     } catch (err) {
       clearTimers()
       setBootVisible(BOOT_LINES.length)
-      setError(err instanceof Error ? err.message : "Request failed")
+      setError(err instanceof Error ? err.message : "Permintaan gagal")
       setPhase("done")
     }
   }
 
   function skip() {
-    if (phase !== "booting") return
-    clearTimers()
-    setBootVisible(BOOT_LINES.length)
+    if (phase === "booting" || phase === "streaming") {
+      clearTimers()
+      // Fast-forward: show whatever we have; if data not yet in, wait flag
+      // stays until fetch resolves (phase flips there).
+      setBootVisible(BOOT_LINES.length)
+      if (data) {
+        setStreamLines(buildStreamScript(data))
+        setStreamProgress(100)
+        setPhase("done")
+      } else if (phase === "streaming") {
+        setPhase("done")
+        setData((d) => d)
+      }
+    }
   }
 
-  const shownSummaryLine =
-    data &&
-    `✓ ${data.moduleCount} modul · ${data.findingTotal} temuan · health ${data.overallHealth} · surface ${data.attackSurface.entryPoints} entry/${data.attackSurface.reachableModules} reachable` +
-      (elapsedMs !== null ? ` · ${ (elapsedMs / 1000).toFixed(1) }s` : "")
-
+  // ── walkthrough over flat findings ────────────────────────────────
   const flatItems = useMemo(() => {
     if (!data) return []
-    return data.chapters.flatMap((ch, ci) =>
-      ch.items.map((it, ii) => ({ chapterIndex: ci, item: it as AuditItem, itemIndex: ii }))
-    )
+    return data.chapters.flatMap((ch) => ch.items.map((it) => ({ item: it as AuditItem })))
   }, [data])
 
-  const activeItem = cursor >= 0 && cursor < flatItems.length ? flatItems[cursor] : null
+  const active = cursor >= 0 && cursor < flatItems.length ? flatItems[cursor].item : null
 
   const focusTarget: AuditFocusTarget | null = useMemo(() => {
-    if (!activeItem) return null
-    const it = activeItem.item
-    const filePath =
-      it.location?.filePath ?? it.filePath ?? null
+    if (!active) return null
+    const filePath = active.location?.filePath ?? active.filePath ?? null
     const cycleFiles =
-      it.checkId === "circularDependency" && it.message.includes("\u2192")
-        ? it.message.split("\u2192").map((p) => p.trim()).filter(Boolean)
+      active.checkId === "circularDependency" &&
+      typeof active.message === "string" &&
+      active.message.includes("→")
+        ? active.message.split("→").map((p) => p.trim()).filter(Boolean)
         : []
     return { filePath, cycleFiles }
-  }, [activeItem])
-
-  const jumpToChapter = useCallback(
-    (chapterIndex: number) => {
-      const first = flatItems.findIndex((f) => f.chapterIndex === chapterIndex)
-      if (first >= 0) setCursor(first)
-      // Reveal every chapter up to the jumped one so it is visible.
-      setRevealedChapters((r) => Math.max(r, chapterIndex + 1))
-      chapterRefs.current[chapterIndex]?.scrollIntoView({ block: "start", behavior: "smooth" })
-    },
-    [flatItems]
-  )
+  }, [active])
 
   const goNext = useCallback(() => {
     setCursor((c) => Math.min(c + 1, flatItems.length - 1))
   }, [flatItems.length])
-  const goPrev = useCallback(() => {
-    setCursor((c) => Math.max(c - 1, 0))
-  }, [])
+  const goPrev = useCallback(() => setCursor((c) => Math.max(c - 1, 0)), [])
 
-  // Keyboard arrows drive the walkthrough while results are on screen.
   useEffect(() => {
-    if (phase !== "done" || !data || flatItems.length === 0) return
+    if (!active) return
     const onKey = (e: KeyboardEvent) => {
       const el = document.activeElement
       if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA")) return
+      if (openFile) return
       if (e.key === "ArrowRight") goNext()
       else if (e.key === "ArrowLeft") goPrev()
     }
     window.addEventListener("keydown", onKey)
     return () => window.removeEventListener("keydown", onKey)
-  }, [phase, data, flatItems.length, goNext, goPrev])
+  }, [active, openFile, goNext, goPrev])
+
+  // ── derived counts for the status strip ───────────────────────────
+  const counts = useMemo(() => {
+    if (!data) return null
+    let threats = 0
+    let warns = 0
+    let hygiene = 0
+    for (const ch of data.chapters) {
+      if (ch.kind === "security") {
+        for (const it of ch.items) {
+          if (it.severity === "critical" || it.severity === "high") threats++
+          else warns++
+        }
+      } else hygiene += ch.count
+    }
+    return { threats, warns, hygiene }
+  }, [data])
+
+  const visible = phase === "booting" || phase === "streaming" ? [...(phase === "booting" ? BOOT_LINES.slice(0, bootVisible) : []), ...streamLines] : streamLines
+  void visible
 
   return (
     <div className="relative flex h-full min-h-0 flex-col">
-      {/* audit input row */}
+      {/* input row */}
       <div className="flex shrink-0 items-center gap-2 border-b border-neutral-800 px-3 py-2">
         <span className="font-mono text-xs text-violet-400">audit ▸</span>
         <input
@@ -413,184 +418,234 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
           onKeyDown={(e) => e.key === "Enter" && void startAudit()}
           placeholder="https://github.com/org/repo"
           spellCheck={false}
-          autoCapitalize="off"
           autoComplete="off"
           className="min-w-0 flex-1 bg-transparent font-mono text-xs text-neutral-200 outline-none placeholder:text-neutral-700"
         />
+        {(phase === "booting" || phase === "streaming") && (
+          <button
+            onClick={skip}
+            className="rounded border border-neutral-800 px-2 py-0.5 font-mono text-[10px] text-neutral-500 hover:text-neutral-300"
+          >
+            skip ⏭
+          </button>
+        )}
         <button
           onClick={() => void startAudit()}
-          disabled={phase === "booting"}
-          className="rounded border border-neutral-700 px-2.5 py-0.5 font-mono text-[11px] text-neutral-300 hover:border-red-500 hover:text-red-400 disabled:cursor-not-allowed disabled:opacity-40"
+          disabled={phase === "booting" || phase === "streaming"}
+          className="shrink-0 rounded border border-neutral-700 px-2.5 py-0.5 font-mono text-[11px] text-neutral-300 hover:border-emerald-600 hover:text-emerald-400 disabled:cursor-not-allowed disabled:opacity-40"
         >
-          {phase === "booting" ? "scanning…" : "▶ audit"}
+          {phase === "booting" || phase === "streaming" ? "scanning…" : "▶ audit"}
         </button>
       </div>
 
-      {/* theater + chapters (left) | 3D fly-cam (right, large screens) */}
+      {/* THEATER: stream | focus | graph */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
-      <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-auto p-3 font-mono text-xs leading-relaxed">
-        {phase === "idle" && (
-          <p className="text-neutral-600">
-            Tekan <span className="text-red-400">▶ audit</span> — ARCLUX akan menjalankan detektor,
-            keamanan, dan attack surface secara berurutan di atas data nyata.
-          </p>
-        )}
-
-        {(phase !== "idle") &&
-          BOOT_LINES.slice(0, bootVisible).map((line, i) => (
-            <div key={i} className={i === BOOT_LINES.length - 1 ? "text-cyan-400/80" : "text-neutral-400"}>
-              {line.startsWith("✓") || line.includes("▸ mengindeks") ? line : line}
-              {i < bootVisible - 1 || phase === "done" ? "" : ""}
-            </div>
-          ))}
-
-        {phase === "booting" && (
-          <button
-            onClick={skip}
-            className="ml-auto block rounded border border-neutral-800 px-2 py-0.5 text-[10px] text-neutral-500 hover:text-neutral-300"
-          >
-            skip intro ⏭
-          </button>
-        )}
-
-        {phase === "done" && error && (
-          <div className="rounded border border-red-900/60 bg-red-950/30 px-2.5 py-1.5">
-            <span className="font-semibold text-red-400">✗ </span>
-            <span className="text-red-300/90">{error}</span>
+        {/* STREAM */}
+        <div className="flex w-full shrink-0 flex-col md:w-[42%]">
+          <div className="flex items-center justify-between border-b border-neutral-800/70 px-3 py-1.5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-600">
+              stream
+            </span>
+            <span className="font-mono text-[10px] tabular-nums text-neutral-600">
+              {phase === "streaming" ? `${streamProgress}%` : ""}
+            </span>
           </div>
-        )}
 
-        {phase === "done" && data && (
-          <>
-            <div className="text-emerald-400">{shownSummaryLine}</div>
+          <div
+            ref={scrollRef}
+            className="scanlines relative min-h-0 flex-1 overflow-hidden p-3 font-mono text-[11px] leading-[1.7]"
+          >
+            {phase === "idle" && (
+              <p className="text-neutral-600">
+                tekan <span className="text-emerald-500">▶ audit</span> — ARCLUX memindai
+                struktur, keamanan, dan permukaan serangan secara berurutan.
+              </p>
+            )}
 
-            {/* health bars */}
-            <div className="grid grid-cols-2 gap-2 pt-1 sm:grid-cols-4">
-              {data.categories.map((c) => (
-                <div key={c.id} className="rounded border border-neutral-800/80 bg-neutral-950/70 p-2">
-                  <div className="flex items-baseline justify-between gap-1">
-                    <span className="truncate text-[10px] uppercase tracking-wide text-neutral-500">
-                      {c.label}
-                    </span>
-                    <span className="text-sm font-semibold tabular-nums text-neutral-200">{c.score}</span>
-                  </div>
-                  <div className="mt-1 h-1 overflow-hidden rounded-full bg-neutral-800">
-                    <div
-                      className={`h-full rounded-full ${
-                        c.score >= 90 ? "bg-emerald-500" : c.score >= 70 ? "bg-yellow-500" : c.score >= 40 ? "bg-orange-500" : "bg-red-500"
-                      }`}
-                      style={{ width: `${c.score}%` }}
-                    />
-                  </div>
+            {phase === "booting" &&
+              BOOT_LINES.slice(0, bootVisible).map((l, i) => (
+                <div key={`b${i}`} className={TONE_CLASS[l.tone]}>
+                  {l.text}
                 </div>
               ))}
+
+            {streamLines.map((l, i) => (
+              <div key={i} className={TONE_CLASS[l.tone]}>
+                {l.text}
+              </div>
+            ))}
+
+            {(phase === "booting" || phase === "streaming") && (
+              <span className="inline-block h-3.5 w-2 animate-pulse bg-emerald-500 align-middle" />
+            )}
+
+            {phase === "done" && error && (
+              <div className="mt-2 rounded border border-red-900/60 bg-red-950/30 px-2.5 py-1.5">
+                <span className="font-semibold text-red-400">✗ </span>
+                <span className="text-red-300/90">{error}</span>
+              </div>
+            )}
+          </div>
+
+          {/* progress rail */}
+          {(phase === "streaming" || (phase === "done" && data)) && (
+            <div className="h-0.5 shrink-0 bg-neutral-900">
+              <div
+                className="h-full bg-emerald-500 transition-all duration-150"
+                style={{ width: `${phase === "done" ? 100 : streamProgress}%` }}
+              />
             </div>
+          )}
+        </div>
 
-            {/* chapters */}
-            {data.chapters.map((chapter, ci) =>
-              ci < revealedChapters ? (
-                <section
-                  key={chapter.id}
-                  ref={(el) => {
-                    chapterRefs.current[ci] = el
-                  }}
-                  className="scroll-mt-2 pt-1"
+        {/* FOCUS */}
+        <div className="hidden min-w-0 flex-1 flex-col border-l border-neutral-800/70 md:flex">
+          <div className="flex items-center justify-between border-b border-neutral-800/70 px-3 py-1.5">
+            <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-neutral-500">
+              focus
+            </span>
+            {flatItems.length > 0 && (
+              <span className="font-mono text-[10px] tabular-nums text-neutral-600">
+                {Math.max(cursor + 1, 0)} / {flatItems.length}
+              </span>
+            )}
+          </div>
+
+          {!active ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+              {phase === "done" && flatItems.length > 0 ? (
+                <>
+                  <p className="font-mono text-xs text-neutral-500">
+                    {flatItems.length} temuan menunggu
+                  </p>
+                  <button
+                    onClick={() => setCursor(0)}
+                    className="rounded border border-emerald-700 px-4 py-1.5 font-mono text-xs text-emerald-400 hover:bg-emerald-950/40"
+                  >
+                    ▶ mulai walkthrough
+                  </button>
+                </>
+              ) : (
+                <p className="font-mono text-xs text-neutral-700">
+                  {phase === "done" ? "bersih — nol temuan 🎯" : "menunggu hasil…"}
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1 flex-col p-4">
+              {/* severity banner */}
+              <div
+                className={`mb-3 rounded border px-3 py-2 ${
+                  active.severity === "critical"
+                    ? "border-red-600/60 bg-red-950/40"
+                    : active.severity === "high" || active.severity === "error"
+                      ? "border-orange-600/50 bg-orange-950/30"
+                      : active.severity === "medium" || active.severity === "warning"
+                        ? "border-yellow-600/40 bg-yellow-950/20"
+                        : "border-neutral-700/60 bg-neutral-900/40"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-[11px] font-bold uppercase tracking-[0.25em] text-neutral-100">
+                    {active.severity}
+                  </span>
+                  <code className="font-mono text-[11px] text-neutral-400">
+                    {active.source === "security" ? active.ruleId : active.checkId}
+                  </code>
+                  {active.cwe && active.cwe.length > 0 && (
+                    <code className="ml-auto hidden font-mono text-[10px] text-neutral-600 sm:block">
+                      {active.cwe.join(" · ")}
+                    </code>
+                  )}
+                </div>
+              </div>
+
+              <p className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap font-mono text-sm leading-relaxed text-neutral-200">
+                {active.source === "security"
+                  ? (active.description ?? active.title ?? "")
+                  : active.message}
+              </p>
+
+              {(active.location?.filePath || active.filePath) && (
+                <code className="mt-3 truncate font-mono text-xs text-neutral-500">
+                  ↳ {active.location?.filePath ?? active.filePath}
+                  {active.location?.line !== undefined && `:${active.location.line}`}
+                </code>
+              )}
+
+              <div className="mt-3 flex items-center gap-2 border-t border-neutral-800 pt-3">
+                <button
+                  onClick={goPrev}
+                  disabled={cursor <= 0}
+                  className="rounded border border-neutral-700 px-2.5 py-1 font-mono text-[11px] text-neutral-300 hover:border-neutral-500 disabled:opacity-30"
                 >
-                  <h3 className="mb-1.5 flex items-baseline gap-2">
-                    <span className="text-neutral-600">──</span>
-                    <span
-                      className={
-                        chapter.kind === "security"
-                          ? "font-semibold tracking-wide text-red-400"
-                          : "font-semibold tracking-wide text-yellow-400"
-                      }
-                    >
-                      BAB {ci + 1} ▸ {chapter.label.toUpperCase()}
-                    </span>
-                    <span className="text-neutral-600">({chapter.count})</span>
-                    <span className="flex-1 border-t border-dashed border-neutral-800" />
-                  </h3>
-                  <ul className="space-y-1.5 pl-2">
-                    {chapter.items.map((item, i) => (
-                      <FindingRow
-                        key={`${chapter.id}-${i}`}
-                        item={item}
-                        onOpenFile={(path, line) => setOpenFile({ path, line })}
-                      />
-                    ))}
-                  </ul>
-                </section>
-              ) : null
-            )}
+                  ‹ prev
+                </button>
+                {(active.location?.filePath || active.filePath) && (
+                  <button
+                    onClick={() =>
+                      setOpenFile({
+                        path: (active.location?.filePath ?? active.filePath) as string,
+                        line: active.location?.line,
+                      })
+                    }
+                    className="rounded border border-blue-800 px-2.5 py-1 font-mono text-[11px] text-blue-400 hover:bg-blue-950/40"
+                  >
+                    lihat file ↗
+                  </button>
+                )}
+                <button
+                  onClick={goNext}
+                  disabled={cursor >= flatItems.length - 1}
+                  className="ml-auto rounded border border-emerald-700 px-3 py-1 font-mono text-[11px] text-emerald-400 hover:bg-emerald-950/40 disabled:opacity-30"
+                >
+                  next ▶
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
 
-            {data.chapters.length === 0 && revealedChapters > 0 && (
-              <div className="text-emerald-400">✓ Bersih — tidak ada temuan di semua kategori.</div>
-            )}
-          </>
+        {/* GRAPH (xl+) */}
+        {data && active && (
+          <div className="hidden min-h-0 w-[26%] shrink-0 border-l border-neutral-800/70 xl:flex xl:flex-col">
+            <div className="border-b border-neutral-800/70 px-3 py-1.5">
+              <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-neutral-500">
+                graph
+              </span>
+            </div>
+            <div className="min-h-0 flex-1">
+              <AuditGraphPane repoUrl={repoInput.trim()} branch={branch} target={focusTarget} />
+            </div>
+          </div>
         )}
       </div>
 
-        {openFile && (
-          <FilePreviewOverlay
-            target={openFile}
-            repoUrl={repoInput.trim()}
-            branch={branch}
-            onClose={() => setOpenFile(null)}
-          />
-        )}
+      {openFile && (
+        <FilePreviewOverlay
+          target={openFile}
+          repoUrl={repoInput.trim()}
+          branch={branch}
+          onClose={() => setOpenFile(null)}
+        />
+      )}
 
-        {/* walkthrough navigator + 3D pane (lg+) */}
-        {phase === "done" && data && flatItems.length > 0 && (
-          <div className="hidden w-[42%] shrink-0 flex-col border-l border-neutral-800 lg:flex">
-            {/* chapter jump sidebar */}
-            <div className="max-h-[30%] shrink-0 overflow-auto border-b border-neutral-800 p-2">
-              <p className="mb-1 px-1 font-mono text-[10px] uppercase tracking-wide text-neutral-600">
-                bab · {data.chapters.length}
-              </p>
-              <ul className="space-y-0.5">
-                {data.chapters.map((ch, ci) => (
-                  <li key={ch.id}>
-                    <button
-                      onClick={() => jumpToChapter(ci)}
-                      className={`flex w-full items-baseline gap-2 rounded px-2 py-1 text-left font-mono text-[11px] transition-colors ${
-                        activeItem?.chapterIndex === ci
-                          ? "bg-neutral-800 text-white"
-                          : "text-neutral-400 hover:bg-neutral-900 hover:text-neutral-200"
-                      }`}
-                    >
-                      <span className="text-neutral-600">{ci + 1}.</span>
-                      <span className="truncate">{ch.label}</span>
-                      <span className="ml-auto tabular-nums text-neutral-600">{ch.count}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-            <AuditGraphPane repoUrl={repoInput.trim()} branch={branch} target={focusTarget} />
-            <div className="flex shrink-0 items-center gap-2 border-t border-neutral-800 px-3 py-2">
-              <button
-                onClick={goPrev}
-                disabled={cursor <= 0}
-                className="rounded border border-neutral-700 px-2 py-0.5 font-mono text-[11px] text-neutral-300 hover:border-blue-500 disabled:opacity-30"
-              >
-                ‹ prev
-              </button>
-              <span className="font-mono text-[11px] tabular-nums text-neutral-500">
-                {cursor + 1} / {flatItems.length}
-              </span>
-              <button
-                onClick={goNext}
-                disabled={cursor >= flatItems.length - 1}
-                className="rounded border border-neutral-700 px-2 py-0.5 font-mono text-[11px] text-neutral-300 hover:border-blue-500 disabled:opacity-30"
-              >
-                next ›
-              </button>
-              <span className="ml-auto hidden font-mono text-[10px] text-neutral-600 xl:inline">
-                ←/→ navigate
-              </span>
-            </div>
-          </div>
+      {/* audit status strip */}
+      <div className="flex shrink-0 items-center justify-between border-t border-neutral-800 bg-black/60 px-3 py-1.5 font-mono text-[10px]">
+        {counts ? (
+          <span className="flex gap-3">
+            <span className="text-red-500">THREATS {counts.threats}</span>
+            <span className="text-yellow-500">WARN {counts.warns}</span>
+            <span className="text-neutral-500">HYGIENE {counts.hygiene}</span>
+            {data && <span className="text-emerald-500">HEALTH {data.overallHealth}</span>}
+          </span>
+        ) : (
+          <span className="text-neutral-600">audit</span>
         )}
+        <span className="hidden gap-3 text-neutral-600 sm:flex">
+          <span><span className="text-neutral-400">←/→</span> navigate</span>
+          <span><span className="text-neutral-400">esc</span> close</span>
+        </span>
       </div>
     </div>
   )


### PR DESCRIPTION
Rombak total mode audit sesuai kritik: *'gaada nuansa hacker'* + *'muncul per bab bikin cape scroll'*.

**SEBELUM**: log panjang numpuk 1905 baris di transkrip 💀
**SESUDAH**: tiga zona —

**▶ ALIRAN (kiri)** — pertunjukannya
- Skrip pindai dibangun dari **hasil nyata**: `analyze(...) → 820 modul`, sweep per kategori, `rule(file:line) [sev]` berkode warna
- Reveal 55ms/baris + kursor blok berkedip + rel progres %
- Batas 24/chapter → sisanya ditunjuk ke FOCUS (`… +N more`)
- Baris boot jadi gaya `init.parsers[27] → ok`

◎ FOKUS (tengah) — **satu temuan per layar**
- Banner tingkat keparahan besar, pesan apa adanya, file:line
- ‹ prev · k/N · next › + ←/→ · lihat file ↗ tetap ada

▦ GRAFIK (kanan, xl+) — terbang-layar mengikuti navigasi

Strip bawah: THREATS · WARN · HYGIENE · HEALTH counter.

Nol detector baru — murni koreografi di atas data yang sama.