### PR TITLE
docs: log MCP server, per-file cache, npm publish progress

### DIFF
--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -824,3 +824,9 @@ DaemonRepositoryWatcher now routes every analysis trigger through packages/sched
 **Status:** Done
 
 New CLI command 'arclux exec <cmd> [args...]' (apps/cli/commands/exec.ts) runs commands through packages/terminal's TerminalManager -- sandbox capability checks + session recording (issue #351 layer). TerminalManager was built and tested (tests/terminal.test.ts, 15 cases) but had zero production consumers; this wires it to the CLI. Also confirmed packages/acquisition IS wired (remote-analysis/analyzeRemoteSource.ts imports createRepositoryAcquirer -- wired via relative path so earlier consumer greps missed it); the remaining stub packages (boundaries/adapters/observation/web-intake/package-manager) are intentionally kept -- they are planned work, not dead code. Full suite 580/580, typecheck clean.
+
+## 2026-08-26 — Per-file incremental cache (PR #562)
+
+**Status:** Done
+
+New packages/incremental with Cell/Database/Query classes for per-file cache invalidation. File content hashing via xxhash, disk persistence, TTL expiry. Built and verified standalone but buildIndex still does full rebuild — watchRepository wraps pipeline API coarsely. Per-file incremental is deferred (decision #6).

--- a/progres/status-infra.md
+++ b/progres/status-infra.md
@@ -565,3 +565,30 @@ ABOUT.md is no longer a feature list — it's a map: two-layer positioning (inte
   branch switches eat each other's uncommitted work. Second session
   now works in a separate clone (/root/arclux-pg) — port 3000
   conflicts were dev servers from BOTH sessions.
+
+## 2026-08-26 — MCP server: 32 tools, registry-driven auto-evolution (PRs #563-#566)
+
+**Status:** Done
+
+Built ARCLUX MCP server from scratch across 4 PRs:
+- #563: Initial rewrite — 21 tools covering full engine (analyze/doctor/health/verify/diagnose, 4 graph tools, 3 impact tools, security, search, detect, diff, branches, history, file_info, dsl, config)
+- #564: CLI integration — 'arclux mcp' subcommand, esbuild bundle, @modelcontextprotocol/sdk wired
+- #565: Expanded to 30 tools — parse_file, detect_language, resolve_routes/components/hooks/providers, run_rules, daemon_status, db_repos/db_analyses, semantic_diff
+- #566: Auto-evolution fixes — runRules was BROKEN (passed [] never ran rules), parse_file standalone via Compiler API, dynamic tool descriptions from registries
+
+Key gotchas:
+- web-tree-sitter WASM loading blocks MCP server startup if parsers imported at top level — tree-sitter parsers MUST be lazy-loaded
+- MCP protocol requires initialize → notifications/initialized → tools/list (not just initialize)
+- nodeRequire.resolve() can't be trusted in webpack bundles — use process.cwd() walkup
+- esbuild externals must include @modelcontextprotocol/sdk or it gets bundled incorrectly
+- pnpm workspace.yaml must include packages/* or workspace deps fail to resolve
+
+Final state: 32 tools, 20 detectors, 14 rules, 25 parsers — all registry-driven.
+Adding a new detector: 1 import + 1 map entry → auto-appears in tool description.
+Adding a new rule: 1 import + 1 entry in ALL_RULES → auto-wired to run_rules.
+
+## 2026-08-26 — npm publish-ready: arclux on npm (PR #561)
+
+**Status:** Done
+
+Single-file CLI bundle (apps/cli/dist/arclux.mjs, ~10MB) via esbuild. Package name 'arclux' confirmed free on npm. ships dist/ + wasms/ (tree-sitter grammars). bin: arclux. engines: node>=20. prepublishOnly runs build-cli.mjs. Verified: pnpm install works, arclux --version outputs 0.2.0.


### PR DESCRIPTION
Logs progress for work done in this session:

- MCP server: 32 tools, 4 PRs (#563-#566), registry-driven auto-evolution
- Per-file incremental cache: PR #562
- npm publish-ready: PR #561

Also created Getting Started issue (#567).