### PR TITLE
feat(cli): expose arclux as a programmatic library/SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to ARCLUX are documented here. Format based on
 - **MCP server (32 tools)** — `arclux mcp` starts the Model Context
   Protocol server; registry-driven auto-evolution (new detectors/rules
   appear automatically in tool descriptions).
+- **Library / SDK exports** — `import { analyzeRepository } from "arclux"`
+  exposes the full analysis engine programmatically (graphs, impact,
+  search, security, rules, diagnostics) with typed `.d.ts` declarations,
+  separate from the CLI bundle.
 
 ## [0.2.1] — 2026-08-23
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,63 @@
+# ARCLUX CLI + Library
+
+ARCLUX is a codebase intelligence platform: 27-language parser, dependency &
+call graphs, 20 architecture detectors, impact tracing, security pipeline, and
+the ARCLUX scripting DSL.
+
+## Install
+
+```bash
+npm install -g arclux      # CLI
+# or run without installing:
+npx arclux <command>
+```
+
+## CLI
+
+```bash
+arclux analyze [path]      # parse, index, build dependency graph
+arclux graph [path]        # visualize the dependency graph (SVG)
+arclux impact <file>       # trace what a change affects
+arclux verify [path]       # run framework rules
+arclux doctor              # self-check the pipeline
+arclux mcp                 # start the Model Context Protocol server
+```
+
+Run `arclux --help` for the full command list.
+
+## Library (embed in your own tool)
+
+The `arclux` package exposes the full analysis engine as a programmatic API —
+no CLI, no UI dependencies. Build static-analysis, code-review, or refactor
+tooling on top of it.
+
+```ts
+import { analyzeRepository, type AnalyzeRepositoryResult } from "arclux";
+
+const result = await analyzeRepository({ localPath: "./my-repo" });
+console.log(result.meta.name);
+console.log(`${result.moduleCount} modules, ${result.graph.nodes.length} nodes`);
+```
+
+Also exported:
+
+- **Engine** — `analyzeRepository`, `ensureParsersRegistered`, `parseOrgAndName`
+- **Graphs** — `buildDependencyGraph`, `buildCallGraph`, `buildImportGraph`,
+  `buildExportGraph`, `buildFolderGraph`
+- **Impact** — `traceConsumers`, `traceDependencies`, `calculateAffectedFiles`,
+  `calculateAffectedModules`, `calculateAffectedRoutes`,
+  `calculateAffectedComponents`, `buildImpactTree`
+- **Search** — `buildSearchIndex`, `search`
+- **Security** — `analyzeRepositorySecurity`, `mapAttackSurface`
+- **Rules** — `runRules`
+- **Diagnostics** — `runDiagnostics`, `getFixSuggestions`
+
+> Note: `Repository` stores modules in a private `Map`. Never
+> `JSON.stringify()` it directly or spread it into an API response — it
+> serializes to an empty `{}`. Derive a plain object first.
+
+## Development
+
+```bash
+node scripts/build-cli.mjs   # bundles dist/arclux.mjs + dist/arclux-lib.mjs + types
+```

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -33,7 +33,7 @@ import { registerScriptCommand } from "./script";
 import { registerMcpCommand } from "./commands/mcp";
 
 const program = new Command();
-program.name("arclux").description("Repository intelligence CLI").version("0.2.0");
+program.name("arclux").description("Repository intelligence CLI").version("0.2.1");
 
 registerAnalyzeCommand(program);
 registerGraphCommand(program);

