### PR TITLE
feat(web): indikator pending di semua navigasi

### DIFF
--- a/apps/web/components/layout/BottomNav.tsx
+++ b/apps/web/components/layout/BottomNav.tsx
@@ -8,13 +8,13 @@
 
 "use client"
 
-import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useState } from "react"
 import { AnimatePresence, motion } from "motion/react"
 import { LayoutDashboard, MoreHorizontal, Network, ClipboardCheck } from "lucide-react"
 import { cn } from "@/lib/cn"
 import { GLOBAL_ITEMS, NAV_GROUPS } from "@/lib/navigation"
+import { NavLink, PendingSwap } from "@/components/layout/NavLink"
 
 interface BottomNavProps {
   org: string
@@ -56,7 +56,7 @@ export function BottomNav({ org, repo }: BottomNavProps) {
             const href = `${base}${suffix}`
             const isActive = pathname === href
             return (
-              <Link
+              <NavLink
                 key={href}
                 href={href}
                 aria-current={isActive ? "page" : undefined}
@@ -69,9 +69,13 @@ export function BottomNav({ org, repo }: BottomNavProps) {
                     transition={{ type: "spring", stiffness: 500, damping: 40 }}
                   />
                 )}
-                <Icon className={cn("h-5 w-5", isActive ? "text-primary" : "text-muted-foreground")} />
+                <PendingSwap
+                  icon={Icon}
+                  spinClassName="h-5 w-5"
+                  className={cn("h-5 w-5", isActive ? "text-primary" : "text-muted-foreground")}
+                />
                 <span className={isActive ? "text-foreground" : "text-muted-foreground"}>{label}</span>
-              </Link>
+              </NavLink>
             )
           })}
           <button
@@ -119,13 +123,13 @@ export function BottomNav({ org, repo }: BottomNavProps) {
                       const href = `${base}${suffix}`
                       return (
                         <li key={href}>
-                          <Link
+                          <NavLink
                             href={href}
                             onClick={() => setMoreOpen(false)}
-                            className="flex items-center gap-3 rounded-xl border border-transparent bg-card/40 p-3 transition-colors hover:border-primary/30 hover:bg-accent/60"
+                            className="flex items-center gap-3 rounded-xl border border-transparent bg-card/40 p-3 opacity-80 transition-opacity hover:opacity-100 hover:border-primary/30 hover:bg-accent/60"
                           >
                             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                              <Icon className="h-4.5 w-4.5" />
+                              <PendingSwap icon={Icon} className="h-4.5 w-4.5" />
                             </span>
                             <span className="min-w-0">
                               <span className="block text-sm font-medium">{label}</span>
@@ -135,7 +139,7 @@ export function BottomNav({ org, repo }: BottomNavProps) {
                                 </span>
                               )}
                             </span>
-                          </Link>
+                          </NavLink>
                         </li>
                       )
                     })}
@@ -149,13 +153,13 @@ export function BottomNav({ org, repo }: BottomNavProps) {
                 <ul className="space-y-1">
                   {GLOBAL_ITEMS.map(({ label, suffix, icon: Icon, description }) => (
                     <li key={suffix}>
-                      <Link
+                      <NavLink
                         href={suffix}
                         onClick={() => setMoreOpen(false)}
-                        className="flex items-center gap-3 rounded-xl border border-transparent bg-card/40 p-3 transition-colors hover:border-primary/30 hover:bg-accent/60"
+                        className="flex items-center gap-3 rounded-xl border border-transparent bg-card/40 p-3 opacity-80 transition-opacity hover:opacity-100 hover:border-primary/30 hover:bg-accent/60"
                       >
                         <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                          <Icon className="h-4.5 w-4.5" />
+                          <PendingSwap icon={Icon} className="h-4.5 w-4.5" />
                         </span>
                         <span className="min-w-0">
                           <span className="block text-sm font-medium">{label}</span>
@@ -163,7 +167,7 @@ export function BottomNav({ org, repo }: BottomNavProps) {
                             <span className="block truncate text-xs text-muted-foreground">{description}</span>
                           )}
                         </span>
-                      </Link>
+                      </NavLink>
                     </li>
                   ))}
                 </ul>

--- a/apps/web/components/layout/NavLink.tsx
+++ b/apps/web/components/layout/NavLink.tsx
@@ -1,0 +1,62 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import Link from "next/link"
+import { useLinkStatus } from "next/link"
+import { Loader2 } from "lucide-react"
+import { cn } from "@/lib/cn"
+
+/**
+ * Renders a spinner only while THIS link's navigation is pending.
+ * Must be rendered inside a <Link> subtree — useLinkStatus reads the
+ * enclosing link's status (Next 15.3+).
+ */
+export function PendingSpinner({ className }: { className?: string }) {
+  const { pending } = useLinkStatus()
+  if (!pending) return null
+  return (
+    <Loader2
+      className={cn("h-4 w-4 shrink-0 animate-spin text-primary", className)}
+      aria-hidden
+    />
+  )
+}
+
+/**
+ * Link with built-in pending affordance: while its route loads, the icon
+ * slot cross-fades to a spinner and the whole row dims — so a slow
+ * transition never reads as "nothing happened / bug".
+ *
+ * Children receive nothing special; pass icon+label yourself and drop
+ * <PendingSpinner/> wherever the spinner should appear.
+ */
+export const NavLink = Link
+
+/** Icon slot that swaps to a spinner while the enclosing link pends. */
+export function PendingSwap({
+  icon: Icon,
+  className,
+  spinClassName,
+}: {
+  icon: React.ComponentType<{ className?: string }>
+  className?: string
+  spinClassName?: string
+}) {
+  const { pending } = useLinkStatus()
+  if (pending) {
+    return (
+      <Loader2
+        aria-hidden
+        className={cn("shrink-0 animate-spin text-primary", spinClassName ?? className)}
+      />
+    )
+  }
+  return <Icon aria-hidden className={className} />
+}

