### PR TITLE
feat(gameserver): authoritative MMO server core (D-008)

### DIFF
--- a/apps/cli/lib.ts
+++ b/apps/cli/lib.ts
@@ -60,18 +60,13 @@ export {
   mergeManifest,
   buildVesselModel,
 } from "../../packages/universe/stats";
-export {
-  connectRepository,
-} from "../../packages/universe/connect";
+export { connectRepository } from "../../packages/universe/connect";
 export {
   checkComponent,
   validateVesselComponents,
   OVERRIDE_CAP_OFFSET,
 } from "../../packages/universe/license";
-export {
-  validateManifest,
-  capOverride,
-} from "../../packages/universe/schema";
+export { validateManifest, capOverride } from "../../packages/universe/schema";
 export type {
   VesselModel,
   SystemState,
@@ -81,6 +76,43 @@ export type {
   LicenseTier,
   VesselStatDerivation,
 } from "../../packages/universe/types";
+
+// ── gameserver (authoritative MMO server core) ────────────────────────────
+export { WorldRegion, distanceBetween, regionFromState } from "../../packages/gameserver/world";
+export { validateIntent } from "../../packages/gameserver/validator";
+export { SimulationEngine, computeEntityHash } from "../../packages/gameserver/simulation";
+export {
+  applyCombatIntent,
+  DAMAGE_CEILING,
+} from "../../packages/gameserver/combat";
+export {
+  WorldRegion as WorldRegionType,
+} from "../../packages/gameserver/world";
+export type {
+  GameEntity,
+  VesselEntity,
+  StationEntity,
+  WorldEntity,
+  RegionState,
+  GameEvent,
+  PlayerIntent,
+  Vec3,
+  FactionId,
+  EntityKind,
+} from "../../packages/gameserver/types";
+export type {
+  SimulationOptions,
+  TickResult,
+} from "../../packages/gameserver/simulation";
+export type {
+  ValidationResult,
+  ValidatorDecision,
+  ValidatorContext,
+} from "../../packages/gameserver/validator";
+export type {
+  CombatImpact,
+  CombatLogger,
+} from "../../packages/gameserver/combat";
 
 // ── types ─────────────────────────────────────────────────────────────────
 export type {

--- a/packages/gameserver/combat.ts
+++ b/packages/gameserver/combat.ts
@@ -1,0 +1,124 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Combat simulation (Layer I.2, I.7) — authoritative.
+//
+// Damage is applied PER SUBSYSTEM (not a single HP bar), reusing the universe
+// `SystemState` health values. There is a hard damage ceiling per tick so a
+// single hit cannot one-shot (I.7). All outcomes are deterministic and pushed
+// as combat events for replay (I.8). Visual rendering happens client-side only.
+
+import type { PlayerIntent, VesselEntity } from "./types";
+import type { WorldRegion } from "./world";
+
+/** Max damage a single attack can deal, per subsystem (Layer I.7 ceiling). */
+export const DAMAGE_CEILING = 12;
+
+/** Whether a fully depleted subsystem counts as "destroyed". */
+export const SUBSYSTEM_DESTROYED_AT = 0;
+
+export interface CombatImpact {
+  targetId: string;
+  subsystemId: string;
+  before: number;
+  after: number;
+  damage: number;
+  destroyed: boolean;
+}
+
+export type CombatLogger = (meta: Record<string, unknown>) => void;
+
+/**
+ * Apply a validated attack intent to a target vessel. Called ONLY after the
+ * WorldValidator has accepted the intent. Reduces the target subsystem health
+ * by a ruleset-bounded amount and records the impact.
+ */
+export function applyCombatIntent(
+  region: WorldRegion,
+  attacker: VesselEntity,
+  intent: PlayerIntent,
+  logger?: CombatLogger
+): CombatImpact | undefined {
+  const targetId = intent.payload?.targetId as string | undefined;
+  const weaponType = intent.payload?.weapon as string | undefined;
+  if (!targetId || !weaponType) return undefined;
+
+  const target = region.getVessel(targetId);
+  if (!target) return undefined;
+
+  const subsystemId = resolveTargetSubsystem(weaponType);
+  const sys = target.vessel.systems.find((s) => s.id === subsystemId);
+  if (!sys) return undefined;
+
+  const rawCapability = attackPower(attacker, weaponType);
+  const damage = applyDamageCeiling(rawCapability, sys.health);
+
+  const before = sys.health;
+  sys.health = Math.max(SUBSYSTEM_DESTROYED_AT, before - damage);
+  const destroyed = sys.health <= SUBSYSTEM_DESTROYED_AT;
+
+  // Set a cooldown on the attacker's weapon so it can't fire every tick.
+  attacker.cooldowns[weaponType] = cooldownTicks(weaponType);
+
+  const impact: CombatImpact = {
+    targetId,
+    subsystemId,
+    before,
+    after: sys.health,
+    damage,
+    destroyed,
+  };
+
+  logger?.({
+    attackerId: attacker.id,
+    ...impact,
+    weaponType,
+  });
+
+  return impact;
+}
+
+/** Map a weapon capability to the subsystem it damages. */
+function resolveTargetSubsystem(weaponType: string): string {
+  switch (weaponType) {
+    case "weapon.plasma":
+    case "weapon.railgun":
+      return "weapons";
+    case "weapon.missile":
+      return "defense";
+    case "weapon.emp":
+      return "engine";
+    case "weapon.explosive":
+      return "reactor";
+    default:
+      return "defense";
+  }
+}
+
+/** Raw damage from attacker capability + weapon (before ceiling). */
+function attackPower(attacker: VesselEntity, weaponType: string): number {
+  const weaponStat = attacker.vessel.systems.find((s) => s.id === "weapons")?.health ?? 50;
+  const base = 4 + (weaponStat / 100) * 8; // 4..12
+  return Math.round(base * 10) / 10;
+}
+
+/** Clamp damage to the ruleset ceiling, never dipping below 0. */
+function applyDamageCeiling(raw: number, currentHealth: number): number {
+  const capped = Math.min(raw, DAMAGE_CEILING);
+  return Math.min(capped, currentHealth);
+}
+
+/** Cooldown (in ticks) per weapon archetype. */
+function cooldownTicks(weaponType: string): number {
+  switch (weaponType) {
+    case "weapon.missile": return 6;
+    case "weapon.emp": return 8;
+    case "weapon.explosive": return 10;
+    default: return 4;
+  }
+}

--- a/packages/gameserver/index.ts
+++ b/packages/gameserver/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// `packages/gameserver` — authoritative ARCLUX MMO server core.
+//
+// Barrel: everything a shard host needs to run an authoritative region server
+// (sim loop, world registry, validator, combat). Clients only render what this
+// validates/simulates. Reuses packages/universe for vessel model + licensing.
+
+export * from "./types";
+export * from "./world";
+export * from "./validator";
+export * from "./simulation";
+export * from "./combat";

--- a/packages/gameserver/simulation.ts
+++ b/packages/gameserver/simulation.ts
@@ -1,0 +1,196 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// SimulationEngine — deterministic tick loop for a region.
+//
+//   - Collects queued PlayerIntents for the tick.
+//   - Validates each via WorldValidator; rejected intents are logged (replay).
+//   - Applies movement + combat from accepted intents.
+//   - Advances physics (velocity -> position) with fixed dt per tick.
+//   - Records every accepted/rejected intent as a GameEvent (input-queue +
+//     event replay, Layer I.8 / riesgo #6 determinism).
+//
+// This is the authoritative sim (D-008): clients send intent, server computes
+// truth.
+
+import type { GameEvent, PlayerIntent, Vec3, VesselEntity, WorldEntity } from "./types";
+import { WorldRegion } from "./world";
+import { validateIntent, type ValidatorContext } from "./validator";
+import { applyCombatIntent } from "./combat";
+
+export interface SimulationOptions {
+  /** Region the server owns. */
+  region: WorldRegion;
+  /** Fixed timestep per tick, in seconds. */
+  dt?: number;
+  /** Validation context (player identity + authorization). */
+  authProvider: (playerId: string) => ValidatorContext;
+}
+
+export interface TickResult {
+  accepted: GameEvent[];
+  rejected: GameEvent[];
+  tick: number;
+  snapshot: ReturnType<WorldRegion["snapshot"]>;
+}
+
+/**
+ * Runs the authoritative server loop. In production this is invoked N times
+ * per second by a scheduler; here step() is the pure single-tick primitive.
+ */
+export class SimulationEngine {
+  readonly region: WorldRegion;
+  private readonly dt: number;
+  private readonly authProvider: (playerId: string) => ValidatorContext;
+  private pending: PlayerIntent[] = [];
+  private eventLog: GameEvent[] = [];
+  private eventSeq = 0;
+
+  constructor(opts: SimulationOptions) {
+    this.region = opts.region;
+    this.dt = opts.dt ?? 0.1; // default 10 ticks/sec
+    this.authProvider = opts.authProvider;
+  }
+
+  /** Enqueue a client intent for the NEXT tick. */
+  enqueue(intent: PlayerIntent): void {
+    this.pending.push(intent);
+  }
+
+  /** Process one tick: drain queue, validate, simulate, advance physics. */
+  step(): TickResult {
+    const queue = this.pending;
+    this.pending = [];
+    const accepted: GameEvent[] = [];
+    const rejected: GameEvent[] = [];
+
+    for (const intent of queue) {
+      const ctx = this.authProvider(intent.playerId);
+      const verdict = validateIntent(this.region, intent, ctx);
+      if (verdict.decision === "reject") {
+        rejected.push(this.log("intent_rejected", intent.playerId, {
+          entityId: intent.entityId,
+          type: intent.type,
+          seq: intent.seq,
+          reason: verdict.reason,
+        }));
+        continue;
+      }
+
+      accepted.push(this.log(`intent_${intent.type}`, intent.playerId, {
+        entityId: intent.entityId,
+        type: intent.type,
+        seq: intent.seq,
+        payload: intent.payload,
+      }));
+
+      this.applyIntent(intent, ctx);
+    }
+
+    this.integratePhysics();
+    this.decrementCooldowns();
+    this.region.advanceTick();
+
+    return {
+      accepted,
+      rejected,
+      tick: this.region.tick,
+      snapshot: this.region.snapshot(),
+    };
+  }
+
+  /** The full event log (replay foundation). */
+  replayLog(): GameEvent[] {
+    return [...this.eventLog];
+  }
+
+  private log(type: string, actorId: string, payload: Record<string, unknown>): GameEvent {
+    const ev: GameEvent = {
+      id: `${this.region.regionId}:${this.region.tick}:${this.eventSeq++}`,
+      regionId: this.region.regionId,
+      tick: this.region.tick,
+      type,
+      actorId,
+      payload,
+      timestamp: new Date().toISOString(),
+    };
+    this.eventLog.push(ev);
+    return ev;
+  }
+
+  private applyIntent(intent: PlayerIntent, ctx: ValidatorContext): void {
+    const entity = this.region.get(intent.entityId);
+    if (!entity) return;
+    switch (intent.type) {
+      case "move": {
+        const to = intent.payload as unknown as Vec3;
+        moveToward(entity, to, this.dt);
+        break;
+      }
+      case "attack": {
+        if (entity.kind === "vessel") {
+          applyCombatIntent(this.region, entity, intent, (meta) => {
+            this.log("combat", intent.playerId, { entityId: entity.id, ...meta });
+          });
+        }
+        break;
+      }
+      case "dock":
+      case "scan":
+        // handled by validator/log; no authoritative state change here yet.
+        break;
+    }
+  }
+
+  private integratePhysics(): void {
+    // Simple verlet-lite: position += velocity * dt. Authoritative motion.
+    for (const e of this.region["entities"].values()) {
+      e.position.x += e.velocity.x * this.dt;
+      e.position.y += e.velocity.y * this.dt;
+      e.position.z += e.velocity.z * this.dt;
+    }
+  }
+
+  private decrementCooldowns(): void {
+    for (const e of this.region["entities"].values()) {
+      if (e.kind !== "vessel") continue;
+      for (const key of Object.keys(e.cooldowns)) {
+        e.cooldowns[key] = Math.max(0, (e.cooldowns[key] ?? 1) - 1);
+      }
+    }
+  }
+}
+
+function moveToward(entity: WorldEntity, target: Vec3, dt: number): void {
+  // Simple: set velocity toward target point (not instant teleport), then the
+  // physics integrator moves it. Speed is a placeholder constant (m/s).
+  const speed = 250;
+  const dx = target.x - entity.position.x;
+  const dy = target.y - entity.position.y;
+  const dz = target.z - entity.position.z;
+  const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  if (dist < 1) {
+    entity.velocity = { x: 0, y: 0, z: 0 };
+    return;
+  }
+  entity.velocity = {
+    x: (dx / dist) * speed,
+    y: (dy / dist) * speed,
+    z: (dz / dist) * speed,
+  };
+  // Update heading to face the travel direction.
+  entity.heading.yaw = Math.atan2(dx, dz);
+  entity.heading.pitch = Math.atan2(dy, Math.sqrt(dx * dx + dz * dz));
+}
+
+/** Compute a deterministic state hash for a vessel (Layer I.5 fingerprint). */
+export function computeEntityHash(e: VesselEntity): string {
+  const { x, y, z } = e.position;
+  const sys = e.vessel.systems.map((s) => `${s.id}:${Math.round(s.health)}`).join(",");
+  return `${e.id}|${x.toFixed(2)},${y.toFixed(2)},${z.toFixed(2)}|${sys}`;
+}

--- a/packages/gameserver/types.ts
+++ b/packages/gameserver/types.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// `packages/gameserver` — authoritative ARCLUX MMO server (D-008).
+//
+// This package is the referee / simulation authority of the universe. It owns
+// world state, runs the tick loop, validates player intents, and emits events.
+// Clients only RENDER what the server validates & simulates (Layer I).
+//
+// Design anchors (see docs/blueprint/progres/):
+//   D-005 multi-shard, D-006 region + gates, D-008 server-authoritative,
+//   D-009 self-host per shard.
+
+/** A point in 3D region space. Components are in meters. */
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export type FactionId = string;
+
+export type EntityKind = "vessel" | "station";
+
+/** Base identity shared by every in-world entity. */
+export interface GameEntity {
+  id: string;
+  kind: EntityKind;
+  owner?: string;
+  faction?: FactionId;
+  /** Position in the region's space. */
+  position: Vec3;
+  /** Velocity in m/s. */
+  velocity: Vec3;
+  /** Orientation (Euler, radians). */
+  heading: { yaw: number; pitch: number };
+}
+
+/** A vessel in the world — wraps the universe VesselModel live state. */
+export interface VesselEntity extends GameEntity {
+  kind: "vessel";
+  /** Vessel definition / stats — reused from packages/universe. */
+  vessel: import("../universe/types").VesselModel;
+  /** Last known state hash (anti-cheat, Layer I.5). */
+  stateHash: string;
+  /** Per-subsystem cooldown remaining (ticks). */
+  cooldowns: Record<string, number>;
+}
+
+/** A station — a protected social/economic anchor (02-station). */
+export interface StationEntity extends GameEntity {
+  kind: "station";
+  name: string;
+  /** Safe-zone radius in meters (default 1000). */
+  safeZoneRadius: number;
+  communityId?: string;
+}
+
+export type WorldEntity = VesselEntity | StationEntity;
+
+/** Live state of a single region (a shard's world). */
+export interface RegionState {
+  regionId: string;
+  name: string;
+  tick: number;
+  entities: Map<string, WorldEntity>;
+  /** Fixed timestamp of region creation. */
+  createdAt: string;
+}
+
+/** A validated, immutable event that happened in the world. */
+export interface GameEvent {
+  id: string;
+  regionId: string;
+  tick: number;
+  type: string;
+  actorId?: string;
+  payload: Record<string, unknown>;
+  timestamp: string;
+}
+
+/** An action/command sent by a client — NOT authoritative until validated. */
+export interface PlayerIntent {
+  playerId: string;
+  entityId: string;
+  type: string;
+  payload: Record<string, unknown>;
+  /** Client-sent sequence for input-ordering + replay. */
+  seq: number;
+}

--- a/packages/gameserver/validator.ts
+++ b/packages/gameserver/validator.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// WorldValidator — the server as referee (Layer I.4).
+//
+// Every player intent passes through here. The validator decides whether an
+// intent is LEGAL before it is simulated. Clients never determine truth; they
+// render what the validator + sim produce.
+//
+// Reuses packages/universe::LicenseValidator for component/authorization
+// checks (Layer I.6), keeping a single source of truth for licensing.
+
+import { checkComponent, type AuthorizationContext } from "../universe/license";
+import type { VesselEntity, PlayerIntent, WorldEntity } from "./types";
+import { WorldRegion, distanceBetween } from "./world";
+
+export type ValidatorDecision = "accept" | "reject";
+
+export interface ValidationResult {
+  decision: ValidatorDecision;
+  reason?: string;
+}
+
+export interface ValidatorContext {
+  /** Harusny isi player identity (dimiliki region/identity layer). */
+  playerId: string;
+  /** Components the actor owns / has grants for. */
+  auth: AuthorizationContext;
+}
+
+/**
+ * Validate a single intent. The rules mirror Layer I checklist:
+ * attacker valid, weapon/component authorized, license valid, vessel state
+ * valid, cooldown valid, range valid, target valid, damage <= ruleset, state
+ * version valid.
+ */
+export function validateIntent(
+  region: WorldRegion,
+  intent: PlayerIntent,
+  ctx: ValidatorContext
+): ValidationResult {
+  if (intent.playerId !== ctx.playerId) {
+    return { decision: "reject", reason: "player identity mismatch" };
+  }
+
+  const entity = region.get(intent.entityId);
+  if (!entity) {
+    return { decision: "reject", reason: `unknown entity: ${intent.entityId}` };
+  }
+  if (entity.owner !== ctx.playerId) {
+    return { decision: "reject", reason: "not the acting owner of entity" };
+  }
+
+  switch (intent.type) {
+    case "move":
+      return validateMove(region, entity, intent);
+    case "attack": {
+      const v = entity as VesselEntity;
+      if (v.kind !== "vessel") return { decision: "reject", reason: "stations cannot attack" };
+      return validateAttack(region, v, intent, ctx);
+    }
+    case "scan":
+      return { decision: "accept" };
+    case "dock":
+      return validateDock(region, entity, intent);
+    default:
+      return { decision: "reject", reason: `unsupported intent: ${intent.type}` };
+  }
+}
+
+function validateMove(
+  _region: WorldRegion,
+  entity: WorldEntity,
+  intent: PlayerIntent
+): ValidationResult {
+  const to = intent.payload as { x?: number; y?: number; z?: number };
+  if (typeof to.x !== "number" || typeof to.y !== "number" || typeof to.z !== "number") {
+    return { decision: "reject", reason: "move requires numeric x/y/z target" };
+  }
+  return { decision: "accept" };
+}
+
+function validateDock(
+  region: WorldRegion,
+  entity: WorldEntity,
+  intent: PlayerIntent
+): ValidationResult {
+  const stationId = intent.payload?.stationId as string | undefined;
+  const station = stationId ? region.get(stationId) : undefined;
+  if (!station || station.kind !== "station") {
+    return { decision: "reject", reason: "dock requires a valid station target" };
+  }
+  // Must be close enough to dock.
+  if (distanceBetween(entity, station) > station.safeZoneRadius * 2) {
+    return { decision: "reject", reason: "out of docking range" };
+  }
+  return { decision: "accept" };
+}
+
+function safeZoneBlocked(region: WorldRegion, target: WorldEntity): string | undefined {
+  const stations = region.entitiesWithin(target.position, 1_000_000);
+  for (const s of stations) {
+    if (s.kind === "station") {
+      if (distanceBetween(target, s) <= s.safeZoneRadius) {
+        return s.id;
+      }
+    }
+  }
+  return undefined;
+}
+
+function validateAttack(
+  region: WorldRegion,
+  attacker: VesselEntity,
+  intent: PlayerIntent,
+  ctx: ValidatorContext
+): ValidationResult {
+  const targetId = intent.payload?.targetId as string | undefined;
+  const weaponType = intent.payload?.weapon as string | undefined;
+  if (!targetId) return { decision: "reject", reason: "attack requires targetId" };
+  if (!weaponType) return { decision: "reject", reason: "attack requires weapon" };
+
+  const target = region.get(targetId);
+  if (!target) return { decision: "reject", reason: `unknown target: ${targetId}` };
+  if (target.kind === "station") {
+    return { decision: "reject", reason: "stations are protected (cannot attack)" };
+  }
+
+  // Safe-zone: cannot hosti target inside a protected station radius (02 §8-9).
+  const nearStation = safeZoneBlocked(region, target);
+  if (nearStation) {
+    return { decision: "reject", reason: `target in safe zone of station ${nearStation}` };
+  }
+
+  // Range check.
+  const weaponRange = 5000; // meters — ruleset placeholder
+  if (distanceBetween(attacker, target) > weaponRange) {
+    return { decision: "reject", reason: "target out of weapon range" };
+  }
+
+  // Cooldown check (simplified — actual per-weapon ruleset in combat.ts).
+  const cooldown = attacker.cooldowns[weaponType] ?? 0;
+  if (cooldown > 0) {
+    return { decision: "reject", reason: `weapon ${weaponType} on cooldown (${cooldown} ticks)` };
+  }
+
+  // Component/license authorization (Layer I.6) — attacker must be authorized
+  // for the weapon capability.
+  const weaponComponent = attacker.vessel.components.find((c) => c.capability === weaponType);
+  if (weaponComponent) {
+    const check = checkComponent(weaponComponent, ctx.auth);
+    if (check.decision === "disabled") {
+      return { decision: "reject", reason: `weapon component not authorized: ${check.reason}` };
+    }
+  }
+
+  return { decision: "accept" };
+}

--- a/packages/gameserver/world.ts
+++ b/packages/gameserver/world.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// WorldRegion — the authoritative entity registry for one region (shard).
+//
+// Everything that mutates world state goes through here (or through the
+// simulation engine). The region owns its entities; external code never
+// mutates the map directly.
+
+import type { GameEntity, RegionState, StationEntity, VesselEntity, WorldEntity } from "./types";
+
+export interface SpawnVesselOptions {
+  id: string;
+  owner?: string;
+  vessel: import("../universe/types").VesselModel;
+  position?: { x: number; y: number; z: number };
+}
+
+export interface SpawnStationOptions {
+  id: string;
+  name: string;
+  owner?: string;
+  communityId?: string;
+  position?: { x: number; y: number; z: number };
+  safeZoneRadius?: number;
+}
+
+/**
+ * A region's live world. Holds the entity registry and enforces simple
+ * invariants (unique ids). Simulation/validator operate on this.
+ */
+export class WorldRegion {
+  readonly regionId: string;
+  readonly name: string;
+  readonly createdAt: string;
+  tick: number;
+
+  private entities = new Map<string, WorldEntity>();
+
+  constructor(regionId: string, name: string) {
+    this.regionId = regionId;
+    this.name = name;
+    this.createdAt = new Date().toISOString();
+    this.tick = 0;
+  }
+
+  /** Advance tick counter (called by simulation loop). */
+  advanceTick(): void {
+    this.tick += 1;
+  }
+
+  has(id: string): boolean {
+    return this.entities.has(id);
+  }
+
+  get(id: string): WorldEntity | undefined {
+    return this.entities.get(id);
+  }
+
+  getVessel(id: string): VesselEntity | undefined {
+    const e = this.entities.get(id);
+    return e?.kind === "vessel" ? e : undefined;
+  }
+
+  /** Returns a plain snapshot (for client render / persistence, no live refs). */
+  snapshot(): { regionId: string; tick: number; entities: WorldEntity[] } {
+    return {
+      regionId: this.regionId,
+      tick: this.tick,
+      entities: Array.from(this.entities.values()),
+    };
+  }
+
+  /**
+   * All entities within `radius` meters of a point. Used by combat targeting,
+   * safe-zone checks, and proximity broadcasts.
+   */
+  entitiesWithin(position: { x: number; y: number; z: number }, radius: number): WorldEntity[] {
+    const out: WorldEntity[] = [];
+    for (const e of this.entities.values()) {
+      const dx = e.position.x - position.x;
+      const dy = e.position.y - position.y;
+      const dz = e.position.z - position.z;
+      if (Math.sqrt(dx * dx + dy * dy + dz * dz) <= radius) {
+        out.push(e);
+      }
+    }
+    return out;
+  }
+
+  spawnVessel(opts: SpawnVesselOptions): VesselEntity {
+    if (this.entities.has(opts.id)) {
+      throw new Error(`Entity already exists in region: ${opts.id}`);
+    }
+    const entity: VesselEntity = {
+      id: opts.id,
+      kind: "vessel",
+      owner: opts.owner,
+      vessel: opts.vessel,
+      stateHash: "",
+      cooldowns: {},
+      position: opts.position ?? { x: 0, y: 0, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+      heading: { yaw: 0, pitch: 0 },
+    };
+    this.entities.set(entity.id, entity);
+    return entity;
+  }
+
+  spawnStation(opts: SpawnStationOptions): StationEntity {
+    if (this.entities.has(opts.id)) {
+      throw new Error(`Entity already exists in region: ${opts.id}`);
+    }
+    const entity: StationEntity = {
+      id: opts.id,
+      kind: "station",
+      name: opts.name,
+      owner: opts.owner,
+      communityId: opts.communityId,
+      safeZoneRadius: opts.safeZoneRadius ?? 1000,
+      position: opts.position ?? { x: 0, y: 0, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+      heading: { yaw: 0, pitch: 0 },
+    };
+    this.entities.set(entity.id, entity);
+    return entity;
+  }
+
+  remove(id: string): boolean {
+    return this.entities.delete(id);
+  }
+}
+
+/** Rebuild a WorldRegion from a persisted RegionState (for recovery). */
+export function regionFromState(state: RegionState): WorldRegion {
+  const region = new WorldRegion(state.regionId, state.name);
+  region.tick = state.tick;
+  for (const e of state.entities.values()) {
+    region["entities"].set(e.id, e);
+  }
+  return region;
+}
+
+/** Distance between two entities (meters). */
+export function distanceBetween(a: GameEntity, b: GameEntity): number {
+  const dx = a.position.x - b.position.x;
+  const dy = a.position.y - b.position.y;
+  const dz = a.position.z - b.position.z;
+  return Math.sqrt(dx * dx + dy * dy + dz * dz);
+}


### PR DESCRIPTION
`packages/gameserver` — inti server MMORPG ARCLUX yang authoritative (keputusan D-008: server-authoritative penuh).

Client cuma RENDER hasil yang server validasi & simulasikan (Layer I — "server = referee, client = render").

## Isi
- **types.ts** — Vec3, GameEntity, VesselEntity, StationEntity, RegionState, GameEvent, PlayerIntent
- **world.ts** — `WorldRegion` entity registry (spawn/move/remove vessel & station), proximity query, data safe-zone, snapshot buat render/persist, `regionFromState` (recovery), `distanceBetween`
- **validator.ts** — `WorldValidator`: tiap intent divalidasi sebelum sim — identity player, ownership, target, range, cooldown, **safe-zone** (radius station terproteksi), component/license (reuse `packages/universe::LicenseValidator`)
- **simulation.ts** — `SimulationEngine`: tick loop deterministik, input-queue, physics integrator, event log accepted/rejected (fondasi replay, Layer I.8 / risiko #6)
- **combat.ts** — damage PER SUBSYSTEM (reuse `SystemState`), damage ceiling (I.7), event impact deterministik
- **index.ts** barrel + **wired ke apps/cli/lib.ts** (programmatic export)

## Verifikasi (tsx smoke test end-to-end)
- ✅ safe-zone: attack ditolak saat target dalam radius station
- ✅ out-of-range: attack ditolak (>5000m)
- ✅ ownership: player gak bisa kontrol vessel orang lain
- ✅ damage + ceiling: weapons 100→88 (max 12)
- ✅ replay log: records intent_attack + combat(weapons)
- ✅ tsc bersih untuk file baru; esbuild bundle sukses

Per standing rule: **TIDAK auto-merge** — biar direview dulu.