### PR TITLE
feat(mcp): CLI integration — arclux mcp subcommand

### DIFF
--- a/apps/cli/commands/mcp.ts
+++ b/apps/cli/commands/mcp.ts
@@ -1,0 +1,14 @@
+// Copyright 2026 Mikatoshi
+// Licensed under the Apache License, Version 2.0
+
+import type { Command } from "commander";
+
+export function registerMcpCommand(program: Command): void {
+  program
+    .command("mcp")
+    .description("Start MCP server — exposes ARCLUX tools via Model Context Protocol (stdio)")
+    .action(async () => {
+      const { startMcpServer } = await import("../../../packages/mcp/src/index.ts");
+      await startMcpServer();
+    });
+}

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -30,6 +30,7 @@ import { registerLanguageCommand } from "./language";
 import { registerSecurityCommand } from "./security";
 import { registerShellCommand } from "./shell";
 import { registerScriptCommand } from "./script";
+import { registerMcpCommand } from "./commands/mcp";
 
 const program = new Command();
 program.name("arclux").description("Repository intelligence CLI").version("0.2.0");
@@ -56,5 +57,6 @@ registerLanguageCommand(program);
 registerSecurityCommand(program);
 registerShellCommand(program);
 registerScriptCommand(program);
+registerMcpCommand(program);
 
 program.parse();

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "arclux",
   "version": "0.2.0",
-  "description": "Codebase intelligence platform — 27-language parser, dependency & call graphs, 20 architecture detectors, impact tracing, security pipeline, and the ARCLUX scripting DSL.",
+  "description": "Codebase intelligence platform \u2014 27-language parser, dependency & call graphs, 20 architecture detectors, impact tracing, security pipeline, and the ARCLUX scripting DSL.",
   "license": "Apache-2.0",
   "type": "module",
   "private": false,