--- a/apps/web/components/layout/Sidebar.tsx
+++ b/apps/web/components/layout/Sidebar.tsx
@@ -8,12 +8,12 @@
 
 "use client"
 
-import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { motion } from "motion/react"
 import { X } from "lucide-react"
 import { cn } from "@/lib/cn"
 import { NAV_GROUPS, GLOBAL_ITEMS } from "@/lib/navigation"
+import { NavLink, PendingSwap } from "@/components/layout/NavLink"
 
 interface SidebarProps {
   org: string
@@ -55,7 +55,7 @@ export function Sidebar({ org, repo, collapsed = false, overlay = false, onClose
                   transition={{ type: "spring", stiffness: 500, damping: 40 }}
                 />
               )}
-              <Link
+              <NavLink
                 href={href}
                 title={collapsed ? itemLabel : description ?? itemLabel}
                 aria-current={isActive ? "page" : undefined}
@@ -69,14 +69,15 @@ export function Sidebar({ org, repo, collapsed = false, overlay = false, onClose
                 {isActive && (
                   <span className="absolute left-0 top-1/2 h-5 w-[2.5px] -translate-y-1/2 rounded-full bg-primary shadow-[0_0_8px_2px] shadow-primary/40" />
                 )}
-                <Icon
+                <PendingSwap
+                  icon={Icon}
                   className={cn(
                     "h-4 w-4 shrink-0 transition-transform duration-150 group-hover:scale-110",
                     isActive && "text-primary drop-shadow-[0_0_6px_rgba(0,112,243,0.6)]"
                   )}
                 />
                 {!collapsed && <span className="truncate">{itemLabel}</span>}
-              </Link>
+              </NavLink>
             </li>
           )
         })}

--- a/apps/web/components/patterns/CommandPalette.tsx
+++ b/apps/web/components/patterns/CommandPalette.tsx
@@ -14,11 +14,11 @@
 
 "use client"
 
-import { useCallback } from "react"
-import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useState } from "react"
+import { useRouter, usePathname } from "next/navigation"
 import { Command } from "cmdk"
 import { motion } from "motion/react"
-import { SquareTerminal, Settings } from "lucide-react"
+import { Loader2, SquareTerminal, Settings } from "lucide-react"
 import { cn } from "@/lib/cn"
 import { useCommandPalette } from "@/hooks/useCommandPalette"
 import { GLOBAL_ITEMS, NAV_GROUPS } from "@/lib/navigation"
@@ -31,15 +31,37 @@ export interface CommandPaletteProps {
 export function CommandPalette({ org, repo }: CommandPaletteProps) {
   const { open, setOpen } = useCommandPalette()
   const router = useRouter()
+  const pathname = usePathname()
+  // Stay open with a spinner on the chosen row until the route actually
+  // changes — slow first-compile navigations never read as dead clicks.
+  const [navigating, setNavigating] = useState<string | null>(null)
   const base = `/${org}/${repo}`
 
   const navigate = useCallback(
     (href: string) => {
+      // Keep the palette open with a row spinner while the route settles;
+      // the effect below closes it the moment the path matches.
+      setNavigating(href)
       router.push(href)
-      setOpen(false)
     },
-    [router, setOpen]
+    [router]
   )
+
+  useEffect(() => {
+    // Closing on route arrival is an external-system response (the
+    // router completed); synchronous here is intentional and safe.
+    /* eslint-disable react-hooks/set-state-in-effect */
+    if (open && navigating && pathname === navigating) {
+      setOpen(false)
+      setNavigating(null)
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [open, navigating, pathname, setOpen])
+
+  const RowSpinner = ({ href }: { href: string }) =>
+    navigating === href ? (
+      <Loader2 className="ml-auto h-4 w-4 shrink-0 animate-spin text-primary" aria-hidden />
+    ) : null
 
   if (!open) return null
 
@@ -101,6 +123,7 @@ export function CommandPalette({ org, repo }: CommandPaletteProps) {
                           </span>
                         )}
                       </span>
+                      <RowSpinner href={href} />
                     </Command.Item>
                   )
                 })}
@@ -130,6 +153,7 @@ export function CommandPalette({ org, repo }: CommandPaletteProps) {
                       <span className="block truncate text-xs text-muted-foreground">{description}</span>
                     )}
                   </span>
+                  <RowSpinner href={suffix} />
                 </Command.Item>
               ))}
             </Command.Group>


### PR DESCRIPTION
Keluhan: *'pencet fitur harus ada penanda, kalau gada rasanya bug padahal loading'* — benar banget, apalagi kompilasi pertama di HP lambat.

**Fix**: `useLinkStatus` (Next 15.3+) dipasang di SEMUA permukaan nav:

- Icon item yang diklik **cross-fade jadi spinner** selama route-nya load, row redup
- Sidebar rail + drawer overlay ✓
- BottomNav fixed slots + kartu More-sheet ✓
- CommandPalette: karena pakai `router.push` (bukan Link), dia punya mekanisme sendiri — palette tetap terbuka, spinner muncul di baris terpilih, tutup sendiri pas pathname cocok

Satu komponen kecil baru (`NavLink.tsx`: PendingSpinner + PendingSwap), sisanya integrasi.