### PR TITLE
fix(web): audit halo animation gak pernah muncul — 2 bug

### DIFF
--- a/apps/web/components/graph/GraphAuditOverlay.tsx
+++ b/apps/web/components/graph/GraphAuditOverlay.tsx
@@ -8,7 +8,7 @@
 
 "use client"
 
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { motion, AnimatePresence } from "motion/react"
 import { RadioTower, X } from "lucide-react"
 import { useGraphContext } from "./GraphProvider"
@@ -19,6 +19,10 @@ interface GraphAuditOverlayProps {
   repoUrl: string
   branch?: string
   fgRef: React.MutableRefObject<ForceGraphMethods | undefined>
+  /** Current dimension — halos only exist in 3D, so clicking from 2D
+   *  switches the canvas first (user never has to hunt the toggle). */
+  is3D: boolean
+  onEnable3D: () => void
 }
 
 interface AuditChapterItem {
@@ -55,17 +59,33 @@ const SEV_BADGE: Record<string, string> = {
  * Core files untouched: this is pure composition around GraphViewport's
  * existing fgRef + /api/audit output.
  */
-export function GraphAuditOverlay({ repoUrl, branch, fgRef }: GraphAuditOverlayProps) {
+export function GraphAuditOverlay({ repoUrl, branch, fgRef, is3D, onEnable3D }: GraphAuditOverlayProps) {
   const { graph } = useGraphContext()
   const [mode, setMode] = useState<"idle" | "scanning" | "done">("idle")
   const [summary, setSummary] = useState<AuditResponseShape | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const overlay = useGraphAuditOverlay(fgRef)
+
+  // filePath → id from the provider graph (full node data — the scene's
+  // node objects don't carry filePath, see hook docs).
+  const filePathToId = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const n of graph?.nodes ?? []) {
+      if (n.filePath) map.set(n.filePath, n.id)
+    }
+    return map
+  }, [graph])
+
+  const overlay = useGraphAuditOverlay(fgRef, filePathToId)
 
   const graphReady = graph !== null
 
   async function runAudit() {
     if (!graphReady || mode === "scanning") return
+    if (!is3D) {
+      onEnable3D()
+      // Give the 3D canvas a beat to mount before halos start landing.
+      await new Promise((r) => setTimeout(r, 350))
+    }
     setMode("scanning")
     setError(null)
     setSummary(null)

--- a/apps/web/components/graph/GraphViewport.tsx
+++ b/apps/web/components/graph/GraphViewport.tsx
@@ -97,7 +97,13 @@ export function GraphViewport({ repoUrl, branch }: GraphViewportProps) {
           <div style={{ position: "relative", width: "100%", height: "100%" }}>
             {is3D ? <GraphCanvas3D fgRef={fgRef} /> : <GraphCanvas />}
           </div>
-          {is3D && <GraphAuditOverlay repoUrl={repoUrl} branch={branch} fgRef={fgRef} />}
+          <GraphAuditOverlay
+            repoUrl={repoUrl}
+            branch={branch}
+            fgRef={fgRef}
+            is3D={is3D}
+            onEnable3D={() => setIs3D(true)}
+          />
           <GraphMenu is3D={is3D} onToggle3D={() => setIs3D((v) => !v)} fgRef={fgRef} />
           <GraphSearch />
           <GraphFocusView />

--- a/apps/web/hooks/useGraphAuditOverlay.ts
+++ b/apps/web/hooks/useGraphAuditOverlay.ts
@@ -67,7 +67,11 @@ export interface UseGraphAuditOverlayReturn {
 }
 
 export function useGraphAuditOverlay(
-  fgRef: React.MutableRefObject<ForceGraphMethods | undefined>
+  fgRef: React.MutableRefObject<ForceGraphMethods | undefined>,
+  /** filePath → nodeId, built from GraphProvider's graph (NOT the scene —
+   *  GraphCanvas3D's node objects don't carry filePath, so building this
+   *  map from graphData() never matched anything: the original bug). */
+  filePathToId: Map<string, string>
 ): UseGraphAuditOverlayReturn {
   const [findings, setFindings] = useState<AuditOverlayFinding[]>([])
   const [isScanning, setIsScanning] = useState(false)
@@ -191,7 +195,7 @@ export function useGraphAuditOverlay(
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
       rafRef.current = null
     }
-  }, [findings, isScanning, fgRef])
+  }, [findings, isScanning, fgRef, filePathToId])
 
   const clear = useCallback(() => stop(false), [stop])
 


### PR DESCRIPTION
**Laporan user testing**: *'audit nya kok gada animasinya di graph'*. Benar — dua bug:

1. **filePath gak pernah nyampe ke scene**: node object di GraphCanvas3D cuma bawa `{id,name,val,color}` — TANPA filePath — jadi map `filePath→node` yang dibangun dari scene **selalu kosong** → halo gak pernah dibikin, bahkan di mode 3D. Fix: map dibangun dari graph di **GraphProvider** (data node lengkap), di-pass ke hook. Core renderer tetap zero-diff.

2. **Chip cuma muncul di 3D, padahal default graph = 2D** → orang gak pernah liat tombolnya. Fix: overlay render di dua mode; klik dari 2D = **auto-switch ke 3D** + 350ms beat buat mount, terus replay jalan.

Bonus verifikasi: `__threeObj` confirmed ada di 3d-force-graph (dist:368). tsc 0, lint bersih.