@@ -35,7 +35,8 @@
   "dependencies": {
     "@clack/prompts": "^1.7.0",
     "commander": "^15.0.0",
-    "web-tree-sitter": "0.25.0"
+    "web-tree-sitter": "0.25.0",
+    "@modelcontextprotocol/sdk": "^1.30.0"
   },
   "devDependencies": {
     "esbuild": "^0.28.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:cli": "node scripts/build-cli.mjs"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@radix-ui/react-accordion": "^1.2.20",
     "@radix-ui/react-scroll-area": "^1.2.18",
     "chokidar": "^5.0.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@arclux/mcp",
+  "version": "0.2.0",
+  "description": "MCP server for ARCLUX — exposes codebase intelligence tools via Model Context Protocol",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src/",
+    "README.md"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,91 +1,90 @@
 // Copyright 2026 Mikatoshi
 // Licensed under the Apache License, Version 2.0
 //
-// ARCLUX MCP Server — exposes the full analysis engine as MCP tools.
-// Run with: npx tsx scripts/mcp-server.mjs
-// Client config: { "arclux": { "command": "npx", "args": ["tsx", "scripts/mcp-server.mjs"] } }
+// ARCLUX MCP Server — 21 tools covering the full analysis engine.
+// Entry point: startMcpServer() (called by `arclux mcp` CLI command).
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 
 // ── engine ────────────────────────────────────────────────────────────────
-import { analyzeRepository } from "../packages/engine/pipeline.ts";
-import { runDoctor } from "../packages/engine/runDoctor.ts";
-import { runAllChecks } from "../packages/engine/contract.ts";
-import { computeHealthScore } from "../packages/engine/healthScore.ts";
+import { analyzeRepository } from "../../engine/pipeline.ts";
+import { runDoctor } from "../../engine/runDoctor.ts";
+import { runAllChecks } from "../../engine/contract.ts";
+import { computeHealthScore } from "../../engine/healthScore.ts";
 
 // ── graph ─────────────────────────────────────────────────────────────────
-import { buildCallGraph } from "../packages/graph/buildCallGraph.ts";
-import { buildDependencyGraph } from "../packages/graph/buildDependencyGraph.ts";
-import { buildExportGraph } from "../packages/graph/buildExportGraph.ts";
-import { buildFolderGraph } from "../packages/graph/buildFolderGraph.ts";
+import { buildCallGraph } from "../../graph/buildCallGraph.ts";
+import { buildDependencyGraph } from "../../graph/buildDependencyGraph.ts";
+import { buildExportGraph } from "../../graph/buildExportGraph.ts";
+import { buildFolderGraph } from "../../graph/buildFolderGraph.ts";
 
 // ── impact ────────────────────────────────────────────────────────────────
-import { buildImpactTree } from "../packages/impact/buildImpactTree.ts";
-import { calculateAffectedFiles } from "../packages/impact/calculateAffectedFiles.ts";
-import { calculateAffectedRoutes } from "../packages/impact/calculateAffectedRoutes.ts";
-import { traceConsumers } from "../packages/impact/traceConsumers.ts";
-import { traceDependencies } from "../packages/impact/traceDependencies.ts";
+import { buildImpactTree } from "../../impact/buildImpactTree.ts";
+import { calculateAffectedFiles } from "../../impact/calculateAffectedFiles.ts";
+import { calculateAffectedRoutes } from "../../impact/calculateAffectedRoutes.ts";
+import { traceConsumers } from "../../impact/traceConsumers.ts";
+import { traceDependencies } from "../../impact/traceDependencies.ts";
 
 // ── security ──────────────────────────────────────────────────────────────
-import { analyzeRepositorySecurity } from "../packages/security-analysis/integration.ts";
-import { mapAttackSurface } from "../packages/correlation/AttackSurfaceMapper.ts";
+import { analyzeRepositorySecurity } from "../../security-analysis/integration.ts";
+import { mapAttackSurface } from "../../correlation/AttackSurfaceMapper.ts";
 
 // ── search ────────────────────────────────────────────────────────────────
-import { buildSearchIndex } from "../packages/search/SearchIndex.ts";
-import { search } from "../packages/search/SearchEngine.ts";
+import { buildSearchIndex } from "../../search/SearchIndex.ts";
+import { search } from "../../search/SearchEngine.ts";
 
 // ── diagnostics ───────────────────────────────────────────────────────────
-import { runDiagnostics } from "../packages/diagnostics/DiagnosticEngine.ts";
-import { getFixSuggestions } from "../packages/diagnostics/FixSuggestion.ts";
+import { runDiagnostics } from "../../diagnostics/DiagnosticEngine.ts";
+import { getFixSuggestions } from "../../diagnostics/FixSuggestion.ts";
 
 // ── diff ──────────────────────────────────────────────────────────────────
-import { computeArchitecturalDiff } from "../packages/diff/architecturalDiff.ts";
+import { computeArchitecturalDiff } from "../../diff/architecturalDiff.ts";
 
 // ── git ───────────────────────────────────────────────────────────────────
-import { cloneRepository } from "../packages/git/cloneRepository.ts";
-import { cleanupRepository } from "../packages/git/cleanupRepository.ts";
-import { getBranches } from "../packages/git/getBranches.ts";
-import { detectDefaultBranch } from "../packages/git/detectDefaultBranch.ts";
-import { getCommitHistory } from "../packages/git/getCommitHistory.ts";
-import { getContributors } from "../packages/git/getContributors.ts";
+import { cloneRepository } from "../../git/cloneRepository.ts";
+import { cleanupRepository } from "../../git/cleanupRepository.ts";
+import { getBranches } from "../../git/getBranches.ts";
+import { detectDefaultBranch } from "../../git/detectDefaultBranch.ts";
+import { getCommitHistory } from "../../git/getCommitHistory.ts";
+import { getContributors } from "../../git/getContributors.ts";
 
 // ── editor ────────────────────────────────────────────────────────────────
-import { openFile, listDependencyTargets, listDirectConsumerTargets } from "../packages/editor/CodeNavigator.ts";
+import { openFile, listDependencyTargets, listDirectConsumerTargets } from "../../editor/CodeNavigator.ts";
 
 // ── dsl ───────────────────────────────────────────────────────────────────
-import { runScriptSource } from "../packages/dsl/script.ts";
+import { runScriptSource } from "../../dsl/script.ts";
 
-// ── detectors (for the `detect` tool) ─────────────────────────────────────
-import { detectCircularDependency } from "../packages/detectors/detectCircularDependency.ts";
-import { detectUnusedExports } from "../packages/detectors/detectUnusedExports.ts";
-import { detectOrphanFiles } from "../packages/detectors/detectOrphanFiles.ts";
-import { detectOrphanIntegration } from "../packages/detectors/detectOrphanIntegration.ts";
-import { detectLargeModules } from "../packages/detectors/detectLargeModules.ts";
-import { detectDuplicateModules } from "../packages/detectors/detectDuplicateModules.ts";
-import { detectSharedModules } from "../packages/detectors/detectSharedModules.ts";
-import { detectIndexFiles } from "../packages/detectors/detectIndexFiles.ts";
-import { detectLayerViolation } from "../packages/detectors/detectLayerViolation.ts";
-import { detectDeadCode } from "../packages/detectors/detectDeadCode.ts";
-import { detectAmbiguousSymbolResolution } from "../packages/detectors/detectAmbiguousSymbolResolution.ts";
-import { detectComponentConvention } from "../packages/detectors/detectComponentConvention.ts";
-import { detectFeatureStructure } from "../packages/detectors/detectFeatureStructure.ts";
-import { detectMissingExports } from "../packages/detectors/detectMissingExports.ts";
-import { detectRepositoryPattern } from "../packages/detectors/detectRepositoryPattern.ts";
-import { detectRouteConvention } from "../packages/detectors/detectRouteConvention.ts";
-import { detectStoryConvention } from "../packages/detectors/detectStoryConvention.ts";
-import { detectTestConvention } from "../packages/detectors/detectTestConvention.ts";
-import { detectUnusedFiles } from "../packages/detectors/detectUnusedFiles.ts";
-import { detectEntryPoints } from "../packages/detectors/detectEntryPoints.ts";
+// ── detectors ─────────────────────────────────────────────────────────────
+import { detectCircularDependency } from "../../detectors/detectCircularDependency.ts";
+import { detectUnusedExports } from "../../detectors/detectUnusedExports.ts";
+import { detectOrphanFiles } from "../../detectors/detectOrphanFiles.ts";
+import { detectOrphanIntegration } from "../../detectors/detectOrphanIntegration.ts";
+import { detectLargeModules } from "../../detectors/detectLargeModules.ts";
+import { detectDuplicateModules } from "../../detectors/detectDuplicateModules.ts";
+import { detectSharedModules } from "../../detectors/detectSharedModules.ts";
+import { detectIndexFiles } from "../../detectors/detectIndexFiles.ts";
+import { detectLayerViolation } from "../../detectors/detectLayerViolation.ts";
+import { detectDeadCode } from "../../detectors/detectDeadCode.ts";
+import { detectAmbiguousSymbolResolution } from "../../detectors/detectAmbiguousSymbolResolution.ts";
+import { detectComponentConvention } from "../../detectors/detectComponentConvention.ts";
+import { detectFeatureStructure } from "../../detectors/detectFeatureStructure.ts";
+import { detectMissingExports } from "../../detectors/detectMissingExports.ts";
+import { detectRepositoryPattern } from "../../detectors/detectRepositoryPattern.ts";
+import { detectRouteConvention } from "../../detectors/detectRouteConvention.ts";
+import { detectStoryConvention } from "../../detectors/detectStoryConvention.ts";
+import { detectTestConvention } from "../../detectors/detectTestConvention.ts";
+import { detectUnusedFiles } from "../../detectors/detectUnusedFiles.ts";
+import { detectEntryPoints } from "../../detectors/detectEntryPoints.ts";
 
 // ── cache ─────────────────────────────────────────────────────────────────
-import { getCacheStats, clearAllCaches } from "../packages/cache/CacheProvider.ts";
+import { getCacheStats, clearAllCaches } from "../../cache/CacheProvider.ts";
 
 // ──────────────────────────────────────────────────────────────────────────
-// Detector registry — name => function(repository) => finding[]
+// Detector registry
 // ──────────────────────────────────────────────────────────────────────────
-const DETECTORS = {
+const DETECTORS: Record<string, (repo: any) => any[]> = {
   circular:               detectCircularDependency,
   unused_exports:         detectUnusedExports,
   orphan_files:           detectOrphanFiles,
@@ -111,21 +110,21 @@ const DETECTORS = {
 // ──────────────────────────────────────────────────────────────────────────
 // Helpers
 // ──────────────────────────────────────────────────────────────────────────
-function analyzeOpts(args) {
-  if (args.localPath) return { localPath: args.localPath };
-  if (args.repoUrl) return { repoUrl: args.repoUrl, branch: args.branch };
+function analyzeOpts(args: Record<string, unknown>) {
+  if (args.localPath) return { localPath: args.localPath as string };
+  if (args.repoUrl) return { repoUrl: args.repoUrl as string, branch: args.branch as string | undefined };
   throw new Error("Provide repoUrl or localPath");
 }
 
-async function doAnalyze(args) {
+async function doAnalyze(args: Record<string, unknown>) {
   return analyzeRepository(analyzeOpts(args));
 }
 
-function json(data) {
-  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+function json(data: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
 }
 
-async function withClone(repoUrl, branch, fn) {
+async function withClone(repoUrl: string, branch: string | undefined, fn: (localPath: string) => Promise<any>) {
   const clone = await cloneRepository({ url: repoUrl, branch });
   try {
     return await fn(clone.localPath);
@@ -134,7 +133,7 @@ async function withClone(repoUrl, branch, fn) {
   }
 }
 
-function resolveFile(moduleId, repository) {
+function resolveFile(moduleId: string, repository: any) {
   const mod = repository.getModuleById(moduleId)
     ?? repository.getModuleByPath(moduleId);
   if (!mod) throw new Error("Module not found: " + moduleId);
@@ -149,7 +148,7 @@ const TOOLS = [
     name: "analyze",
     description: "Full analysis pipeline - parse all files, build index, build dependency graph, detect frameworks. Returns meta, moduleCount, graph stats, scanSummary, dependencies.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string", description: "Git URL to clone and analyze" },
         localPath: { type: "string", description: "Local filesystem path to analyze (no clone)" },
@@ -161,7 +160,7 @@ const TOOLS = [
     name: "doctor",
     description: "Run all 20 architecture detectors. Returns findings with checkId, severity, filePath, message.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -173,7 +172,7 @@ const TOOLS = [
     name: "health",
     description: "Compute health score with 4 categories (structural, hygiene, conventions, info). Returns overall score 0-100 + per-category breakdown.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -185,7 +184,7 @@ const TOOLS = [
     name: "verify",
     description: "Run 10 core detectors + 14 framework rules, return PASS/FAIL verdict.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -197,7 +196,7 @@ const TOOLS = [
     name: "diagnose",
     description: "Run diagnostic adapters (circular, dead code, ambiguous symbols), attach impact context, return events with fix suggestions.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -209,7 +208,7 @@ const TOOLS = [
     name: "callgraph",
     description: "Build function call graph. Returns nodes (functions) and edges (caller to callee).",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -221,7 +220,7 @@ const TOOLS = [
     name: "dependency_graph",
     description: "Build import dependency graph. Returns nodes and edges.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -233,7 +232,7 @@ const TOOLS = [
     name: "export_graph",
     description: "Build export relationship graph - who exports what, who imports where from.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -245,7 +244,7 @@ const TOOLS = [
     name: "folder_graph",
     description: "Build directory tree structure with file counts per folder.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -257,7 +256,7 @@ const TOOLS = [
     name: "impact",
     description: "Full impact analysis for a file - dependency tree, affected files list, affected routes.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -271,7 +270,7 @@ const TOOLS = [
     name: "impact_consumers",
     description: "Trace all direct and transitive consumers of a module (who calls this).",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -285,7 +284,7 @@ const TOOLS = [
     name: "impact_dependencies",
     description: "Trace all direct and transitive dependencies of a module (what does this call).",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -299,7 +298,7 @@ const TOOLS = [
     name: "security",
     description: "Full security analysis - hardcoded secrets, unsafe patterns, trust boundaries, cross-boundary calls, dependency risk. Includes attack surface map.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -311,7 +310,7 @@ const TOOLS = [
     name: "search",
     description: "Fuzzy search for symbols, files, or code patterns across the repository.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -326,7 +325,7 @@ const TOOLS = [
     name: "detect",
     description: "Run specific detector(s) by name. Available: circular, unused_exports, orphan_files, orphan_integration, large_modules, duplicate_modules, shared_modules, index_files, layer_violation, dead_code, ambiguous_symbols, component_convention, feature_structure, missing_exports, repository_pattern, route_convention, story_convention, test_convention, unused_files, entry_points. Use [\"all\"] for all.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -344,7 +343,7 @@ const TOOLS = [
     name: "diff",
     description: "Architectural diff between two git refs - lists changed files and traces affected consumers.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -359,7 +358,7 @@ const TOOLS = [
     name: "branches",
     description: "List remote branches for a repository. Returns branch names and default branch.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl: { type: "string", description: "Git URL" },
       },
@@ -370,7 +369,7 @@ const TOOLS = [
     name: "history",
     description: "Get commit history and contributors. Clones repo shallowly, reads git log, then cleans up.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -383,7 +382,7 @@ const TOOLS = [
     name: "file_info",
     description: "Get module info for a file - exports, imports, calls, dependency targets, and direct consumers.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -397,7 +396,7 @@ const TOOLS = [
     name: "dsl",
     description: "Execute an ARCLUX DSL script. The script should call analyze(\"url\") or analyze(\"/path\") internally.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         source: { type: "string", description: "DSL source code" },
       },
@@ -408,7 +407,7 @@ const TOOLS = [
     name: "config",
     description: "Detect repository metadata - name, frameworks, package manager, root path.",
     inputSchema: {
-      type: "object",
+      type: "object" as const,
       properties: {
         repoUrl:   { type: "string" },
         localPath: { type: "string" },
@@ -421,7 +420,7 @@ const TOOLS = [
 // ──────────────────────────────────────────────────────────────────────────
 // Tool handlers
 // ──────────────────────────────────────────────────────────────────────────
-async function handleTool(name, args) {
+async function handleTool(name: string, args: Record<string, unknown>) {
   switch (name) {
 
     case "analyze": {
@@ -482,20 +481,20 @@ async function handleTool(name, args) {
     case "impact": {
       const r = await doAnalyze(args);
       return json({
-        tree: buildImpactTree(r.repository, args.moduleId),
-        affectedFiles: calculateAffectedFiles(r.repository, args.moduleId),
-        affectedRoutes: calculateAffectedRoutes(r.repository, args.moduleId),
+        tree: buildImpactTree(r.repository, args.moduleId as string),
+        affectedFiles: calculateAffectedFiles(r.repository, args.moduleId as string),
+        affectedRoutes: calculateAffectedRoutes(r.repository, args.moduleId as string),
       });
     }
 
     case "impact_consumers": {
       const r = await doAnalyze(args);
-      return json(traceConsumers(r.repository, args.moduleId));
+      return json(traceConsumers(r.repository, args.moduleId as string));
     }
 
     case "impact_dependencies": {
       const r = await doAnalyze(args);
-      return json(traceDependencies(r.repository, args.moduleId));
+      return json(traceDependencies(r.repository, args.moduleId as string));
     }
 
     case "security": {
@@ -508,15 +507,15 @@ async function handleTool(name, args) {
     case "search": {
       const r = await doAnalyze(args);
       const idx = buildSearchIndex(r.repository);
-      return json(search(idx, args.query, { limit: args.limit ?? 50 }));
+      return json(search(idx, args.query as string, { limit: (args.limit as number) ?? 50 }));
     }
 
     case "detect": {
       const r = await doAnalyze(args);
-      const names = args.detectors ?? [];
+      const names = (args.detectors as string[]) ?? [];
       const runAll = names.includes("all");
       const targets = runAll ? Object.keys(DETECTORS) : names;
-      const results = {};
+      const results: Record<string, any> = {};
       let total = 0;
       for (const n of targets) {
         const fn = DETECTORS[n];
@@ -533,41 +532,41 @@ async function handleTool(name, args) {
 
     case "diff": {
       const r = await doAnalyze(args);
-      return json(computeArchitecturalDiff(r.repository, r.meta.rootPath, args.refA, args.refB));
+      return json(computeArchitecturalDiff(r.repository, r.meta.rootPath, args.refA as string, args.refB as string));
     }
 
     case "branches": {
       return json({
-        branches: getBranches(args.repoUrl),
-        defaultBranch: detectDefaultBranch(args.repoUrl),
+        branches: getBranches(args.repoUrl as string),
+        defaultBranch: detectDefaultBranch(args.repoUrl as string),
       });
     }
 
     case "history": {
-      const fn = async (localPath) => {
-        const commits = await getCommitHistory(localPath, { maxCount: args.maxCount ?? 20, branch: args.branch });
+      const fn = async (localPath: string) => {
+        const commits = await getCommitHistory(localPath, { maxCount: (args.maxCount as number) ?? 20, branch: args.branch as string });
         const contributors = await getContributors(localPath);
         return { commits, contributors };
       };
-      const result = args.localPath ? await fn(args.localPath) : await withClone(args.repoUrl, args.branch, fn);
+      const result = args.localPath ? await fn(args.localPath as string) : await withClone(args.repoUrl as string, args.branch as string, fn);
       return json(result);
     }
 
     case "file_info": {
       const r = await doAnalyze(args);
-      const mod = resolveFile(args.filePath, r.repository);
+      const mod = resolveFile(args.filePath as string, r.repository);
       return json({
         moduleId: mod.id, filePath: mod.file.relativePath,
-        exports: mod.exports.map(e => ({ name: e.name, kind: e.kind })),
-        imports: mod.imports.map(i => ({ source: i.source, names: i.names })),
-        calls: mod.calls.map(c => c.name),
+        exports: mod.exports.map((e: any) => ({ name: e.name, kind: e.kind })),
+        imports: mod.imports.map((i: any) => ({ source: i.source, names: i.names })),
+        calls: mod.calls.map((c: any) => c.name),
         dependencies: listDependencyTargets(r.repository, mod.id),
         consumers: listDirectConsumerTargets(r.repository, mod.id),
       });
     }
 
     case "dsl": {
-      return json(await runScriptSource(args.source));
+      return json(await runScriptSource(args.source as string));
     }
 
     case "config": {
@@ -581,28 +580,26 @@ async function handleTool(name, args) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Server
+// Public API — called by `arclux mcp` CLI command
 // ──────────────────────────────────────────────────────────────────────────
-const server = new Server(
-  { name: "arclux", version: "0.2.0" },
-  { capabilities: { tools: {}, resources: {} } }
-);
+export async function startMcpServer(): Promise<void> {
+  const server = new Server(
+    { name: "arclux", version: "0.2.0" },
+    { capabilities: { tools: {}, resources: {} } }
+  );
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  try {
-    return await handleTool(request.params.name, request.params.arguments ?? {});
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return { content: [{ type: "text", text: "Error: " + message }], isError: true };
-  }
-});
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    try {
+      return await handleTool(request.params.name, request.params.arguments ?? {});
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { content: [{ type: "text" as const, text: "Error: " + message }], isError: true };
+    }
+  });
 
-async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("ARCLUX MCP server running on stdio - 21 tools ready");
 }
-
-main().catch((error) => { console.error("Fatal error:", error); process.exit(1); });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.20
         version: 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -57,6 +60,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.7.0
         version: 1.7.0
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -166,6 +172,19 @@ importers:
         version: 4.3.3
       typescript:
         specifier: ^5
+        version: 5.9.3
+
+  packages/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.43
+      typescript:
+        specifier: ^5.0.0
         version: 5.9.3
 
 packages:
@@ -2231,6 +2250,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4681,6 +4701,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.0.12(hono@4.12.32)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.6.1(express@5.2.1)
+      hono: 4.12.32
+      jose: 6.2.5
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -8095,6 +8137,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "apps/*"
+  - "packages/*"

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -52,6 +52,7 @@ const external = [
   "commander",
   "@clack/prompts",
   "web-tree-sitter",
+  "@modelcontextprotocol/sdk",
   // Node builtins are always external.
   "node:*",
   "fs",

--- a/scripts/mcp-server.mjs
+++ b/scripts/mcp-server.mjs
@@ -1,0 +1,608 @@
+// Copyright 2026 Mikatoshi
+// Licensed under the Apache License, Version 2.0
+//
+// ARCLUX MCP Server — exposes the full analysis engine as MCP tools.
+// Run with: npx tsx scripts/mcp-server.mjs
+// Client config: { "arclux": { "command": "npx", "args": ["tsx", "scripts/mcp-server.mjs"] } }
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+// ── engine ────────────────────────────────────────────────────────────────
+import { analyzeRepository } from "../packages/engine/pipeline.ts";
+import { runDoctor } from "../packages/engine/runDoctor.ts";
+import { runAllChecks } from "../packages/engine/contract.ts";
+import { computeHealthScore } from "../packages/engine/healthScore.ts";
+
+// ── graph ─────────────────────────────────────────────────────────────────
+import { buildCallGraph } from "../packages/graph/buildCallGraph.ts";
+import { buildDependencyGraph } from "../packages/graph/buildDependencyGraph.ts";
+import { buildExportGraph } from "../packages/graph/buildExportGraph.ts";
+import { buildFolderGraph } from "../packages/graph/buildFolderGraph.ts";
+
+// ── impact ────────────────────────────────────────────────────────────────
+import { buildImpactTree } from "../packages/impact/buildImpactTree.ts";
+import { calculateAffectedFiles } from "../packages/impact/calculateAffectedFiles.ts";
+import { calculateAffectedRoutes } from "../packages/impact/calculateAffectedRoutes.ts";
+import { traceConsumers } from "../packages/impact/traceConsumers.ts";
+import { traceDependencies } from "../packages/impact/traceDependencies.ts";
+
+// ── security ──────────────────────────────────────────────────────────────
+import { analyzeRepositorySecurity } from "../packages/security-analysis/integration.ts";
+import { mapAttackSurface } from "../packages/correlation/AttackSurfaceMapper.ts";
+
+// ── search ────────────────────────────────────────────────────────────────
+import { buildSearchIndex } from "../packages/search/SearchIndex.ts";
+import { search } from "../packages/search/SearchEngine.ts";
+
+// ── diagnostics ───────────────────────────────────────────────────────────
+import { runDiagnostics } from "../packages/diagnostics/DiagnosticEngine.ts";
+import { getFixSuggestions } from "../packages/diagnostics/FixSuggestion.ts";
+
+// ── diff ──────────────────────────────────────────────────────────────────
+import { computeArchitecturalDiff } from "../packages/diff/architecturalDiff.ts";
+
+// ── git ───────────────────────────────────────────────────────────────────
+import { cloneRepository } from "../packages/git/cloneRepository.ts";
+import { cleanupRepository } from "../packages/git/cleanupRepository.ts";
+import { getBranches } from "../packages/git/getBranches.ts";
+import { detectDefaultBranch } from "../packages/git/detectDefaultBranch.ts";
+import { getCommitHistory } from "../packages/git/getCommitHistory.ts";
+import { getContributors } from "../packages/git/getContributors.ts";
+
+// ── editor ────────────────────────────────────────────────────────────────
+import { openFile, listDependencyTargets, listDirectConsumerTargets } from "../packages/editor/CodeNavigator.ts";
+
+// ── dsl ───────────────────────────────────────────────────────────────────
+import { runScriptSource } from "../packages/dsl/script.ts";
+
+// ── detectors (for the `detect` tool) ─────────────────────────────────────
+import { detectCircularDependency } from "../packages/detectors/detectCircularDependency.ts";
+import { detectUnusedExports } from "../packages/detectors/detectUnusedExports.ts";
+import { detectOrphanFiles } from "../packages/detectors/detectOrphanFiles.ts";
+import { detectOrphanIntegration } from "../packages/detectors/detectOrphanIntegration.ts";
+import { detectLargeModules } from "../packages/detectors/detectLargeModules.ts";
+import { detectDuplicateModules } from "../packages/detectors/detectDuplicateModules.ts";
+import { detectSharedModules } from "../packages/detectors/detectSharedModules.ts";
+import { detectIndexFiles } from "../packages/detectors/detectIndexFiles.ts";
+import { detectLayerViolation } from "../packages/detectors/detectLayerViolation.ts";
+import { detectDeadCode } from "../packages/detectors/detectDeadCode.ts";
+import { detectAmbiguousSymbolResolution } from "../packages/detectors/detectAmbiguousSymbolResolution.ts";
+import { detectComponentConvention } from "../packages/detectors/detectComponentConvention.ts";
+import { detectFeatureStructure } from "../packages/detectors/detectFeatureStructure.ts";
+import { detectMissingExports } from "../packages/detectors/detectMissingExports.ts";
+import { detectRepositoryPattern } from "../packages/detectors/detectRepositoryPattern.ts";
+import { detectRouteConvention } from "../packages/detectors/detectRouteConvention.ts";
+import { detectStoryConvention } from "../packages/detectors/detectStoryConvention.ts";
+import { detectTestConvention } from "../packages/detectors/detectTestConvention.ts";
+import { detectUnusedFiles } from "../packages/detectors/detectUnusedFiles.ts";
+import { detectEntryPoints } from "../packages/detectors/detectEntryPoints.ts";
+
+// ── cache ─────────────────────────────────────────────────────────────────
+import { getCacheStats, clearAllCaches } from "../packages/cache/CacheProvider.ts";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Detector registry — name => function(repository) => finding[]
+// ──────────────────────────────────────────────────────────────────────────
+const DETECTORS = {
+  circular:               detectCircularDependency,
+  unused_exports:         detectUnusedExports,
+  orphan_files:           detectOrphanFiles,
+  orphan_integration:     detectOrphanIntegration,
+  large_modules:          detectLargeModules,
+  duplicate_modules:      detectDuplicateModules,
+  shared_modules:         detectSharedModules,
+  index_files:            detectIndexFiles,
+  layer_violation:        detectLayerViolation,
+  dead_code:              detectDeadCode,
+  ambiguous_symbols:      detectAmbiguousSymbolResolution,
+  component_convention:   detectComponentConvention,
+  feature_structure:      detectFeatureStructure,
+  missing_exports:        detectMissingExports,
+  repository_pattern:     detectRepositoryPattern,
+  route_convention:       detectRouteConvention,
+  story_convention:       detectStoryConvention,
+  test_convention:        detectTestConvention,
+  unused_files:           detectUnusedFiles,
+  entry_points:           detectEntryPoints,
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────
+function analyzeOpts(args) {
+  if (args.localPath) return { localPath: args.localPath };
+  if (args.repoUrl) return { repoUrl: args.repoUrl, branch: args.branch };
+  throw new Error("Provide repoUrl or localPath");
+}
+
+async function doAnalyze(args) {
+  return analyzeRepository(analyzeOpts(args));
+}
+
+function json(data) {
+  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+}
+
+async function withClone(repoUrl, branch, fn) {
+  const clone = await cloneRepository({ url: repoUrl, branch });
+  try {
+    return await fn(clone.localPath);
+  } finally {
+    await cleanupRepository(clone.localPath);
+  }
+}
+
+function resolveFile(moduleId, repository) {
+  const mod = repository.getModuleById(moduleId)
+    ?? repository.getModuleByPath(moduleId);
+  if (!mod) throw new Error("Module not found: " + moduleId);
+  return mod;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tool definitions (21 tools)
+// ──────────────────────────────────────────────────────────────────────────
+const TOOLS = [
+  {
+    name: "analyze",
+    description: "Full analysis pipeline - parse all files, build index, build dependency graph, detect frameworks. Returns meta, moduleCount, graph stats, scanSummary, dependencies.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string", description: "Git URL to clone and analyze" },
+        localPath: { type: "string", description: "Local filesystem path to analyze (no clone)" },
+        branch:    { type: "string", description: "Branch to clone (default: main)" },
+      },
+    },
+  },
+  {
+    name: "doctor",
+    description: "Run all 20 architecture detectors. Returns findings with checkId, severity, filePath, message.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "health",
+    description: "Compute health score with 4 categories (structural, hygiene, conventions, info). Returns overall score 0-100 + per-category breakdown.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "verify",
+    description: "Run 10 core detectors + 14 framework rules, return PASS/FAIL verdict.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "diagnose",
+    description: "Run diagnostic adapters (circular, dead code, ambiguous symbols), attach impact context, return events with fix suggestions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "callgraph",
+    description: "Build function call graph. Returns nodes (functions) and edges (caller to callee).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "dependency_graph",
+    description: "Build import dependency graph. Returns nodes and edges.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "export_graph",
+    description: "Build export relationship graph - who exports what, who imports where from.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "folder_graph",
+    description: "Build directory tree structure with file counts per folder.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "impact",
+    description: "Full impact analysis for a file - dependency tree, affected files list, affected routes.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        moduleId:  { type: "string", description: "Relative file path or moduleId" },
+      },
+      required: ["moduleId"],
+    },
+  },
+  {
+    name: "impact_consumers",
+    description: "Trace all direct and transitive consumers of a module (who calls this).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        moduleId:  { type: "string" },
+      },
+      required: ["moduleId"],
+    },
+  },
+  {
+    name: "impact_dependencies",
+    description: "Trace all direct and transitive dependencies of a module (what does this call).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        moduleId:  { type: "string" },
+      },
+      required: ["moduleId"],
+    },
+  },
+  {
+    name: "security",
+    description: "Full security analysis - hardcoded secrets, unsafe patterns, trust boundaries, cross-boundary calls, dependency risk. Includes attack surface map.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+  {
+    name: "search",
+    description: "Fuzzy search for symbols, files, or code patterns across the repository.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        query:     { type: "string", description: "Search query" },
+        limit:     { type: "number", description: "Max results (default 50)" },
+      },
+      required: ["query"],
+    },
+  },
+  {
+    name: "detect",
+    description: "Run specific detector(s) by name. Available: circular, unused_exports, orphan_files, orphan_integration, large_modules, duplicate_modules, shared_modules, index_files, layer_violation, dead_code, ambiguous_symbols, component_convention, feature_structure, missing_exports, repository_pattern, route_convention, story_convention, test_convention, unused_files, entry_points. Use [\"all\"] for all.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        detectors: {
+          type: "array",
+          items: { type: "string" },
+          description: "Detector names to run",
+        },
+      },
+      required: ["detectors"],
+    },
+  },
+  {
+    name: "diff",
+    description: "Architectural diff between two git refs - lists changed files and traces affected consumers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        refA:      { type: "string", description: "First git ref (commit, tag, branch)" },
+        refB:      { type: "string", description: "Second git ref" },
+      },
+      required: ["refA", "refB"],
+    },
+  },
+  {
+    name: "branches",
+    description: "List remote branches for a repository. Returns branch names and default branch.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl: { type: "string", description: "Git URL" },
+      },
+      required: ["repoUrl"],
+    },
+  },
+  {
+    name: "history",
+    description: "Get commit history and contributors. Clones repo shallowly, reads git log, then cleans up.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        maxCount:  { type: "number", description: "Max commits (default 20)" },
+      },
+    },
+  },
+  {
+    name: "file_info",
+    description: "Get module info for a file - exports, imports, calls, dependency targets, and direct consumers.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+        filePath:  { type: "string", description: "Relative file path in the repo" },
+      },
+      required: ["filePath"],
+    },
+  },
+  {
+    name: "dsl",
+    description: "Execute an ARCLUX DSL script. The script should call analyze(\"url\") or analyze(\"/path\") internally.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        source: { type: "string", description: "DSL source code" },
+      },
+      required: ["source"],
+    },
+  },
+  {
+    name: "config",
+    description: "Detect repository metadata - name, frameworks, package manager, root path.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        repoUrl:   { type: "string" },
+        localPath: { type: "string" },
+        branch:    { type: "string" },
+      },
+    },
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tool handlers
+// ──────────────────────────────────────────────────────────────────────────
+async function handleTool(name, args) {
+  switch (name) {
+
+    case "analyze": {
+      const r = await doAnalyze(args);
+      return json({
+        meta: r.meta, moduleCount: r.moduleCount, scanSummary: r.scanSummary,
+        graph: { nodeCount: r.graph.nodes.length, edgeCount: r.graph.edges.length },
+        dependencies: r.dependencies,
+      });
+    }
+
+    case "doctor": {
+      const r = await doAnalyze(args);
+      return json(runDoctor(r.repository));
+    }
+
+    case "health": {
+      const r = await doAnalyze(args);
+      const dr = runDoctor(r.repository);
+      return json(computeHealthScore(dr.findings, r.moduleCount));
+    }
+
+    case "verify": {
+      const r = await doAnalyze(args);
+      const result = runAllChecks(r.repository);
+      return json({ verdict: result.errorCount === 0 ? "PASS" : "FAIL", ...result });
+    }
+
+    case "diagnose": {
+      const r = await doAnalyze(args);
+      const findings = runDiagnostics(r.repository);
+      return json({ findings, fixes: getFixSuggestions(findings) });
+    }
+
+    case "callgraph": {
+      const r = await doAnalyze(args);
+      const g = buildCallGraph(r.repository);
+      return json({ nodes: g.nodes, edges: g.edges });
+    }
+
+    case "dependency_graph": {
+      const r = await doAnalyze(args);
+      const g = buildDependencyGraph(r.repository);
+      return json({ nodes: g.nodes, edges: g.edges });
+    }
+
+    case "export_graph": {
+      const r = await doAnalyze(args);
+      const g = buildExportGraph(r.repository);
+      return json({ nodes: g.nodes, edges: g.edges });
+    }
+
+    case "folder_graph": {
+      const r = await doAnalyze(args);
+      return json(buildFolderGraph(r.repository));
+    }
+
+    case "impact": {
+      const r = await doAnalyze(args);
+      return json({
+        tree: buildImpactTree(r.repository, args.moduleId),
+        affectedFiles: calculateAffectedFiles(r.repository, args.moduleId),
+        affectedRoutes: calculateAffectedRoutes(r.repository, args.moduleId),
+      });
+    }
+
+    case "impact_consumers": {
+      const r = await doAnalyze(args);
+      return json(traceConsumers(r.repository, args.moduleId));
+    }
+
+    case "impact_dependencies": {
+      const r = await doAnalyze(args);
+      return json(traceDependencies(r.repository, args.moduleId));
+    }
+
+    case "security": {
+      const r = await doAnalyze(args);
+      const sec = analyzeRepositorySecurity(r.repository, r.meta.rootPath);
+      const graph = buildCallGraph(r.repository);
+      return json({ security: sec, attackSurface: mapAttackSurface(r.repository, graph) });
+    }
+
+    case "search": {
+      const r = await doAnalyze(args);
+      const idx = buildSearchIndex(r.repository);
+      return json(search(idx, args.query, { limit: args.limit ?? 50 }));
+    }
+
+    case "detect": {
+      const r = await doAnalyze(args);
+      const names = args.detectors ?? [];
+      const runAll = names.includes("all");
+      const targets = runAll ? Object.keys(DETECTORS) : names;
+      const results = {};
+      let total = 0;
+      for (const n of targets) {
+        const fn = DETECTORS[n];
+        if (!fn) {
+          results[n] = { error: "Unknown detector: " + n + ". Available: " + Object.keys(DETECTORS).join(", ") };
+          continue;
+        }
+        const findings = fn(r.repository);
+        results[n] = { count: findings.length, findings };
+        total += findings.length;
+      }
+      return json({ totalFindings: total, detectors: results });
+    }
+
+    case "diff": {
+      const r = await doAnalyze(args);
+      return json(computeArchitecturalDiff(r.repository, r.meta.rootPath, args.refA, args.refB));
+    }
+
+    case "branches": {
+      return json({
+        branches: getBranches(args.repoUrl),
+        defaultBranch: detectDefaultBranch(args.repoUrl),
+      });
+    }
+
+    case "history": {
+      const fn = async (localPath) => {
+        const commits = await getCommitHistory(localPath, { maxCount: args.maxCount ?? 20, branch: args.branch });
+        const contributors = await getContributors(localPath);
+        return { commits, contributors };
+      };
+      const result = args.localPath ? await fn(args.localPath) : await withClone(args.repoUrl, args.branch, fn);
+      return json(result);
+    }
+
+    case "file_info": {
+      const r = await doAnalyze(args);
+      const mod = resolveFile(args.filePath, r.repository);
+      return json({
+        moduleId: mod.id, filePath: mod.file.relativePath,
+        exports: mod.exports.map(e => ({ name: e.name, kind: e.kind })),
+        imports: mod.imports.map(i => ({ source: i.source, names: i.names })),
+        calls: mod.calls.map(c => c.name),
+        dependencies: listDependencyTargets(r.repository, mod.id),
+        consumers: listDirectConsumerTargets(r.repository, mod.id),
+      });
+    }
+
+    case "dsl": {
+      return json(await runScriptSource(args.source));
+    }
+
+    case "config": {
+      const r = await doAnalyze(args);
+      return json({ meta: r.meta, dependencies: r.dependencies });
+    }
+
+    default:
+      throw new Error("Unknown tool: " + name);
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Server
+// ──────────────────────────────────────────────────────────────────────────
+const server = new Server(
+  { name: "arclux", version: "0.2.0" },
+  { capabilities: { tools: {}, resources: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  try {
+    return await handleTool(request.params.name, request.params.arguments ?? {});
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { content: [{ type: "text", text: "Error: " + message }], isError: true };
+  }
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("ARCLUX MCP server running on stdio - 21 tools ready");
+}
+
+main().catch((error) => { console.error("Fatal error:", error); process.exit(1); });


### PR DESCRIPTION
## `arclux mcp` — Production-Grade MCP Integration

Integrates the 21-tool MCP server directly into the ARCLUX CLI.

### What changed

| File | Action |
|------|--------|
| `packages/mcp/src/index.ts` | 21-tool MCP server (exports `startMcpServer()`) |
| `packages/mcp/package.json` | Workspace package with `@modelcontextprotocol/sdk` |
| `apps/cli/commands/mcp.ts` | `arclux mcp` CLI subcommand |
| `apps/cli/index.ts` | Registered alongside 22 existing commands |
| `apps/cli/package.json` | Added `@modelcontextprotocol/sdk` dependency |
| `scripts/build-cli.mjs` | Added SDK to esbuild externals |
| `pnpm-workspace.yaml` | Added `packages/*` to workspace |
| `scripts/mcp-server.mjs` | Removed (replaced by proper CLI integration) |

### Usage

```bash
# Direct
npx arclux mcp

# opencode.json / claude_desktop_config.json
{
  "mcpServers": {
    "arclux": { "command": "npx", "args": ["arclux", "mcp"] }
  }
}
```

### 21 MCP tools

| Category | Tools |
|----------|-------|
| Core | analyze, doctor, health, verify, diagnose |
| Graph | callgraph, dependency_graph, export_graph, folder_graph |
| Impact | impact, impact_consumers, impact_dependencies |
| Security | security (with attack surface) |
| Search | search (fuzzy) |
| Detectors | detect (20 detectors by name, or ["all"]) |
| Git | diff, branches, history |
| Editor | file_info (module + deps + consumers) |
| DSL | dsl (execute .arclux scripts) |
| Config | config (repo metadata) |

### Verified

`tools/list` returns all 21 tools via JSON-RPC stdio. esbuild bundles everything into `dist/arclux.mjs`.

### Build

Run `pnpm build:cli` after merge to regenerate the bundled binary.
