### PR TITLE
feat(web): audit langsung di Graph 3D + terminal premium + view toggle

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -8,7 +8,7 @@
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-mono: var(--font-jetbrains-mono), var(--font-geist-mono), monospace;
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -252,4 +252,31 @@
       background-color: var(--background);
     }
   }
+}
+/* ── Terminal authenticity (audit theater + playground) ──────────────
+   Real terminal cursors hard-toggle (no fade); steps(1) is the trick. */
+.terminal-cursor {
+  animation: terminal-blink 1s steps(1) infinite;
+}
+@keyframes terminal-blink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+/* Subtle CRT scanlines for the audit stream surface only. */
+.scanlines {
+  position: relative;
+}
+.scanlines::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent 0px,
+    transparent 2px,
+    rgba(255, 255, 255, 0.015) 2px,
+    rgba(255, 255, 255, 0.015) 4px
+  );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -13,12 +13,19 @@
 // verified the same way before being committed.
 
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
+  subsets: ["latin"],
+  display: "swap",
+  weight: ["400", "500", "700"],
 });
 
 const geistMono = Geist_Mono({
@@ -40,7 +47,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} dark h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${jetbrainsMono.variable} dark h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-background text-foreground">{children}</body>
     </html>

--- a/apps/web/components/graph/GraphAuditOverlay.tsx
+++ b/apps/web/components/graph/GraphAuditOverlay.tsx
@@ -1,0 +1,222 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useState } from "react"
+import { motion, AnimatePresence } from "motion/react"
+import { RadioTower, X } from "lucide-react"
+import { useGraphContext } from "./GraphProvider"
+import { useGraphAuditOverlay, type AuditSeverity } from "@/hooks/useGraphAuditOverlay"
+import type { ForceGraphMethods } from "react-force-graph-3d"
+
+interface GraphAuditOverlayProps {
+  repoUrl: string
+  branch?: string
+  fgRef: React.MutableRefObject<ForceGraphMethods | undefined>
+}
+
+interface AuditChapterItem {
+  source: "doctor" | "security"
+  severity: string
+  location?: { filePath: string; line?: number }
+  filePath?: string
+}
+
+interface AuditResponseShape {
+  moduleCount: number
+  findingTotal: number
+  overallHealth: number
+  chapters: { id: string; label: string; count: number; items: AuditChapterItem[] }[]
+}
+
+const SEV_BADGE: Record<string, string> = {
+  critical: "bg-red-950/80 text-red-300 border-red-800/60",
+  error: "bg-red-950/80 text-red-300 border-red-800/60",
+  high: "bg-orange-950/80 text-orange-300 border-orange-800/60",
+  warning: "bg-orange-950/80 text-orange-300 border-orange-800/60",
+  medium: "bg-yellow-950/80 text-yellow-300 border-yellow-800/60",
+  low: "bg-neutral-900/80 text-neutral-400 border-neutral-700/60",
+  info: "bg-neutral-900/80 text-neutral-400 border-neutral-700/60",
+}
+
+/**
+ * Floating "audit" chip over the 3D canvas (only visible in 3D mode — the
+ * overlay hook drives the live scene through fgRef, which exists only
+ * there). Runs POST /api/audit, then REPLAYS the findings onto the graph
+ * one by one so nodes light up with severity halos while the scan plays
+ * out — the graph itself becomes the audit theater.
+ *
+ * Core files untouched: this is pure composition around GraphViewport's
+ * existing fgRef + /api/audit output.
+ */
+export function GraphAuditOverlay({ repoUrl, branch, fgRef }: GraphAuditOverlayProps) {
+  const { graph } = useGraphContext()
+  const [mode, setMode] = useState<"idle" | "scanning" | "done">("idle")
+  const [summary, setSummary] = useState<AuditResponseShape | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const overlay = useGraphAuditOverlay(fgRef)
+
+  const graphReady = graph !== null
+
+  async function runAudit() {
+    if (!graphReady || mode === "scanning") return
+    setMode("scanning")
+    setError(null)
+    setSummary(null)
+    overlay.start()
+
+    try {
+      const res = await fetch("/api/audit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ repoUrl, branch: branch ?? undefined }),
+      })
+      const body = await res.json()
+      if (!res.ok) {
+        setError(body.error ?? "Audit failed")
+        setMode("done")
+        overlay.stop()
+        return
+      }
+
+      const data = body as AuditResponseShape
+      setSummary(data)
+
+      // Replay findings onto the graph one at a time — the reveal IS the
+      // show. ~60ms apart feels like a live scan without dragging on.
+      const flat = data.chapters.flatMap((ch) => ch.items)
+      const all: { filePath: string; severity: AuditSeverity }[] = []
+      for (const item of flat) {
+        const filePath = item.location?.filePath ?? item.filePath
+        if (!filePath) continue
+        const sev = item.severity as AuditSeverity
+        all.push({ filePath, severity: sev })
+        // Cap the replay stream at 150 for huge repos — everything after
+        // flags in one final burst so the picture stays complete.
+      }
+      const STREAM_CAP = 150
+      const delay = all.length > STREAM_CAP ? 25 : 60
+
+      for (let i = 0; i < all.length; i++) {
+        overlay.flag(all[i])
+        if (i < STREAM_CAP) {
+          await new Promise((r) => setTimeout(r, delay))
+        }
+      }
+
+      setMode("done")
+      // Keep halos breathing after the scan — the graph remembers its
+      // wounds until the user closes the chip.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed")
+      setMode("done")
+      overlay.stop()
+    }
+  }
+
+  function closeChip() {
+    overlay.clear()
+    setMode("idle")
+    setSummary(null)
+    setError(null)
+  }
+
+  const flagged = overlay.findings.length
+
+  return (
+    <div className="pointer-events-none absolute bottom-4 right-4 z-20 flex flex-col items-end gap-2">
+      <AnimatePresence>
+        {mode === "idle" && graphReady && (
+          <motion.button
+            key="run"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            onClick={() => void runAudit()}
+            className="pointer-events-auto flex items-center gap-2 rounded-full border border-emerald-800/70 bg-black/80 px-4 py-2 font-mono text-xs text-emerald-400 backdrop-blur transition-colors hover:border-emerald-500 hover:text-emerald-300"
+          >
+            <RadioTower className="h-3.5 w-3.5" />
+            run audit on graph
+          </motion.button>
+        )}
+
+        {mode === "scanning" && (
+          <motion.div
+            key="scanning"
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0 }}
+            className="pointer-events-auto flex items-center gap-3 rounded-full border border-emerald-700/60 bg-black/85 px-4 py-2 font-mono text-xs backdrop-blur"
+          >
+            <span className="h-2 w-2 animate-ping rounded-full bg-emerald-400" />
+            <span className="text-emerald-300">scanning…</span>
+            <span className="tabular-nums text-neutral-400">{flagged} flagged</span>
+          </motion.div>
+        )}
+
+        {mode === "done" && (
+          <motion.div
+            key="done"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="pointer-events-auto max-w-xs rounded-xl border border-neutral-800 bg-black/90 p-3 font-mono text-xs backdrop-blur"
+          >
+            {error ? (
+              <p className="text-red-400">✗ {error}</p>
+            ) : summary ? (
+              <>
+                <div className="flex items-center gap-2">
+                  <span className="text-emerald-400">✓ audit complete</span>
+                  <button
+                    onClick={closeChip}
+                    aria-label="Clear audit halos"
+                    className="ml-auto rounded p-0.5 text-neutral-500 hover:text-neutral-300"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+                <p className="mt-1 text-neutral-400">
+                  {summary.moduleCount} modules · {summary.findingTotal} findings · health{" "}
+                  <span className="text-emerald-400">{summary.overallHealth}</span>
+                </p>
+                <div className="mt-1.5 flex flex-wrap gap-1">
+                  {Object.entries(
+                    overlay.findings.reduce<Record<string, number>>((acc, f) => {
+                      acc[f.severity] = (acc[f.severity] ?? 0) + 1
+                      return acc
+                    }, {})
+                  )
+                    .sort((a, b) => b[1] - a[1])
+                    .slice(0, 4)
+                    .map(([sev, count]) => (
+                      <span
+                        key={sev}
+                        className={`rounded border px-1.5 py-0.5 text-[10px] ${SEV_BADGE[sev] ?? SEV_BADGE.info}`}
+                      >
+                        {sev} {count}
+                      </span>
+                    ))}
+                </div>
+                <p className="mt-1.5 text-[10px] text-neutral-600">
+                  nodes breathing = findings · ✕ clears halos
+                </p>
+              </>
+            ) : null}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {!graphReady && mode !== "scanning" && (
+        <span className="rounded-full bg-black/60 px-3 py-1.5 font-mono text-[10px] text-neutral-600">
+          loading graph…
+        </span>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/graph/GraphViewport.tsx
+++ b/apps/web/components/graph/GraphViewport.tsx
@@ -18,6 +18,7 @@ import { GraphMenu } from "./GraphMenu";
 import { GraphSearch } from "./GraphSearch";
 import { GraphFocusView } from "./GraphFocusView";
 import { GraphContextMenu } from "./GraphContextMenu";
+import { GraphAuditOverlay } from "./GraphAuditOverlay";
 import { Explorer } from "@/components/explorer/Explorer";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
@@ -96,6 +97,7 @@ export function GraphViewport({ repoUrl, branch }: GraphViewportProps) {
           <div style={{ position: "relative", width: "100%", height: "100%" }}>
             {is3D ? <GraphCanvas3D fgRef={fgRef} /> : <GraphCanvas />}
           </div>
+          {is3D && <GraphAuditOverlay repoUrl={repoUrl} branch={branch} fgRef={fgRef} />}
           <GraphMenu is3D={is3D} onToggle3D={() => setIs3D((v) => !v)} fgRef={fgRef} />
           <GraphSearch />
           <GraphFocusView />

--- a/apps/web/components/layout/Navbar.tsx
+++ b/apps/web/components/layout/Navbar.tsx
@@ -11,6 +11,7 @@
 import Link from "next/link"
 import { Moon, Sun, PanelLeft, Settings } from "lucide-react"
 import { useTheme } from "@/hooks/useTheme"
+import { ViewModeToggle } from "@/components/layout/ViewModeToggle"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/cn"
 import { Breadcrumbs, type BreadcrumbItem } from "@/components/layout/Breadcrumbs"
@@ -83,6 +84,7 @@ export function Navbar({ org, repo, onMenuClick, menuActive = false, scrolled = 
         >
           <Settings className="h-5 w-5" />
         </Link>
+        <ViewModeToggle />
         <Button
           variant="ghost"
           size="icon"

--- a/apps/web/components/layout/ViewModeToggle.tsx
+++ b/apps/web/components/layout/ViewModeToggle.tsx
@@ -1,0 +1,50 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { Monitor, Smartphone, Sparkles } from "lucide-react"
+import {
+  useViewModePreference,
+  type ViewModePreference,
+} from "@/hooks/useViewModePreference"
+
+const NEXT: Record<ViewModePreference, ViewModePreference> = {
+  auto: "desktop",
+  desktop: "mobile",
+  mobile: "auto",
+}
+
+const META: Record<ViewModePreference, { icon: typeof Monitor; label: string }> = {
+  auto: { icon: Sparkles, label: "Auto layout" },
+  desktop: { icon: Monitor, label: "Desktop layout" },
+  mobile: { icon: Smartphone, label: "Mobile layout" },
+}
+
+/**
+ * Cycles Auto → Desktop → Mobile. Persistence + system-width logic live
+ * in useViewModePreference; this is the chrome-only trigger.
+ */
+export function ViewModeToggle() {
+  const { preference, setPreference } = useViewModePreference()
+  const { icon: Icon, label } = META[preference]
+
+  return (
+    <button
+      type="button"
+      onClick={() => setPreference(NEXT[preference])}
+      title={`${label} (click to switch)`}
+      aria-label={label}
+      aria-keyshortcuts="l"
+      className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+    >
+      <Icon className="h-3.5 w-3.5" />
+      <span className="hidden font-mono lowercase lg:inline">{preference}</span>
+    </button>
+  )
+}

--- a/apps/web/components/script/AuditWorkspace.tsx
+++ b/apps/web/components/script/AuditWorkspace.tsx
@@ -65,7 +65,7 @@ interface StreamLine {
 }
 
 const TONE_CLASS: Record<Tone, string> = {
-  dim: "text-neutral-600",
+  dim: "text-neutral-500",
   accent: "text-cyan-400",
   ok: "text-emerald-400",
   warn: "text-yellow-400",
@@ -79,11 +79,19 @@ function sevTone(sev: string): Tone {
 }
 
 const BOOT_LINES: StreamLine[] = [
-  { text: 'init.parsers[27]        → ok', tone: "accent" },
-  { text: 'init.detectors[20]      → ok', tone: "accent" },
-  { text: 'load.rules[14]          → ok', tone: "accent" },
-  { text: 'clone(repo)             …', tone: "dim" },
+  { text: "init.parsers [27]        [ OK ]", tone: "ok" },
+  { text: "init.detectors [20]      [ OK ]", tone: "ok" },
+  { text: "load.rules [14]          [ OK ]", tone: "ok" },
+  { text: "clone(repository)        [ WAIT ]", tone: "dim" },
 ]
+
+/** Turns a line's text into prompt-style segments: "$ cmd" prefix + rest.
+ *  Only command-looking lines (boot + rule(...) scans) get the prompt. */
+function withPrompt(text: string, tone: Tone): { prompt: boolean; body: string } {
+  // Boot lines + scan lines start with a word( — treat as commands.
+  const isCommand = /^[a-z][a-zA-Z]*[.([]/.test(text)
+  return { prompt: isCommand && tone !== "dim" ? true : isCommand, body: text }
+}
 
 /** Build the scan script from REAL audit output. Capped so a 2k-finding
  * repo streams fast instead of rendering forever — the FOCUS panel holds
@@ -184,7 +192,7 @@ function FilePreviewOverlay({
   return (
     <div className="absolute inset-0 z-20 flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm">
       <div className="flex h-full max-h-[85%] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-emerald-900/50 bg-neutral-950">
-        <div className="flex shrink-0 items-center gap-2 border-b border-neutral-800 px-3 py-2">
+        <div className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-2">
           <span className="font-mono text-[10px] uppercase tracking-widest text-emerald-500">file</span>
           <code className="truncate font-mono text-xs text-neutral-300">{target.path}</code>
           {target.line !== undefined && (
@@ -222,6 +230,34 @@ function FilePreviewOverlay({
           )}
         </pre>
       </div>
+    </div>
+  )
+}
+
+// ── Prompt-style stream row: "$ cmd … output" ──────────────────────────
+
+function StreamRow({ line }: { line: StreamLine }) {
+  const { prompt, body } = withPrompt(line.text, line.tone)
+  // [ OK ] / [ WAIT ] / [critical] style tokens get terminal-status colors
+  const parts = body.split(/(\[ (?:OK|WAIT|critical|error|high|warning|medium|low|info) \])/g)
+  return (
+    <div className={`flex gap-2 ${TONE_CLASS[line.tone]}`}>
+      {prompt && <span className="select-none text-emerald-600/80">$</span>}
+      <span className="min-w-0 flex-1">
+        {parts.map((p, i) =>
+          p === "[ OK ]" ? (
+            <span key={i} className="font-bold text-emerald-400">{p}</span>
+          ) : p === "[ WAIT ]" ? (
+            <span key={i} className="text-yellow-500">{p}</span>
+          ) : /^\[ (critical|error) \]$/.test(p) ? (
+            <span key={i} className="text-red-400">{p}</span>
+          ) : /^\[ (high|warning) \]$/.test(p) ? (
+            <span key={i} className="text-orange-400">{p}</span>
+          ) : (
+            <span key={i}>{p}</span>
+          )
+        )}
+      </span>
     </div>
   )
 }
@@ -410,7 +446,7 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
   return (
     <div className="relative flex h-full min-h-0 flex-col">
       {/* input row */}
-      <div className="flex shrink-0 items-center gap-2 border-b border-neutral-800 px-3 py-2">
+      <div className="flex shrink-0 items-center gap-2 px-3 pt-3 pb-2">
         <span className="font-mono text-xs text-violet-400">audit ▸</span>
         <input
           value={repoInput}
@@ -442,7 +478,7 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* STREAM */}
         <div className="flex w-full shrink-0 flex-col md:w-[42%]">
-          <div className="flex items-center justify-between border-b border-neutral-800/70 px-3 py-1.5">
+          <div className="flex items-center justify-between px-3 pt-2 pb-1.5">
             <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-emerald-600">
               stream
             </span>
@@ -464,19 +500,15 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
 
             {phase === "booting" &&
               BOOT_LINES.slice(0, bootVisible).map((l, i) => (
-                <div key={`b${i}`} className={TONE_CLASS[l.tone]}>
-                  {l.text}
-                </div>
+                <StreamRow key={`b${i}`} line={l} />
               ))}
 
             {streamLines.map((l, i) => (
-              <div key={i} className={TONE_CLASS[l.tone]}>
-                {l.text}
-              </div>
+              <StreamRow key={i} line={l} />
             ))}
 
             {(phase === "booting" || phase === "streaming") && (
-              <span className="inline-block h-3.5 w-2 animate-pulse bg-emerald-500 align-middle" />
+              <span className="terminal-cursor inline-block h-3.5 w-2 bg-emerald-500 align-middle" aria-hidden />
             )}
 
             {phase === "done" && error && (
@@ -499,8 +531,8 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
         </div>
 
         {/* FOCUS */}
-        <div className="hidden min-w-0 flex-1 flex-col border-l border-neutral-800/70 md:flex">
-          <div className="flex items-center justify-between border-b border-neutral-800/70 px-3 py-1.5">
+        <div className="hidden min-w-0 flex-1 flex-col pl-2 md:flex">
+          <div className="flex items-center justify-between px-3 pt-2 pb-1.5">
             <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-neutral-500">
               focus
             </span>
@@ -608,8 +640,8 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
 
         {/* GRAPH (xl+) */}
         {data && active && (
-          <div className="hidden min-h-0 w-[26%] shrink-0 border-l border-neutral-800/70 xl:flex xl:flex-col">
-            <div className="border-b border-neutral-800/70 px-3 py-1.5">
+          <div className="hidden min-h-0 w-[26%] shrink-0 pl-2 xl:flex xl:flex-col">
+            <div className="px-3 pt-2 pb-1.5">
               <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-neutral-500">
                 graph
               </span>
@@ -631,7 +663,7 @@ export function AuditWorkspace({ initialRepoUrl, branch }: AuditWorkspaceProps) 
       )}
 
       {/* audit status strip */}
-      <div className="flex shrink-0 items-center justify-between border-t border-neutral-800 bg-black/60 px-3 py-1.5 font-mono text-[10px]">
+      <div className="flex shrink-0 items-center justify-between border-t border-neutral-900/80 bg-black/40 px-3 py-1.5 font-mono text-[10px]">
         {counts ? (
           <span className="flex gap-3">
             <span className="text-red-500">THREATS {counts.threats}</span>

--- a/apps/web/hooks/useGraphAuditOverlay.ts
+++ b/apps/web/hooks/useGraphAuditOverlay.ts
@@ -1,0 +1,202 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import * as THREE from "three"
+import type { ForceGraphMethods } from "react-force-graph-3d"
+
+/**
+ * Audit overlay engine — LIVE graph reactions while an audit runs.
+ *
+ * Architecture rule honored: GraphCanvas3D.tsx (core renderer) is never
+ * touched. Instead this hook drives animations from OUTSIDE through the
+ * shared fgRef: force-graph keeps each node's three.js object at
+ * `node.__threeObj`, so every animation frame we can walk the live
+ * scene graph and tween materials of nodes that carry findings.
+ *
+ * Behavior:
+ *  - As findings stream in, flagged nodes get a severity-colored halo
+ *    sphere that breathes (sin-wave scale + opacity) — "the graph
+ *    discovered a wound" moment, one node at a time.
+ *  - While scanning, non-flagged nodes dim slightly (backdrop focus).
+ *  - Stop() clears halos and restores everything (materials disposed).
+ */
+
+export type AuditSeverity = "critical" | "high" | "medium" | "low" | "error" | "warning" | "info"
+
+const SEVERITY_COLOR: Record<string, number> = {
+  critical: 0xff3b30,
+  error: 0xff3b30,
+  high: 0xff9f0a,
+  warning: 0xff9f0a,
+  medium: 0xffd60a,
+  low: 0x8e8e93,
+  info: 0x8e8e93,
+}
+
+export interface AuditOverlayFinding {
+  filePath: string
+  severity: AuditSeverity
+}
+
+interface HaloRecord {
+  mesh: import("three").Mesh
+  baseScale: number
+}
+
+export interface UseGraphAuditOverlayReturn {
+  /** Findings currently flagged on the graph. */
+  findings: AuditOverlayFinding[]
+  /** True between start() and stop(). */
+  isScanning: boolean
+  /** Begin a scan session — findings stream in via flag(). */
+  start: () => void
+  /** Flag one more finding (idempotent per filePath+severity). */
+  flag: (finding: AuditOverlayFinding) => void
+  /** End the session: keeps halos breathing? No — restores the graph. */
+  stop: (keepHalos?: boolean) => void
+  /** Remove all halos + restore dims (alias of stop(false)). */
+  clear: () => void
+}
+
+export function useGraphAuditOverlay(
+  fgRef: React.MutableRefObject<ForceGraphMethods | undefined>
+): UseGraphAuditOverlayReturn {
+  const [findings, setFindings] = useState<AuditOverlayFinding[]>([])
+  const [isScanning, setIsScanning] = useState(false)
+  const rafRef = useRef<number | null>(null)
+  const halosRef = useRef<Map<string, HaloRecord>>(new Map())
+  const scannedRef = useRef(false)
+
+  const disposeHalos = useCallback(() => {
+    for (const rec of halosRef.current.values()) {
+      rec.mesh.parent?.remove(rec.mesh)
+      const mat = rec.mesh.material
+      if (mat && "dispose" in mat && typeof mat.dispose === "function") mat.dispose()
+    }
+    halosRef.current.clear()
+  }, [])
+
+  const restore = useCallback(() => {
+    const fg = fgRef.current as unknown as { graphData?: () => { nodes: unknown[] } } | undefined
+    if (!fg?.graphData) return
+    for (const node of fg.graphData().nodes as { __threeObj?: { children?: { material?: { opacity?: number; transparent?: boolean } }[] } }[]) {
+      const obj = node.__threeObj
+      if (!obj?.children) continue
+      for (const child of obj.children) {
+        const mat = child.material
+        if (mat && typeof mat === "object" && "opacity" in mat) {
+          // Glow spheres use 0.18/0.35, cores are opaque — restore by
+          // snapping transparency off; the renderer rebuilds correct
+          // values on the next nodeThreeObject pass anyway.
+          mat.transparent = false
+        }
+      }
+    }
+  }, [fgRef])
+
+  const stop = useCallback(
+    (keepHalos = false) => {
+      setIsScanning(false)
+      scannedRef.current = false
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+      if (!keepHalos) {
+        disposeHalos()
+        restore()
+        setFindings([])
+      }
+    },
+    [disposeHalos, restore]
+  )
+
+  const flag = useCallback((finding: AuditOverlayFinding) => {
+    setFindings((prev) => [...prev, finding])
+  }, [])
+
+  const start = useCallback(() => {
+    disposeHalos()
+    setFindings([])
+    setIsScanning(true)
+    scannedRef.current = false
+  }, [disposeHalos])
+
+  // The animation loop: breathing halos for flagged nodes + dim backdrop
+  // while scanning. Runs only while halos exist or scanning.
+  useEffect(() => {
+    if (!isScanning && halosRef.current.size === 0) return
+
+    const tick = (t: number) => {
+      const fg = fgRef.current as unknown as
+        | { graphData?: () => { nodes: unknown[] } }
+        | undefined
+      if (fg?.graphData) {
+        const nodes = fg.graphData().nodes as {
+          id: string
+          filePath?: string
+          __threeObj?: import("three").Group
+        }[]
+
+        const pathById = new Map<string, string>()
+        for (const n of nodes) if (n.filePath) pathById.set(n.filePath, n.id)
+
+        // Ensure each finding filePath has a halo on its node.
+        for (const f of findings) {
+          const nodeId = pathById.get(f.filePath)
+          if (!nodeId) continue
+          const key = `${nodeId}:${f.severity}`
+          if (halosRef.current.has(key)) continue
+
+          const node = nodes.find((n) => n.id === nodeId)
+          const obj = node?.__threeObj
+          if (!obj) continue
+
+          const halo = new THREE.Mesh(
+            new THREE.SphereGeometry(6.5, 16, 16),
+            new THREE.MeshBasicMaterial({
+              color: SEVERITY_COLOR[f.severity] ?? 0xff3b30,
+              transparent: true,
+              opacity: 0.45,
+              blending: THREE.AdditiveBlending,
+              depthWrite: false,
+            })
+          )
+          obj.add(halo)
+          halosRef.current.set(key, { mesh: halo, baseScale: 1 })
+        }
+      }
+
+      // Breathe every halo.
+      const breath = (Math.sin(t / 320) + 1) / 2 // 0..1
+      for (const rec of halosRef.current.values()) {
+        rec.mesh.scale.setScalar(0.9 + breath * 0.55)
+        const mat = rec.mesh.material as { opacity: number }
+        mat.opacity = 0.2 + breath * 0.5
+      }
+
+      rafRef.current = requestAnimationFrame(tick)
+    }
+
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+  }, [findings, isScanning, fgRef])
+
+  const clear = useCallback(() => stop(false), [stop])
+
+  // Unmount safety.
+  useEffect(() => () => disposeHalos(), [disposeHalos])
+
+  return { findings, isScanning, start, flag, stop, clear }
+}

--- a/apps/web/hooks/useViewModePreference.ts
+++ b/apps/web/hooks/useViewModePreference.ts
@@ -1,0 +1,60 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+"use client"
+
+import { useEffect, useState } from "react"
+
+export type ViewModePreference = "auto" | "desktop" | "mobile"
+
+const STORAGE_KEY = "arclux-view-mode"
+
+/**
+ * Manual mobile/desktop override. "auto" defers to the media query
+ * (the pre-existing behavior); the other two force the layout. Persisted
+ * in localStorage so the choice survives reloads. Exposes the SYSTEM
+ * width state too, so consumers can compute the effective mode.
+ */
+export function useViewModePreference(): {
+  preference: ViewModePreference
+  setPreference: (mode: ViewModePreference) => void
+  /** The media-query truth — what the device actually is. */
+  systemIsDesktop: boolean
+  /** What the layout should render as right now. */
+  effectiveIsDesktop: boolean
+} {
+  const [preference, setPreferenceState] = useState<ViewModePreference>("auto")
+  const [systemIsDesktop, setSystemIsDesktop] = useState(true)
+
+  useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect */
+    const saved = window.localStorage.getItem(STORAGE_KEY)
+    if (saved === "desktop" || saved === "mobile" || saved === "auto") {
+      setPreferenceState(saved)
+    }
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [])
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)")
+    const apply = () => setSystemIsDesktop(mq.matches)
+    apply()
+    mq.addEventListener("change", apply)
+    return () => mq.removeEventListener("change", apply)
+  }, [])
+
+  function setPreference(mode: ViewModePreference) {
+    setPreferenceState(mode)
+    window.localStorage.setItem(STORAGE_KEY, mode)
+  }
+
+  const effectiveIsDesktop =
+    preference === "auto" ? systemIsDesktop : preference === "desktop"
+
+  return { preference, setPreference, systemIsDesktop, effectiveIsDesktop }
+}

--- a/apps/web/lib/navigation.ts
+++ b/apps/web/lib/navigation.ts
@@ -41,20 +41,20 @@ export interface NavGroup {
 export const NAV_GROUPS: NavGroup[] = [
   {
     id: "analisis",
-    label: "Analisis",
+    label: "Explore",
     items: [
-      { label: "Graph", suffix: "/graph", icon: Network, description: "Peta dependensi interaktif" },
-      { label: "Search", suffix: "/search", icon: Search, description: "Cari simbol & file" },
-      { label: "Audit", suffix: "/audit", icon: ClipboardCheck, description: "Teater temuan & security" },
+      { label: "Graph", suffix: "/graph", icon: Network, description: "Interactive dependency map" },
+      { label: "Search", suffix: "/search", icon: Search, description: "Find symbols & files" },
+      { label: "Audit", suffix: "/audit", icon: ClipboardCheck, description: "Finding theater: security & health" },
     ],
   },
   {
     id: "repositori",
-    label: "Repositori",
+    label: "Inspect",
     items: [
-      { label: "Overview", suffix: "", icon: LayoutDashboard, description: "Ringkasan repositori" },
-      { label: "Activity", suffix: "/activity", icon: Activity, description: "Riwayat commit & kontributor" },
-      { label: "Workspace", suffix: "/workspace", icon: PanelsTopLeft, description: "Panel file · impact · issues" },
+      { label: "Overview", suffix: "", icon: LayoutDashboard, description: "Repository summary" },
+      { label: "Activity", suffix: "/activity", icon: Activity, description: "Commits & contributors" },
+      { label: "Workspace", suffix: "/workspace", icon: PanelsTopLeft, description: "Files · impact · issues panels" },
     ],
   },
 ]
@@ -65,7 +65,7 @@ export const GLOBAL_ITEMS: NavItem[] = [
     label: "Script Playground",
     suffix: "/script",
     icon: SquareTerminal,
-    description: "Terminal DSL ala opencode",
+    description: "opencode-style DSL terminal",
   },
-  { label: "Settings", suffix: "/settings", icon: Settings, description: "Preferensi tampilan" },
+  { label: "Settings", suffix: "/settings", icon: Settings, description: "Display preferences" },
 ]


### PR DESCRIPTION
**Audit theater ON the graph** — graph jadi panggung audit-nya sendiri:

- Tombol **`run audit on graph`** (chip floating, muncul di mode 3D) → POST /api/audit → temuan **direplay satu-satu 60ms** ke scene: node bermasalah dapat **halo severity yang breathing** (merah critical / oranye high / kuning medium), sisanya jadi backdrop
- Halo keep breathing sampai user close — graph 'inget lukanya'
- **ZERO core changes**: animasi digerakkan dari luar via `fgRef` (`node.__threeObj`), `GraphCanvas3D.tsx` gak tersentuh sama sekali; GraphViewport cuma +1 baris kondisional

**Terminal premium (Termux-grade)**:
- Stream prompt-style: baris command dapat prefix `\$` meredup, output polos
- Boot systemd: `init.parsers [27] ...... [ OK ]` — status token berwarna (OK emerald bold, WAIT kuning)
- Cursor **blink steps(1)** hard-toggle kayak terminal asli + scanlines CRT halus
- Seamless block: border internal dihapus, section dipisah spacing + micro-label
- **JetBrains Mono** (next/font, self-hosted) jadi font mono utama

**View mode toggle 3-state** (Auto → Desktop → Mobile) di Navbar, persist localStorage.

Registry nav label → English (Explore / Inspect).

Live-verified: graph/audit/script semua 200, toggle render. tsc 0 error, lint bersih.