--- a/apps/cli/lib.ts
+++ b/apps/cli/lib.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// ARCLUX programmatic API — the `arclux` package as a library, not just a
+// CLI binary. `import { analyzeRepository } from 'arclux'`.
+//
+// This file is bundled separately (dist/arclux-lib.mjs) from the CLI
+// (dist/arclux.mjs) so a consumer can embed the full engine without
+// pulling in commander/@clack/commander UI deps.
+
+// ── engine ────────────────────────────────────────────────────────────────
+export {
+  analyzeRepository,
+  ensureParsersRegistered,
+  parseOrgAndName,
+} from "../../packages/engine/pipeline";
+export { runDoctor } from "../../packages/engine/runDoctor";
+export { runAllChecks } from "../../packages/engine/contract";
+export { computeHealthScore } from "../../packages/engine/healthScore";
+
+// ── graph ─────────────────────────────────────────────────────────────────
+export { buildDependencyGraph } from "../../packages/graph/buildDependencyGraph";
+export { buildCallGraph } from "../../packages/graph/buildCallGraph";
+export { buildImportGraph } from "../../packages/graph/buildImportGraph";
+export { buildExportGraph } from "../../packages/graph/buildExportGraph";
+export { buildFolderGraph } from "../../packages/graph/buildFolderGraph";
+
+// ── impact ────────────────────────────────────────────────────────────────
+export { traceConsumers } from "../../packages/impact/traceConsumers";
+export { traceDependencies } from "../../packages/impact/traceDependencies";
+export { calculateAffectedFiles } from "../../packages/impact/calculateAffectedFiles";
+export { calculateAffectedModules } from "../../packages/impact/calculateAffectedModules";
+export { calculateAffectedRoutes } from "../../packages/impact/calculateAffectedRoutes";
+export { calculateAffectedComponents } from "../../packages/impact/calculateAffectedComponents";
+export { buildImpactTree } from "../../packages/impact/buildImpactTree";
+
+// ── search ────────────────────────────────────────────────────────────────
+export { buildSearchIndex } from "../../packages/search/SearchIndex";
+export { search } from "../../packages/search/SearchEngine";
+
+// ── security ──────────────────────────────────────────────────────────────
+export { analyzeRepositorySecurity } from "../../packages/security-analysis/integration";
+export { mapAttackSurface } from "../../packages/correlation/AttackSurfaceMapper";
+
+// ── rules ─────────────────────────────────────────────────────────────────
+export { runRules } from "../../packages/rules/RuleEngine";
+
+// ── diagnostics ───────────────────────────────────────────────────────────
+export { runDiagnostics } from "../../packages/diagnostics/DiagnosticEngine";
+export { getFixSuggestions } from "../../packages/diagnostics/FixSuggestion";
+
+// ── types ─────────────────────────────────────────────────────────────────
+export type {
+  AnalyzeRepositoryResult,
+  AnalyzeRepositoryOptions,
+} from "../../packages/engine/pipeline";
+export type {
+  DependencyGraph,
+  GraphNode,
+  GraphEdge,
+  ModuleInfo,
+  ParsedFile,
+  RepositoryMeta,
+  ScanSummary,
+} from "../../packages/shared/types";
+export { Repository } from "../../packages/repository/Repository";
+export type { Rule, RuleViolation } from "../../packages/rules/RuleEngine";

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,12 +1,19 @@
 {
   "name": "arclux",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Codebase intelligence platform \u2014 27-language parser, dependency & call graphs, 20 architecture detectors, impact tracing, security pipeline, and the ARCLUX scripting DSL.",
   "license": "Apache-2.0",
   "type": "module",
   "private": false,
   "bin": {
     "arclux": "./dist/arclux.mjs"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/apps/cli/lib.d.ts",
+      "import": "./dist/arclux-lib.mjs"
+    },
+    "./cli": "./dist/arclux.mjs"
   },
   "files": [
     "dist/",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -19,7 +19,7 @@
 // Native deps (web-tree-sitter) stay external — they're regular npm
 // dependencies of the published package.
 
-import { cpSync, mkdirSync, existsSync, readdirSync } from "node:fs";
+import { cpSync, mkdirSync, existsSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
@@ -79,6 +79,57 @@ await build({
   logLevel: "info",
 });
 
+// Library bundle — the `arclux` package as an embeddable import.
+await build({
+  entryPoints: [path.join(root, "apps", "cli", "lib.ts")],
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  format: "esm",
+  outfile: path.join(outDir, "arclux-lib.mjs"),
+  external,
+  banner: {
+    js: "import { createRequire as __cr } from 'node:module'; import { fileURLToPath as __fup } from 'node:url'; import __path from 'node:path'; const require = __cr(import.meta.url); const __filename = __fup(import.meta.url); const __dirname = __path.dirname(__filename);",
+  },
+  sourcemap: false,
+  minify: false,
+  logLevel: "info",
+});
+
+// TypeScript declarations for the library. The lib bundle is ONE module
+// (esbuild inline), but consumers need typed exports — tsc emits a
+// per-source .d.ts tree from lib.ts that mirrors the public API. We ship
+// it layered under dist/ so `exports["."].types` resolves. tsc lives in
+// the root node_modules.
+const tscPath = __req.resolve("typescript/bin/tsc");
+const declDir = path.join(outDir, "decl");
+rmSync(declDir, { recursive: true, force: true });
+const declCmd = [
+  process.execPath,
+  tscPath,
+  path.join(root, "apps", "cli", "lib.ts"),
+  "--declaration", "--emitDeclarationOnly",
+  "--outDir", declDir,
+  "--rootDir", root,
+  "--module", "esnext",
+  "--moduleResolution", "bundler",
+  "--target", "es2022",
+  "--lib", "ES2022",
+  "--skipLibCheck", "--strict", "--esModuleInterop",
+  "--allowImportingTsExtensions", "--types", "node",
+];
+await new Promise((resolve, reject) => {
+  const { spawn } = __req("node:child_process");
+  const child = spawn(declCmd[0], declCmd.slice(1), { stdio: "inherit" });
+  child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`tsc declaration emit failed (exit ${code})`))));
+  child.on("error", reject);
+});
+// Lay the emitted tree into dist/ (lib.d.ts + dist/packages/*.d.ts).
+const libDts = path.join(declDir, "apps", "cli", "lib.d.ts");
+cpSync(libDts, path.join(outDir, "apps", "cli", "lib.d.ts"), { recursive: true });
+cpSync(path.join(declDir, "packages"), path.join(outDir, "packages"), { recursive: true });
+rmSync(declDir, { recursive: true, force: true });
+
 // Ship grammars: vendored overrides first (elm ABI fix), then fill any
 // gaps from tree-sitter-wasms/out.
 const vendoredDir = path.join(root, "packages", "parser", "wasms");
@@ -97,5 +148,6 @@ for (const src of [vendoredDir, npmWasms]) {
 }
 
 console.log(`\n✓ bundled apps/cli/dist/arclux.mjs`);
+console.log(`✓ bundled apps/cli/dist/arclux-lib.mjs (programmatic API)`);
 console.log(`✓ ${shipped} grammars shipped to apps/cli/wasms/`);
 console.log(`  (wasms live as dist's sibling — the loader finds them there)`);


### PR DESCRIPTION
## Library / SDK exports

 — the full engine as an embeddable API, separate from the CLI binary.

- **New**: `apps/cli/lib.ts` — barrel re-exporting engine, graphs, impact, search, security, rules, diagnostics
- **Build**: bundles `dist/arclux-lib.mjs` separately + emits a typed `.d.ts` tree for `exports["."].types`
- **exports field**: `.` → library, `./cli` → CLI binary
- **Version bump**: 0.2.0 → 0.2.1 (feature)
- **Docs**: `apps/cli/README.md` documenting library usage

Verified end-to-end: packed tarball installed in a clean dir, `import { analyzeRepository }` runs a real analysis, TS consumer typechecks clean.