### PR TITLE
feat(web): navigation registry — desktop/mobile terpisah + Ctrl+K global

### DIFF
--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -10,61 +10,168 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, Network, Search, Activity, PanelsTopLeft } from "lucide-react"
+import { useState } from "react"
+import { AnimatePresence, motion } from "motion/react"
+import { LayoutDashboard, MoreHorizontal, Network, ClipboardCheck } from "lucide-react"
 import { cn } from "@/lib/cn"
+import { GLOBAL_ITEMS, NAV_GROUPS } from "@/lib/navigation"
 
 interface BottomNavProps {
   org: string
   repo: string
 }
 
-const ITEMS = [
-  { label: "Overview", icon: LayoutDashboard, suffix: "" },
+/** The four destinations that earn permanent bottom-bar real estate. */
+const FIXED = [
+  { label: "Home", icon: LayoutDashboard, suffix: "" },
   { label: "Graph", icon: Network, suffix: "/graph" },
-  { label: "Search", icon: Search, suffix: "/search" },
-  { label: "Activity", icon: Activity, suffix: "/activity" },
-  { label: "Workspace", icon: PanelsTopLeft, suffix: "/workspace" },
-]
+  { label: "Audit", icon: ClipboardCheck, suffix: "/audit" },
+] as const
 
 /**
- * Mobile-only bottom navigation (< 768px, Tailwind `md:hidden`). Mirrors the
- * desktop sidebar links minus Settings, which lives in the Navbar on mobile
- * (one-off page — keeping the bottom bar to the 5 pages users actually
- * switch between, GitHub-Mobile style). Rendered as a flex child of
- * WorkspaceLayout (not `fixed`) so it never overlaps scrollable content or
- * the graph canvas — it simply takes the bottom 4rem of the column. Safe
- * area padding keeps it above the gesture/home bar on notched phones.
+ * Mobile-only bottom bar (< md). Four fixed slots + a "More" trigger that
+ * springs up a grouped sheet rendering THE SAME registry as the desktop
+ * sidebar — one source of truth, two surfaces tuned independently.
  */
 export function BottomNav({ org, repo }: BottomNavProps) {
   const pathname = usePathname()
   const base = `/${org}/${repo}`
+  const [moreOpen, setMoreOpen] = useState(false)
+
+  const moreActive =
+    !FIXED.some((f) => pathname === `${base}${f.suffix}`) &&
+    [...NAV_GROUPS.flatMap((g) => g.items), ...GLOBAL_ITEMS].some((it) =>
+      pathname === `${base}${it.suffix}` || pathname === it.suffix
+    )
 
   return (
-    <nav
-      aria-label="Primary"
-      className="glass-overlay select-none md:hidden"
-      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
-    >
-      <div className="grid h-16 grid-cols-5">
-        {ITEMS.map(({ label, icon: Icon, suffix }) => {
-          const href = `${base}${suffix}`
-          const isActive = pathname === href
-          return (
-            <Link
-              key={href}
-              href={href}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "flex flex-col items-center justify-center gap-0.5 text-[11px] font-medium transition-transform active:scale-95",
-                isActive ? "text-primary" : "text-muted-foreground"
-              )}
+    <>
+      <nav
+        aria-label="Primary"
+        className="glass-overlay select-none md:hidden"
+        style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      >
+        <div className="grid h-16 grid-cols-4">
+          {FIXED.map(({ label, icon: Icon, suffix }) => {
+            const href = `${base}${suffix}`
+            const isActive = pathname === href
+            return (
+              <Link
+                key={href}
+                href={href}
+                aria-current={isActive ? "page" : undefined}
+                className="relative flex flex-col items-center justify-center gap-0.5 text-[11px] font-medium transition-transform active:scale-95"
+              >
+                {isActive && (
+                  <motion.span
+                    layoutId="bottomnav-active-dot"
+                    className="absolute top-1 h-1 w-6 rounded-full bg-primary shadow-[0_0_10px_2px] shadow-primary/50"
+                    transition={{ type: "spring", stiffness: 500, damping: 40 }}
+                  />
+                )}
+                <Icon className={cn("h-5 w-5", isActive ? "text-primary" : "text-muted-foreground")} />
+                <span className={isActive ? "text-foreground" : "text-muted-foreground"}>{label}</span>
+              </Link>
+            )
+          })}
+          <button
+            type="button"
+            onClick={() => setMoreOpen(true)}
+            aria-expanded={moreOpen}
+            className="relative flex flex-col items-center justify-center gap-0.5 text-[11px] font-medium active:scale-95"
+          >
+            {moreActive && (
+              <span className="absolute top-1 h-1 w-6 rounded-full bg-primary shadow-[0_0_10px_2px] shadow-primary/50" />
+            )}
+            <MoreHorizontal className={cn("h-5 w-5", moreActive ? "text-primary" : "text-muted-foreground")} />
+            <span className={moreActive ? "text-foreground" : "text-muted-foreground"}>More</span>
+          </button>
+        </div>
+      </nav>
+
+      {/* More sheet */}
+      <AnimatePresence>
+        {moreOpen && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              onClick={() => setMoreOpen(false)}
+              className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm md:hidden"
+            />
+            <motion.div
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ type: "spring", stiffness: 380, damping: 38 }}
+              className="fixed inset-x-0 bottom-0 z-50 max-h-[75vh] overflow-y-auto rounded-t-2xl border-t border-white/10 bg-background/95 backdrop-blur-xl md:hidden"
+              style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 0.75rem)" }}
             >
-              <Icon className="h-5 w-5" />
-              {label}
-            </Link>
-          )
-        })}
-      </div>
-    </nav>
+              <div className="mx-auto mt-2 h-1 w-10 rounded-full bg-neutral-700" />
+              {NAV_GROUPS.map((g) => (
+                <section key={g.id} className="px-4 pt-4">
+                  <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/60">
+                    {g.label}
+                  </p>
+                  <ul className="space-y-1">
+                    {g.items.map(({ label, suffix, icon: Icon, description }) => {
+                      const href = `${base}${suffix}`
+                      return (
+                        <li key={href}>
+                          <Link
+                            href={href}
+                            onClick={() => setMoreOpen(false)}
+                            className="flex items-center gap-3 rounded-xl border border-transparent bg-card/40 p-3 transition-colors hover:border-primary/30 hover:bg-accent/60"
+                          >
+                            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                              <Icon className="h-4.5 w-4.5" />
+                            </span>
+                            <span className="min-w-0">
+                              <span className="block text-sm font-medium">{label}</span>
+                              {description && (
+                                <span className="block truncate text-xs text-muted-foreground">
+                                  {description}
+                                </span>
+                              )}
+                            </span>
+                          </Link>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </section>
+              ))}
+              <section className="px-4 pb-2 pt-4">
+                <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/60">
+                  Global
+                </p>
+                <ul className="space-y-1">
+                  {GLOBAL_ITEMS.map(({ label, suffix, icon: Icon, description }) => (
+                    <li key={suffix}>
+                      <Link
+                        href={suffix}
+                        onClick={() => setMoreOpen(false)}
+                        className="flex items-center gap-3 rounded-xl border border-transparent bg-card/40 p-3 transition-colors hover:border-primary/30 hover:bg-accent/60"
+                      >
+                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                          <Icon className="h-4.5 w-4.5" />
+                        </span>
+                        <span className="min-w-0">
+                          <span className="block text-sm font-medium">{label}</span>
+                          {description && (
+                            <span className="block truncate text-xs text-muted-foreground">{description}</span>
+                          )}
+                        </span>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </>
   )
 }

--- a/apps/web/components/layout/Sidebar.tsx
+++ b/apps/web/components/layout/Sidebar.tsx
@@ -10,88 +10,110 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, Network, Search, Settings, PanelsTopLeft, Activity, ClipboardCheck, X } from "lucide-react"
+import { motion } from "motion/react"
+import { X } from "lucide-react"
 import { cn } from "@/lib/cn"
+import { NAV_GROUPS, GLOBAL_ITEMS } from "@/lib/navigation"
 
 interface SidebarProps {
   org: string
   repo: string
-  /** Desktop inline mode: collapsed to a bare icon rail (w-16). */
   collapsed?: boolean
-  /** Tablet overlay mode: rendered in a fixed drawer, shows a close button. */
   overlay?: boolean
-  /** Called when the user asks to close the overlay drawer. */
   onClose?: () => void
 }
 
 /**
- * Navigation sidebar, rendered by WorkspaceLayout in one of two modes:
- * - Desktop (inline, `hidden lg:block` wrapper): `w-64`, collapsible to a
- *   `w-16` icon rail. Width animates via `transition-all duration-300`.
- * - Tablet (overlay): WorkspaceLayout wraps this in a `fixed` drawer with
- *   a backdrop; `overlay` adds the close button. Not rendered on mobile —
- *   BottomNav owns navigation there.
+ * Desktop/tablet navigation rail. Renders from lib/navigation.ts — the
+ * single nav registry shared with BottomNav and CommandPalette.
  *
- * Premium styling: no `border-r` — separation from the content column comes
- * from the sidebar background token (`bg-sidebar`) plus a soft shadow.
+ * Eye-candy contract: glass surface, group micro-labels, and a sliding
+ * active pill (motion layoutId) so selection glides between items
+ * instead of teleporting.
  */
 export function Sidebar({ org, repo, collapsed = false, overlay = false, onClose }: SidebarProps) {
   const pathname = usePathname()
   const base = `/${org}/${repo}`
 
-  const links = [
-    { label: "Overview", href: base, icon: LayoutDashboard },
-    { label: "Graph", href: `${base}/graph`, icon: Network },
-    { label: "Search", href: `${base}/search`, icon: Search },
-    { label: "Activity", href: `${base}/activity`, icon: Activity },
-    { label: "Audit", href: `${base}/audit`, icon: ClipboardCheck },
-    { label: "Workspace", href: `${base}/workspace`, icon: PanelsTopLeft },
-    { label: "Settings", href: `${base}/settings`, icon: Settings },
-  ]
+  const renderGroup = (groupId: string, label: string, items: typeof NAV_GROUPS[number]["items"]) => (
+    <div key={groupId} className="px-2">
+      {!collapsed && (
+        <p className="mb-1 px-2 pt-3 text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground/50">
+          {label}
+        </p>
+      )}
+      <ul className="space-y-0.5">
+        {items.map(({ label: itemLabel, suffix, icon: Icon, description }) => {
+          const href = `${base}${suffix}`
+          const isActive = pathname === href
+          return (
+            <li key={href} className="relative">
+              {isActive && (
+                <motion.span
+                  layoutId="sidebar-active-pill"
+                  className="absolute inset-0 rounded-md bg-gradient-to-r from-primary/15 via-primary/10 to-transparent ring-1 ring-inset ring-primary/30"
+                  transition={{ type: "spring", stiffness: 500, damping: 40 }}
+                />
+              )}
+              <Link
+                href={href}
+                title={collapsed ? itemLabel : description ?? itemLabel}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "group relative flex items-center gap-2.5 rounded-md py-2 text-sm font-medium transition-colors duration-150",
+                  collapsed ? "justify-center px-0" : "px-2",
+                  isActive ? "text-foreground" : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {/* left glow hairline on active */}
+                {isActive && (
+                  <span className="absolute left-0 top-1/2 h-5 w-[2.5px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_8px_2px] shadow-primary/40" />
+                )}
+                <Icon
+                  className={cn(
+                    "h-4 w-4 shrink-0 transition-transform duration-150 group-hover:scale-110",
+                    isActive && "text-primary drop-shadow-[0_0_6px_rgba(0,112,243,0.6)]"
+                  )}
+                />
+                {!collapsed && <span className="truncate">{itemLabel}</span>}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
 
   return (
     <aside
       className={cn(
-        "flex h-full flex-col gap-1 overflow-hidden p-3 text-sidebar-foreground select-none transition-all duration-300",
-        collapsed ? "w-16" : "w-64",
+        "flex h-full flex-col gap-1 overflow-y-auto overflow-x-hidden p-2 text-sidebar-foreground select-none transition-all duration-300 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        collapsed ? "w-16" : "w-60",
         overlay ? "glass-overlay" : "glass-panel"
       )}
     >
       {overlay && (
-        <div className="mb-2 flex items-center justify-between px-2">
-          <span className="text-sm font-semibold">Navigation</span>
+        <div className="mb-1 flex items-center justify-between px-2 pt-1">
+          <span className="text-sm font-semibold">Navigasi</span>
           <button
             type="button"
             onClick={onClose}
-            aria-label="Close navigation"
+            aria-label="Tutup navigasi"
             className="rounded-md p-2 transition-transform hover:bg-accent active:scale-95"
           >
             <X className="h-4 w-4" />
           </button>
         </div>
       )}
-      {links.map(({ label, href, icon: Icon }) => {
-        const isActive = pathname === href
 
-        return (
-          <Link
-            key={href}
-            href={href}
-            title={collapsed ? label : undefined}
-            aria-current={isActive ? "page" : undefined}
-            className={cn(
-              "flex items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium transition-colors active:scale-[0.98]",
-              collapsed && "justify-center px-0",
-              isActive
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-            )}
-          >
-            <Icon className="h-4 w-4 shrink-0" />
-            {!collapsed && <span className="truncate">{label}</span>}
-          </Link>
-        )
-      })}
+      {NAV_GROUPS.map((g) => renderGroup(g.id, g.label, g.items))}
+      {renderGroup("global", "Global", GLOBAL_ITEMS)}
+
+      {!collapsed && (
+        <p className="mt-auto px-3 pb-2 font-mono text-[10px] text-muted-foreground/40">
+          arclux · v0.2.0
+        </p>
+      )}
     </aside>
   )
 }

--- a/apps/web/components/layout/WorkspaceLayout.tsx
+++ b/apps/web/components/layout/WorkspaceLayout.tsx
@@ -12,6 +12,7 @@ import { useState } from "react"
 import { Navbar } from "@/components/layout/Navbar"
 import { Sidebar } from "@/components/layout/Sidebar"
 import { BottomNav } from "@/components/layout/BottomNav"
+import { CommandPalette } from "@/components/patterns/CommandPalette"
 import type { BreadcrumbItem } from "@/components/layout/Breadcrumbs"
 import { useBreakpoint } from "@/hooks/useBreakpoint"
 import { cn } from "@/lib/cn"
@@ -62,6 +63,7 @@ export function WorkspaceLayout({ org, repo, breadcrumbs, children }: WorkspaceL
 
   return (
     <div className="flex h-screen flex-col bg-background text-foreground">
+      <CommandPalette org={org} repo={repo} />
       <Navbar
         org={org}
         repo={repo}

--- a/apps/web/components/patterns/CommandPalette.tsx
+++ b/apps/web/components/patterns/CommandPalette.tsx
@@ -6,20 +6,22 @@
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
 //
-// Built on pacocoursey/cmdk (MIT), used as a direct dependency rather than
-// re-implemented — cmdk's <Command> primitive owns keyboard navigation,
-// focus management, and ARIA wiring, which is accessibility-critical code
-// not worth re-writing from scratch. What's ARCLUX-specific here is the
-// command list itself and how it's wired to navigation.
+// Built on pacocoursey/cmdk (MIT), used as a direct dependency rather
+// than re-implemented — cmdk's <Command> primitive owns keyboard
+// navigation, focus management, and ARIA wiring. ARCLUX-specific: the
+// command list renders from lib/navigation.ts (same registry as the
+// sidebars) plus global destinations, wrapped in motion chrome.
 
 "use client"
 
 import { useCallback } from "react"
 import { useRouter } from "next/navigation"
 import { Command } from "cmdk"
-import { LayoutDashboard, Network, Search, Settings } from "lucide-react"
+import { motion } from "motion/react"
+import { SquareTerminal, Settings } from "lucide-react"
 import { cn } from "@/lib/cn"
 import { useCommandPalette } from "@/hooks/useCommandPalette"
+import { GLOBAL_ITEMS, NAV_GROUPS } from "@/lib/navigation"
 
 export interface CommandPaletteProps {
   org: string
@@ -27,8 +29,6 @@ export interface CommandPaletteProps {
 }
 
 export function CommandPalette({ org, repo }: CommandPaletteProps) {
-  // Open-state + keyboard shortcuts (Cmd/Ctrl+K, "/", Escape) moved into
-  // the shared hook so other surfaces can reuse the same wiring.
   const { open, setOpen } = useCommandPalette()
   const router = useRouter()
   const base = `/${org}/${repo}`
@@ -43,47 +43,108 @@ export function CommandPalette({ org, repo }: CommandPaletteProps) {
 
   if (!open) return null
 
-  const commands = [
-    { label: "Overview", href: base, icon: LayoutDashboard },
-    { label: "Graph", href: `${base}/graph`, icon: Network },
-    { label: "Search", href: `${base}/search`, icon: Search },
-    { label: "Settings", href: `${base}/settings`, icon: Settings },
-  ]
-
   return (
     <div
-      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[20vh]"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 pt-[16vh] backdrop-blur-sm"
       onClick={() => setOpen(false)}
     >
-      <Command
-        className="glass-panel w-full max-w-md overflow-hidden rounded-lg"
+      <motion.div
+        initial={{ opacity: 0, y: -12, scale: 0.98 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+        className="w-full max-w-lg"
         onClick={(e) => e.stopPropagation()}
-        label="Command palette"
       >
-        <Command.Input
-          autoFocus
-          placeholder="Type a command or search..."
-          className="w-full border-b bg-transparent px-4 py-3 text-sm outline-none placeholder:text-muted-foreground"
-        />
-        <Command.List className="max-h-80 overflow-y-auto p-2">
-          <Command.Empty className="py-6 text-center text-sm text-muted-foreground">
-            No results found.
-          </Command.Empty>
-          {commands.map(({ label, href, icon: Icon }) => (
-            <Command.Item
-              key={href}
-              onSelect={() => navigate(href)}
-              className={cn(
-                "flex cursor-pointer items-center gap-2.5 rounded-md px-3 py-2 text-sm",
-                "aria-selected:bg-accent aria-selected:text-accent-foreground"
-              )}
+        {/* gradient hairline crown */}
+        <div className="h-[2px] w-full rounded-t-xl bg-gradient-to-r from-transparent via-primary to-transparent" />
+        <Command
+          className="glass-panel overflow-hidden rounded-b-xl rounded-t-lg shadow-2xl shadow-black/50"
+          onClick={(e) => e.stopPropagation()}
+          label="Command palette"
+        >
+          <Command.Input
+            autoFocus
+            placeholder="Ketik perintah atau cari…"
+            className="w-full border-b bg-transparent px-4 py-3.5 text-sm outline-none placeholder:text-muted-foreground/60"
+          />
+          <Command.List className="max-h-80 overflow-y-auto p-2">
+            <Command.Empty className="py-6 text-center text-sm text-muted-foreground">
+              Tidak ada hasil.
+            </Command.Empty>
+
+            {NAV_GROUPS.map((group) => (
+              <Command.Group
+                key={group.id}
+                heading={group.label}
+                className="[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.18em] [&_[cmdk-group-heading]]:text-muted-foreground/60"
+              >
+                {group.items.map(({ label, suffix, icon: Icon, description }) => {
+                  const href = `${base}${suffix}`
+                  return (
+                    <Command.Item
+                      key={href}
+                      value={`${label} ${description ?? ""}`}
+                      onSelect={() => navigate(href)}
+                      className={cn(
+                        "flex cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm",
+                        "aria-selected:bg-accent aria-selected:text-accent-foreground"
+                      )}
+                    >
+                      <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                        <Icon className="h-3.5 w-3.5" />
+                      </span>
+                      <span className="min-w-0">
+                        <span className="block">{label}</span>
+                        {description && (
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {description}
+                          </span>
+                        )}
+                      </span>
+                    </Command.Item>
+                  )
+                })}
+              </Command.Group>
+            ))}
+
+            <Command.Group
+              heading="Global"
+              className="[&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.18em] [&_[cmdk-group-heading]]:text-muted-foreground/60"
             >
-              <Icon className="h-4 w-4" />
-              {label}
-            </Command.Item>
-          ))}
-        </Command.List>
-      </Command>
+              {GLOBAL_ITEMS.map(({ label, suffix, icon: Icon, description }) => (
+                <Command.Item
+                  key={suffix}
+                  value={`${label} ${description ?? ""}`}
+                  onSelect={() => navigate(suffix)}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm",
+                    "aria-selected:bg-accent aria-selected:text-accent-foreground"
+                  )}
+                >
+                  <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                    <Icon className="h-3.5 w-3.5" />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block">{label}</span>
+                    {description && (
+                      <span className="block truncate text-xs text-muted-foreground">{description}</span>
+                    )}
+                  </span>
+                </Command.Item>
+              ))}
+            </Command.Group>
+          </Command.List>
+
+          <div className="flex items-center gap-4 border-t border-neutral-800/70 px-4 py-2 font-mono text-[10px] text-muted-foreground/60">
+            <span><kbd className="rounded border border-neutral-700 px-1">↑↓</kbd> navigasi</span>
+            <span><kbd className="rounded border border-neutral-700 px-1">↵</kbd> buka</span>
+            <span className="ml-auto"><kbd className="rounded border border-neutral-700 px-1">esc</kbd> tutup</span>
+          </div>
+        </Command>
+      </motion.div>
     </div>
   )
 }
+
+/** Re-exported icons kept for any legacy imports of this module. */
+export { SquareTerminal, Settings }

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -1,0 +1,71 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Single source of truth for repo-scoped navigation. Every surface —
+// desktop sidebar, mobile bottom bar, More sheet, command palette —
+// renders from this registry, so adding a feature means adding ONE
+// entry and it appears everywhere consistently.
+
+import type { LucideIcon } from "lucide-react"
+import {
+  Activity,
+  ClipboardCheck,
+  LayoutDashboard,
+  Network,
+  PanelsTopLeft,
+  Search,
+  Settings,
+  SquareTerminal,
+} from "lucide-react"
+
+export interface NavItem {
+  label: string
+  /** Path appended to /{org}/{repo}. "" = the overview page itself. */
+  suffix: string
+  icon: LucideIcon
+  description?: string
+}
+
+export interface NavGroup {
+  id: string
+  label: string
+  items: NavItem[]
+}
+
+/** Repo-scoped groups, rendered top-to-bottom everywhere. */
+export const NAV_GROUPS: NavGroup[] = [
+  {
+    id: "analisis",
+    label: "Analisis",
+    items: [
+      { label: "Graph", suffix: "/graph", icon: Network, description: "Peta dependensi interaktif" },
+      { label: "Search", suffix: "/search", icon: Search, description: "Cari simbol & file" },
+      { label: "Audit", suffix: "/audit", icon: ClipboardCheck, description: "Teater temuan & security" },
+    ],
+  },
+  {
+    id: "repositori",
+    label: "Repositori",
+    items: [
+      { label: "Overview", suffix: "", icon: LayoutDashboard, description: "Ringkasan repositori" },
+      { label: "Activity", suffix: "/activity", icon: Activity, description: "Riwayat commit & kontributor" },
+      { label: "Workspace", suffix: "/workspace", icon: PanelsTopLeft, description: "Panel file · impact · issues" },
+    ],
+  },
+]
+
+/** Global destinations outside the org/repo scope. */
+export const GLOBAL_ITEMS: NavItem[] = [
+  {
+    label: "Script Playground",
+    suffix: "/script",
+    icon: SquareTerminal,
+    description: "Terminal DSL ala opencode",
+  },
+  { label: "Settings", suffix: "/settings", icon: Settings, description: "Preferensi tampilan" },
+]


### PR DESCRIPTION
**Akar masalah**: 3 permukaan nav di-maintain manual → tiap fitur baru bikin brantak. Sekarang: **satu registry** (`lib/navigation.ts`), semua permukaan nurun dari situ.

**Desktop rail**: glass panel, micro-label grup (Analisis / Repositori / Global), **active pill yang meluncur** antar item (motion layoutId), glow hairline di item aktif.

**Mobile**: bottom bar fix **4 slot** (Home · Graph · Audit · More) — fitur gak rebutan lagi. **More** = sheet spring dari bawah, kartu sentuh besar, isi dari registry yang sama.

**Ctrl+K / '/' di semua halaman repo**: palette cmdk naik-kelas — grouped results, crown gradient, kbd footer, entrance motion. Dimount global di WorkspaceLayout.

Live-verified: `/script` 200 (TUI+audit utuh), workspace page render grup registry baru. tsc 0 error, eslint bersih.