### PR TITLE
docs: add ARCLUX Repository War Universe blueprint

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -1,0 +1,235 @@
+# 🚀 ARCLUX — Repository War Universe
+
+> Repository adalah sumber kebenaran. ARCLUX adalah universe yang \
+> memvisualisasikan, mensimulasikan, dan memberi kehidupan pada repository.
+
+**Blueprint strategis — dibaca dengan izin** · Lihat [BLUEPRINT_LICENSE.md](BLUEPRINT_LICENSE.md) sebelum menggunakan. Draf iterasi 1.
+
+---
+
+## 0. Kompas Strategis
+
+**Satu kalimat visi:**
+> ARCLUX menjadi universe tanpa batas tempat setiap software repository
+> menjadi source of truth bagi entitas virtual (kapal) yang dapat
+> divisualisasikan, dikembangkan, ditransfer, dirusak, diperbaiki, dan
+> berjejak sejarah — dengan engine code-intelligence sebagai mesin di
+> baliknya, dan ARCLUX sebagai *canvas*, bukan konten.
+
+**3 prinsip non-negotiable:**
+1. **Repo user = source of truth.** Kapal dibangun user di repo mereka
+   (`.arclux/`), BUKAN di repo ARCLUX.
+2. **ARCLUX = canvas + mesin.** ARCLUX membangun universe/aturan/engine;
+   konten (kapal, senjata, system) 100% karya user.
+3. **Serangan tidak merusak code asli.** Damage hanya menyentuh layer
+   `.arclux/` / world-state; repo project aman. **"Repair = commit"**
+   (bukan tombol).
+
+**Struktur 3 lapis:**
+```
+ARCLUX CORE (code intelligence — SUDAH ADA / OP)
+   ├─ Parser / Indexer / Graph / Detector / Impact / Security
+   ├─ SDK / MCP / CLI / DSL          (sudah live di npm)
+   ├─ .arclux/ layer                 (BELUM ADA — titik baru)
+   │      vessel / components / systems / state
+   ├─ World Model                    (BELUM ADA — abstraksi baru)
+   └─ Developer World ↔ 3D World     (3D sudah ada; loop-nya belum)
+```
+
+---
+
+## 1. Keputusan Arsitektur
+
+Rekomendasi yang perlu dikunci sebelum eksekusi:
+
+| # | Keputusan | Rekomendasi |
+|---|---|---|
+| K1 | Siapa hitung atribut kapal | **Hybrid**: base-stat otomatis dari analisis + user extends (validated, anti-abuse) |
+| K2 | Skala pondasi | **Single-repo → 1 kapal hidup** dulu; multi-repo/war = milestone lanjutan |
+| K3 | License 3-tier | Masuk pondasi pertama (bikin transfer & kompetisi adil sejak awal) |
+| K4 | Rendering | Pakai `three` + `react-force-graph-3d` yang ada, extend jadi "kapal" |
+
+---
+
+## 2. Arsitektur Teknis
+
+### Layer A — `.arclux/` manifest (objek K1, K3)
+
+Titik baru pertama: file konfigurasi ARCLUX di dalam repo user
+(belum ada; gap teridentifikasi dari riset).
+
+```
+my-project/
+└── .arclux/
+    ├── arclux.json          # manifest: nama kapal, lisensi, override stats
+    ├── vessel/
+    │   └── *.arclux         # definisi kapal (DSL — engine DSL sudah ada & live)
+    ├── components/          # component capability (lihat Layer C)
+    ├── systems/             # subsystem def (engine/reactor/nav/defense/weapon/ai)
+    └── state/               # di-generate ARCLUX, versioned (history → provenance)
+```
+
+- Definisi kapal memakai **DSL ARCLUX** (`packages/dsl`) yang sudah live di
+  npm — user memakai bahasa yang ada, bukan bahasa baru.
+- `.arclux/state/` = world-state yang di-generate ARCLUX, tetap versioned di
+  repo user → terbawa history → nyambung ke provenance.
+
+### Layer B — World Model (abstraksi baru; objek K1, K3)
+
+Package baru (mis. `packages/universe/`):
+
+```
+WorldModel            # agregat status semua vessel + state universe
+VesselModel           # satu kapal: base-stat (engine) + override (user) + live-state
+SystemState           # per-subsystem: health/damage/degraded
+ComponentBinding      # component terpasang → capability (SDK/MCP)
+LicenseValidator      # K3: open/shared/private → authorized/unauthorized
+ProvenanceTracker     # reuse packages/provenance → asal-usul component
+DamageResolver        # simulasikan damage → lokasi modul/file yang kena
+ImpactDebugger        # damage → impact tracing → baris/fungsi yang rusak
+```
+
+**Mapping stat kapal dari analisis:**
+| Atribut kapal | Sumber dari ARCLUX |
+|---|---|
+| Armor/Integrity | `computeHealthScore` |
+| Weapons | Component terpasang + security findings |
+| Defense | Layer violations / attack surface |
+| Engine/Navigation | Graph structure (module/node/edge counts) |
+| Repair-ability | Impact tracing → file yang kena |
+
+Ini mewujudkan "makin project berharga → makin kuat", tapi terukur &
+anti-abuse (K1-C).
+
+### Layer C — Component System (objek K3)
+
+- Component = **capability nyata** dari SDK/MCP, bukan sekadar skin.
+- Setiap component: `id`, `capability` (referensi fungsi SDK), `license`,
+  `provenance`, `owner`.
+- Contoh binding:
+  - `security-scanner` → `analyzeRepositorySecurity`
+  - `impact-solver` → `calculateAffectedFiles`
+  - `route-mapper` → `mapAttackSurface`
+  - `call-graph` → `buildCallGraph`
+- **License 3-tier** (`LicenseValidator`):
+  - 🟢 Open — boleh reuse sesuai terms
+  - 🟡 Shared — butuh attribution/permission
+  - 🔴 Private — hanya owner & yang diizinkan; unauthorized → **capability
+    disabled** (bukan code rusak)
+
+### Layer D — Ingestion & Auto-Update (objek K2)
+
+- **Connect**: `arclux connect <repo-url>` (npm/CLI/MCP/SDK yang sudah live)
+  → membuat boilerplate `.arclux/`.
+- **Auto-update**: daemon (`packages/daemon/`) + watcher
+  (`packages/watcher/`) → event `analysis:updated` → update `VesselModel`
+  → push ke web.
+  - **Gap**: web belum consume SSE daemon (`/events`). Perlu bridge route
+    Next.js (`/api/universe/events`) + `EventSource` client.
+  - **Gap jangka panjang**: `watchRepository` masih full-rebuild; true
+    per-file incremental (`packages/incremental`) belum di-wire ke
+    `buildIndex`.
+
+### Layer E — 3D World (objek K2, K4)
+
+- Render hub/dashboard memakai `three` yang sudah ada.
+- 3D kapal: extend pola `GraphCanvas3D` + `GraphAuditOverlay` (terbukti bisa
+  drive scene dari luar via `fgRef`).
+- Mapping: sistem kapal → mesh 3D, health → warna/scale/partikel damage.
+- Kualitas adaptif (resolution/FPS/effects/render distance) — render di
+  client, sim tetap di world-state (FPS tidak menentukan kebenaran sim).
+
+### Layer F — Developer World → Debug
+
+- **Health Dashboard**: game-HUD + observability; tiap subsystem → health%,
+  click-through ke modul/file/baris (via `ImpactDebugger` +
+  `packages/editor/CodeNavigator` + `packages/impact/*`).
+- **"Repair = commit"**:
+  1. Damage → `DamageResolver` identifikasi modul terkait
+  2. Dev debug & update code
+  3. Commit → ARCLUX re-analyze
+  4. `VesselModel` update → health pulih
+
+### Layer G — Server/Infra (objek K3)
+
+- Sebagian besar workload di client/user runtime (render + sebagian sim).
+- Server/global cuma: identity, sync, persistence, world-events, validation,
+  permissions.
+- Persistence pakai `packages/db` + `packages/storage/RecoveryManager`.
+- Community/fleet/station/territory/hall-of-fame = milestone lanjutan.
+
+### Layer H — Business & Ecosystem
+
+- **Monetisasi**: core sudah `arclux` live di npm. Tier: free core + premium
+  SDK/MCP/enterprise + storage/history + advanced universe component.
+- **Collaborator ecosystem**: extension di atas ARCLUX (SDK, sandbox,
+  validation, publish) — tanpa write access ke core. Fondasi ada di
+  `packages/shell/plugins.ts` + `detectors.ts` (user-space).
+
+---
+
+## 3. Roadmap Milestone
+
+### Milestone 1 — "Kapal Hidup" (pondasi)
+1 repo → 1 kapal yang hidup & bisa dijelajah. Validasi loop inti (#2-4, #7-10).
+
+- `.arclux/` schema + generator (`arclux connect`)
+- World Model core (`VesselModel`, `SystemState`, stat mapping, `ComponentBinding`)
+- Health Dashboard di `apps/web` (hub 2D)
+- 3D vessel (extend `GraphCanvas3D` jadi mesh kapal sederhana)
+- License 3-tier validation (`LicenseValidator` + provenance) — K3
+- Bridge SSE daemon→web (auto-update)
+- `arclux connect` + docs
+
+**Out of scope M1:** perang menyeluruh, multi-repo universe, transfer antar
+kapal, fleet/community, hall-of-fame, global server.
+
+### Milestone 2 — "War & Damage"
+- Damage simulation + `DamageResolver` + `ImpactDebugger`
+- Component rusak → capability turun; repair = commit
+- Catastrophic damage threshold → rebuild via commit
+- Multi-repo connect + war 2 kapal (tak merusak repo asli)
+
+### Milestone 3 — "Universe Persisten"
+- Persistent world-state (server sync, identity, events)
+- Transfer component antar kapal + provenance transfer
+- Hall of Fame / history
+
+### Milestone 4 — "Ecosystem & Economy"
+- Extension Registry + publish + discovery
+- Community/fleet/station/territory
+- Economic loop penuh
+
+---
+
+## 4. Yang Sudah Ada vs Harus Dibangun
+
+| Kebutuhan | Status | Keterangan |
+|---|---|---|
+| npm CLI/MCP/SDK/DSL | ✅ ADA | `arclux` live |
+| 3D engine (`three`) | ✅ ADA | `apps/web`, `GraphCanvas3D` |
+| Scene drive dari luar (`fgRef`) | ✅ ADA | `GraphAuditOverlay` |
+| Daemon + SSE live-push | 🟡 | daemon ada; web belum consume SSE |
+| Persistensi + history trend | ✅ ADA | `AnalysisRecord` |
+| Provenance | 🟡 | `ProvenanceRecord` ada; `Revision/Snapshot` stub |
+| User-space plugin/detector | ✅ ADA | `packages/shell/plugins.ts` |
+| Impact tracing → debug map | ✅ ADA | `packages/impact/*` |
+| Crash-safe storage | ✅ ADA | `RecoveryManager` |
+| Config `.arcluxrc` di repo user | ❌ BELUM | titik baru |
+| World Model / VesselModel | ❌ BELUM | abstraksi baru |
+| License validation | ❌ BELUM | bikin baru |
+| Damage/simulation engine | ❌ BELUM | bikin baru |
+| Global server | ❌ BELUM | baru di M3+ |
+| True per-file incremental | 🟡 | built, belum di-wire ke `buildIndex` |
+
+---
+
+## 5. Risiko & Pertanyaan Terbuka
+
+1. **Anti-abuse & fairness (K1-C):** gimana user extends base-stat tanpa jadi
+   pincang? Butuh rule: override cap / atribut yang tak bisa diubah.
+2. **Validasi sentral vs lokal:** untuk kompetisi adil, mungkin butuh server
+   validation di M2+ war.
+3. **"Perang" perlu attack surface yang adil** — tuning supaya tak mudah 1-hit-KO.
+4. **Skala visi besar:** M1 harus dikunci supaya arsitektur tak melenceng saat
+   ke M2-M4.

--- a/BLUEPRINT_LICENSE.md
+++ b/BLUEPRINT_LICENSE.md
@@ -1,0 +1,53 @@
+# BLUEPRINT LICENSE — Source-Available (Read-Only)
+
+Copyright © 2026 ARCLUX / Mikatoshi. All rights reserved.
+
+This document is **source-available**, not open source, and is **NOT**
+licensed under the Apache License 2.0 (or any other open-source license).
+
+The "ARCLUX Repository War Universe" blueprint (referred to below as "the
+Blueprint") embodies the strategic vision, architecture, data model, and
+product direction of ARCLUX. This license protects that vision.
+
+## Terms
+
+1. **Read & study — permitted.**
+   You may read, view, and study the Blueprint for personal understanding,
+   evaluation, and learning.
+
+2. **Modification — NOT permitted.**
+   You may not create derivative works, forks, or modified versions of the
+   Blueprint, in whole or in part, without prior written permission from
+   the copyright holder (ARCLUX / Mikatoshi).
+
+3. **Distribution — NOT permitted.**
+   You may not copy, reproduce, publish, upload, or redistribute the
+   Blueprint, in whole or in part, in any medium, without prior written
+   permission.
+
+4. **Commercial use — NOT permitted.**
+   You may not use the Blueprint, or the ideas, architecture, and vision
+   expressed within it, to build, operate, or monetize any competing
+   product, service, or project without prior written permission.
+
+5. **Product implementation — governed separately.**
+   This license covers the Blueprint *document*. The software source code
+   of ARCLUX in this repository remains under the Apache License 2.0 where
+   stated. Nothing in this license grants rights to that code beyond what
+   its own license provides.
+
+6. **Violations.**
+   Any use beyond the permissions above, including unauthorized copying or
+   commercialization, is a breach of copyright and this license, and may be
+   pursued to the fullest extent of the law.
+
+## Why
+
+The Blueprint represents ARCLUX's long-term strategic direction. It is
+published for transparency and community insight, but its exclusive
+ownership is critical to the future of the project. If you wish to build on
+or discuss any part of it, contact the copyright holder for permission.
+
+## Contact
+
+Mikatoshi — mikatoshi001@gmail.com


### PR DESCRIPTION
## Blueprint: Repository War Universe

Adds two files (base: ARCLUX.main @ ec835f66):

- **BLUEPRINT.md** — full vision/architecture/roadmap for turning ARCLUX from a tool into a repository-driven universe where each repo becomes a living 'vessel'. Grounded in the existing code-intelligence engine (SDK/MCP/CLI/DSL live on npm), the current 3D renderer, daemon/watcher, db, and provenance.
- **BLUEPRINT_LICENSE.md** — **source-available (read-only)** license. Explicitly NOT Apache; protects the strategic vision (read/study allowed; no modify/distribute/commercialize without permission).

**Not auto-merging** — leave for review.