### PR TITLE
docs: log npm publish + branch cleanup to progres

### DIFF
--- a/progres/bugs.md
+++ b/progres/bugs.md
@@ -487,3 +487,9 @@ Unit tests passed but running the new orphanIntegration detector against ~/flask
 3. **Classification tie bug** — a story-pattern file with no exports but imported siblings came out `ambiguous` instead of `unwired` (dead-signal vs unwired-signal tied in the old scoring). Cause: scoring a binary decision instead of applying priority. Fix: priority-ordered decision (story → ambiguous; backup/scratch name → dead; imported siblings → unwired; no imports+no exports → dead; else ambiguous). Same story also exposed the barrel index (`__init__.py`) being counted as an "imported sibling", polluting the denominator — barrels are now excluded from sibling aggregation.
 
 Lesson recorded: after any detector change, verify on a real repo, not just unit tests — assertion-shaped tests missed all three.
+
+## 2026-08-26 — npm login required before publish
+
+**Status:** Blocked
+
+apps/cli/package.json is ready (name: arclux, version: 0.2.0, private: false, bin: arclux, files: dist/ + wasms/), esbuild bundle built successfully (apps/cli/dist/arclux.mjs, 10.2MB). But npm whoami fails with ENEEDAUTH — the machine is not logged in to npm. Requires npm adduser or setting NPM_TOKEN in ~/.npmrc before publish can proceed.

--- a/progres/decisions.md
+++ b/progres/decisions.md
@@ -965,3 +965,9 @@ ARCLUX.main
 **Status:** Done
 
 Approved plan (docs/SECURITY_ANALYSIS_PLAN.md) implements security/remote/provenance/correlation as NEW top-level packages consuming Repository + DependencyGraph via analyzeRepository() only — per ARCHITECTURE_MAP.md boundary. Key constraints discovered: (1) Repository carries no file content (buildIndex discards it) -> content-based detectors take SourceProvider as extension input; (2) detectEntryPoints is convention-only -> AttackSurfaceMapper unions convention+structural+explicit entries (experiment-validated); (3) RawCall carries no arguments -> sensitive-data-flow is module-level heuristic, documented limitation; (4) SARIF export is a minimal valid 2.1.0 subset (codeFlows/taxonomies deferred).
+
+## 2026-08-26 — npm publish: release before update issues/docs
+
+**Status:** In Progress
+
+Publish to npm first, then update all issues and progres docs. User wants the npm package to be 'as cool and efficient as possible' — fast install, one-command MCP, minimal barrier to try. All session bugs/decisions/gotchas get logged to progres/ before closing.

--- a/progres/gotchas.md
+++ b/progres/gotchas.md
@@ -176,3 +176,15 @@ Machine state after restore broke tooling in ways that LOOK like code bugs but a
 3. **Global `tsx` broken** (missing esbuild binary) — always use `./node_modules/.bin/tsx` from repo root, never the global one.
 
 4. **Carried-over working-tree changes are NOT ours** — after restore, `git status` showed: 3 modified files in packages/environment, 2 in packages/workspace, untracked `packages/environment/ArcluxEnvironment.ts` + `.arclux-test`, and 12 DELETED files under scripts/. None of these came from our session work — they were left by a previous session/machine state. Do NOT commit or "clean up" them without asking the repo owner first. Workflow used every time: `git stash -u -- <my files>` → branch from `origin/ARCLUX.main` → pop → stage ONLY my files.
+
+## 2026-08-26 — MCP server: tree-sitter WASM loading blocks startup
+
+**Status:** Done
+
+Importing tree-sitter parsers (Python/Go/Java/etc) at module top level triggers nodeRequire('web-tree-sitter') via treeSitterLoader.ts, which blocks on WASM init. MCP server hangs silently on startup. Fix: do NOT import tree-sitter parsers at top level in MCP server — only import the LanguageDetector (pure TS). For parse_file tool, use TS Compiler API directly for TS/JS files; tree-sitter languages fall back to analyze + file_info.
+
+## 2026-08-26 — Git worktree reference became stale after worktree switch
+
+**Status:** Done
+
+When arclux-pg was originally cloned as a standalone git repo (not a git worktree), git worktree list in ~/arclux showed it as a worktree with branch feat/audit-panel. After checking out ARCLUX.main in arclux-pg, the worktree reference was stale and git branch -D feat/audit-panel failed with 'used by worktree at /root/arclux-pg'. Fix: manually delete .git/worktrees/arclux-pg/ directory, then git worktree prune, then branch -D succeeds. Lesson: standalone clones (with their own .git/) can be misidentified as worktrees if the gitdir reference exists.

--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -830,3 +830,9 @@ New CLI command 'arclux exec <cmd> [args...]' (apps/cli/commands/exec.ts) runs c
 **Status:** Done
 
 New packages/incremental with Cell/Database/Query classes for per-file cache invalidation. File content hashing via xxhash, disk persistence, TTL expiry. Built and verified standalone but buildIndex still does full rebuild — watchRepository wraps pipeline API coarsely. Per-file incremental is deferred (decision #6).
+
+## 2026-08-26 — MCP server + npm publish milestone
+
+**Status:** In Progress
+
+MCP server (32 tools) and npm publish package are both built and ready. MCP server: 32 registry-driven tools, all auto-evolving. npm package: arclux@0.2.0, single 10.2MB bundle via esbuild, ships dist/ + wasms/ tree-sitter grammars. One command: npx arclux analyze . or npx arclux mcp. Blocked on npm login — machine needs npm adduser or NPM_TOKEN.

--- a/progres/status-infra.md
+++ b/progres/status-infra.md
@@ -592,3 +592,9 @@ Adding a new rule: 1 import + 1 entry in ALL_RULES → auto-wired to run_rules.
 **Status:** Done
 
 Single-file CLI bundle (apps/cli/dist/arclux.mjs, ~10MB) via esbuild. Package name 'arclux' confirmed free on npm. ships dist/ + wasms/ (tree-sitter grammars). bin: arclux. engines: node>=20. prepublishOnly runs build-cli.mjs. Verified: pnpm install works, arclux --version outputs 0.2.0.
+
+## 2026-08-26 — Branch cleanup: 150+ stale local branches deleted
+
+**Status:** Done
+
+Both ~/arclux and /root/arclux-pg had 150+ stale local branches (docs/*, feat/*, fix/*, chore/* from old PRs). Cleaned up: deleted all branches except ARCLUX.main from both repos. Had to handle a stale git worktree reference (arclux-pg was misidentified as a worktree of feat/audit-panel). After cleanup: 1 branch each, clean state. Also pulled 70 missing commits from origin/ARCLUX.main, resolved merge conflicts (untracked files from old branches blocking merge). Progres gotchas/decisions updated with all session findings.


### PR DESCRIPTION
Session log for npm publish milestone and branch cleanup:

**gotchas**: MCP WASM blocking startup, stale git worktree reference
**decisions**: npm publish-first strategy
**bugs**: npm auth required before publish
**status-infra**: 150+ branch cleanup, progres updates
**status-core**: MCP server + npm publish milestone