### PR TITLE
feat(mmo): scaffolding - relay, game client, gameserver gate/netcode/persistence

### DIFF
--- a/BLUEPRINT.md
+++ b/BLUEPRINT.md
@@ -58,7 +58,7 @@ seiring visi yang kian besar). Urutan baca yang disarankan:
 | 04 | [docs/blueprint/04-wreckage-history.md](docs/blueprint/04-wreckage-history.md) | Wreckage & Hall of Fame (museum sejarah, provenance sebagai aset) |
 | 05 | [docs/blueprint/05-vessel-design-dashboard.md](docs/blueprint/05-vessel-design-dashboard.md) | Vessel Design, Visual Governance & 3D Design Dashboard (creative freedom, visual policy, validation, authoring) |
 | 06 | [docs/blueprint/06-community-social-ownership.md](docs/blueprint/06-community-social-ownership.md) | Community, Social Connection & Battlefield Ownership (access keys/trust, intelligence, component history, fleet recovery, roles, governance, asset classification, revocation, dynamic safe-zone, community splits, vessel identity, 3D) — extension V2 + V3 |
-| – | [docs/blueprint/progres/](docs/blueprint/progres/) | Progres desain MMO: keputusan ([decisions-mmo.md](docs/blueprint/progres/decisions-mmo.md)) + arsitektur ([arsitektur.md](docs/blueprint/progres/arsitektur.md)) |
+| – | [docs/blueprint/progres/](docs/blueprint/progres/) | Progres desain MMO: keputusan ([decisions-mmo.md](docs/blueprint/progres/decisions-mmo.md)) + arsitektur ([arsitektur.md](docs/blueprint/progres/arsitektur.md)) + peta implementasi ([MMO-IMPLEMENTATION.md](docs/blueprint/progres/MMO-IMPLEMENTATION.md)) |
 | – | [docs/blueprint/BLUEPRINT_LICENSE.md](docs/blueprint/BLUEPRINT_LICENSE.md) | Lisensi source-available (bukan Apache; read-only) |
 
 ---

--- a/apps/cli/lib.ts
+++ b/apps/cli/lib.ts
@@ -108,11 +108,42 @@ export type {
   ValidationResult,
   ValidatorDecision,
   ValidatorContext,
-} from "../../packages/gameserver/validator";
-export type {
+} from "../../packages/gameserver/validator";export type {
   CombatImpact,
   CombatLogger,
 } from "../../packages/gameserver/combat";
+export { createGateRouter } from "../../packages/gameserver/gate";
+export { createInProcessTransport } from "../../packages/gameserver/netcode";
+export {
+  createInMemoryPersistence,
+  createDbPersistence,
+} from "../../packages/gameserver/persistence";
+export type {
+  GateLink,
+  GateTransitRequest,
+  GateTransitResult,
+  GateRouter,
+} from "../../packages/gameserver/gate";
+export type {
+  NetcodeTransport,
+  NetcodeOptions,
+  NetEvent,
+} from "../../packages/gameserver/netcode";
+export type {
+  PersistenceStore,
+} from "../../packages/gameserver/persistence";
+
+// ── relay (shard registry + bridge, multi-shard) ──────────────────────────
+export { createRelayRegistry } from "../../packages/relay/registry";
+export { createGateCoordinator } from "../../packages/relay/gate";
+export { createIdentityMap } from "../../packages/relay/identity";
+export type {
+  ShardRecord,
+  ShardStatus,
+  RegionClaim,
+  HandoffRequest,
+  HandoffResult,
+} from "../../packages/relay/types";
 
 // ── types ─────────────────────────────────────────────────────────────────
 export type {

--- a/apps/game/README.md
+++ b/apps/game/README.md
@@ -1,0 +1,33 @@
+# ARCLUX GAME — MMO Client (Electron + three.js)
+
+> 🚧 **SCAFFOLD** — kerangka aplikasi, BELUM jalan. Baca
+> `docs/blueprint/progres/MMO-IMPLEMENTATION.md` §2.4 sebelum implementasi.
+>
+> Client = **renderer + input + net**, TIDAK pernah jadi otoritas (D-008,
+> invariant I-1). Semua posisi/damage/ownership datang dari gameserver.
+
+## Struktur
+
+```
+apps/game/
+├── package.json          # Electron + three
+├── tsconfig.json
+├── index.ts              # entry: bootstrap Electron
+└── src/
+    ├── main/             # Electron main process (jendela, lifecycle, IPC bridge)
+    │   └── main.ts
+    └── renderer/         # Electron renderer (3D universe + input + net)
+        ├── index.html
+        ├── renderer.ts   # bootstrap renderer (three scene)
+        ├── scene3d.ts    # 3D vessel render dari RegionState (mesh/material/camera)
+        └── net.ts        # wrapper netcode: kirim intent, terima events
+```
+
+## Arah implementasi (urutan)
+
+1. `main/main.ts` — bootstrap jendela Electron + load `renderer/index.html`
+2. `renderer/scene3d.ts` — render vessel dari `RegionState` (pakai `three`,
+   fondasi sama kayak `apps/web` GraphCanvas3D)
+3. `renderer/net.ts` — gabung `packages/gameserver/netcode.ts` (in-process
+   dulu), kirim `PlayerIntent`, render events
+4. UI universe (blueprint `01-spatial-ux.md`) setelah 3D dasar jalan

--- a/apps/game/index.ts
+++ b/apps/game/index.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// apps/game — ARCLUX MMO client (Electron). Entry: bootstrap Electron main.
+//
+// 🚧 SCAFFOLD — lihat README.md + docs/blueprint/progres/MMO-IMPLEMENTATION.md.
+
+import { startMain } from "./src/main/main";
+
+// IMPL: panggil startMain() setelah Electron devDependencies terpasang.
+// Jalankan: cd apps/game && npx electron .
+console.log("arclux-game: scaffold — bootstrap Electron main di src/main/main.ts");
+void startMain;

--- a/apps/game/package.json
+++ b/apps/game/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "arclux-game",
+  "version": "0.0.0",
+  "description": "ARCLUX MMO client — Electron + three.js renderer (server-authoritative, D-008).",
+  "license": "Apache-2.0",
+  "type": "module",
+  "private": true,
+  "main": "./dist/main/main.js",
+  "scripts": {
+    "start": "electron .",
+    "dev": "node ../../scripts/build-game.mjs && electron ."
+  },
+  "dependencies": {
+    "three": "^0.169.0"
+  },
+  "devDependencies": {
+    "electron": "^31.0.0",
+    "esbuild": "^0.28.0"
+  }
+}

--- a/apps/game/src/main/main.ts
+++ b/apps/game/src/main/main.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// src/main/main.ts — Electron main process (jendela + lifecycle + IPC bridge).
+//
+// 🚧 SCAFFOLD. TODO implementasi di §TODOS.
+
+export interface MainHandle {
+  window: unknown; // BrowserWindow
+}
+
+/**
+ * 🚧 Start jendela Electron utama.
+ */
+export function startMain(): MainHandle {
+  // TODO(main)[bootstrap]  app.whenReady → new BrowserWindow (load renderer/index.html)
+  // TODO(main)[ipc]        bridge: renderer intent → relay/gameserver; events → renderer
+  // TODO(main)[scaff]      security: contextIsolation + nodeIntegration=false
+  //
+  // Impor Electron hanya di main process (node runtime) — bukan di renderer.
+  throw new Error("not implemented (scaffold)");
+}

--- a/apps/game/src/renderer/index.html
+++ b/apps/game/src/renderer/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'"
+    />
+    <title>ARCLUX Game</title>
+    <style>
+      body {
+        margin: 0;
+        background: #0b0e14;
+        color: #e6edf3;
+        font-family: "JetBrains Mono", monospace;
+      }
+      #app {
+        width: 100vw;
+        height: 100vh;
+        overflow: hidden;
+      }
+      #hud {
+        position: fixed;
+        left: 12px;
+        bottom: 12px;
+        font-size: 12px;
+        opacity: 0.7;
+        pointer-events: none;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="hud">ARCLUX GAME — scaffold (renderer belum jalan)</div>
+    <script type="module" src="./renderer.ts"></script>
+  </body>
+</html>

--- a/apps/game/src/renderer/net.ts
+++ b/apps/game/src/renderer/net.ts
@@ -1,0 +1,32 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// src/renderer/net.ts — wrapper netcode: kirim intent, terima events dari server.
+//
+// 🚧 SCAFFOLD. TODO implementasi di §TODOS.
+//
+// Ini jembatan renderer ↔ packages/gameserver/netcode.ts. Untuk prototipe,
+// pakai createInProcessTransport (in-process). Untuk client beneran, ganti
+// channel transport jaringan (TODO net).
+
+import type { PlayerIntent } from "../../../../packages/gameserver/types";
+
+export interface NetHandle {
+  send(intent: PlayerIntent): void;
+  onState(cb: (region: unknown) => void): void;
+}
+
+/**
+ * 🚧 Inisialisasi koneksi client ke world.
+ */
+export function connectNet(): NetHandle {
+  // TODO(net)[transport]  createInProcessTransport op createRelayTransport (gameserver/netcode)
+  // TODO(net)[snapshot]   requestSnapshot → scene.renderRegion
+  // TODO(net)[events]     pumpEvents → scene.updateVessel
+  throw new Error("not implemented (scaffold)");
+}

--- a/apps/game/src/renderer/renderer.ts
+++ b/apps/game/src/renderer/renderer.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// src/renderer/renderer.ts — bootstrap renderer (three scene) di browser context.
+//
+// 🚧 SCAFFOLD. TODO implementasi di §TODOS.
+
+import { initScene3D } from "./scene3d";
+
+export function bootstrapRenderer(): void {
+  // TODO(renderer)[scene]  new WebGLRenderer → append ke #app
+  // TODO(renderer)[loop]    requestAnimationFrame + controls (orbit)
+  // TODO(renderer)[net]     konek ke net.ts: kirim intent, terima events, update scene
+  const scene = initScene3D();
+  void scene;
+}
+
+// Panggil di module bootstrap (renderer tidak punya node entry).
+if (typeof document !== "undefined") {
+  bootstrapRenderer();
+}

--- a/apps/game/src/renderer/scene3d.ts
+++ b/apps/game/src/renderer/scene3d.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// src/renderer/scene3d.ts — 3D vessel render dari RegionState (client-side only).
+//
+// 🚧 SCAFFOLD. TODO implementasi di §TODOS.
+//
+// Prinsip (blueprint 06 §18, invariant I-1): server tentukan posisi/heading/
+// damage; client cuma render mesh/materi/camera. JANGAN hitung physics di sini.
+
+import type { RegionState, VesselEntity } from "../../../../packages/gameserver/types";
+
+export interface Scene3D {
+  /** render satu snapshot region ke kanvas (panggil tiap event/state dari server). */
+  renderRegion(region: RegionState): void;
+  /** posisikan satu vessel menurut koordinat authoritative server. */
+  updateVessel(v: VesselEntity): void;
+}
+
+/**
+ * 🚧 Buat scene three.js. Belum nge-render — itulah TODO utama.
+ */
+export function initScene3D(): Scene3D {
+  // TODO(scene3d)[init]    WebGLRenderer + PerspectiveCamera + Scene (three)
+  // TODO(scene3d)[mesh]    vessel mesh dari VesselModel identity (blueprint 06 §18.3)
+  // TODO(scene3d)[render]  renderRegion: iterate entities → posisikan mesh
+  // TODO(scene3d)[damage]  subsystem state → visual state (non-authoritative)
+  // TODO(scene3d)[gate]    visual gate/jump-gate antar region (01-spatial-ux.md)
+  throw new Error("not implemented (scaffold)");
+}

--- a/apps/game/tsconfig.json
+++ b/apps/game/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/docs/blueprint/progres/MMO-IMPLEMENTATION.md
+++ b/docs/blueprint/progres/MMO-IMPLEMENTATION.md
@@ -1,0 +1,143 @@
+# ARCLUX MMO — IMPLEMENTATION MAP (anti-lupa)
+
+> **Ini "otak" scaffolding.** Sebelum ngoding MMO, baca ini dulu: cek status
+> tiap modul, tahu udah dibikin apa, tinggal isi apa, dan mau diarahin ke mana.
+> JANGAN ngulang bikin yang udah ada — baca §Status dulu.
+>
+> Semantic: ✅ = berfungsi & terverifikasi · 🚧 = kerangka/parsial · ⬜ = kosong.
+> Tiap file yang di-update harus isi §Arah sesuai checklist di bawah ini.
+
+Update terakhir: 2026-08-28 (PR #582 gameserver core merged; scaffolding relay/game).
+
+---
+
+## 1. Peta modul (gambaran besar)
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ARCLUX PLATFORM (developer tooling — SUDAH JADI, bukan game)              │
+│  apps/web · apps/cli · packages/engine·universe·db·daemon·provenance.      │
+├────────────────────────────────────────────────────────────────────────────┤
+│                            GAME MMO (product terpisah)                     │
+│                                                                            │
+│  packages/universe  ✅ World Model (VesselModel, System, License)          │
+│  packages/gameserver 🚧 Authoritative server (world/validator/sim/combat)  │
+│     ├─ gate.ts      🚧 Jump gate routing antar region                      │
+│     ├─ netcode.ts   🚧 Client<->server transport (intent queue)            │
+│     ├─ persistence.ts 🚧 Save/load region state (db + RecoveryManager)     │
+│  packages/relay     🚧 Shard registry + gate handoff + identity            │
+│  apps/game          🚧 Electron client (3D render + input + net)           │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+Keputusan acuan (lihat `docs/blueprint/progres/decisions-mmo.md` D-001..D-012):
+server-authoritative penuh (D-008), self-host per shard (D-009), multi-shard Region
++ Gates (D-005/D-006), repo = 1 vessel (D-007). Desain: `docs/blueprint/0X-*.md`.
+
+---
+
+## 2. Status & arah tiap modul
+
+### 2.1 `packages/universe` ✅ (SRC = vessel identity & source of config)
+- **Udah ada**: `types.ts` (VesselModel/SystemState/SubsystemId/LicenseTier),
+  `stats.ts` (deriveBaseStats/mergeManifest/buildVesselModel), `license.ts`
+  (checkComponent/validateVesselComponents 3-tier), `schema.ts` (validateManifest/
+  capOverride), `connect.ts` (connectRepository). Barrel `index.ts`. PR #580.
+- **Arah berikutnya**: stabil — dipakai gameserver. Tambah hanya kalau model
+  vessel butuh field baru (mis. identity layer §18 blueprint 06: repository id,
+  community ref). **Perubahan di sini menyebar** ke gameserver — review dulu.
+
+### 2.2 `packages/gameserver` 🚧 (server authoritative — PR #582 core)
+**Udah ada (berfungsi, terverifikasi via smoke test):**
+- `types.ts` — Vec3, GameEntity, VesselEntity, StationEntity, RegionState,
+  GameEvent, PlayerIntent
+- `world.ts` — WorldRegion entity registry (spawn/move/remove vessel & station,
+  proximity `entitiesWithin`, snapshot, regionFromState, distanceBetween, safe-zone data)
+- `validator.ts` — validateIntent (identity/owner/range/cooldown/safe-zone/
+  license reuse universe)
+- `simulation.ts` — SimulationEngine (enqueue/step deterministic tick, moveToward,
+  integratePhysics, cooldown, replayLog, computeEntityHash)
+- `combat.ts` — applyCombatIntent, damage per subsystem, DAMAGE_CEILING
+- Barrel `index.ts`
+
+**Belum ada — kerangka di file ini (tinggal isi):**
+- `gate.ts` 🚧 — jump gate routing & handoff antar region. TODOs di dalam file.
+- `netcode.ts` 🚧 — transport client↔server (intent in, events out), reuses
+  SimulationEngine.enqueue. TODOs.
+- `persistence.ts` 🚧 — save/load RegionState via `packages/db` + RecoveryManager. TODOs.
+
+**Arah (prioritas isi berikutnya):**
+1. `gate.ts` — handoff vessel antar region (D-006 jalur eksplisit dulu, seamless nanti)
+2. `persistence.ts` — simpan doang bisa langsung pakai prove of `snapshot`
+3. `netcode.ts` — pasang pas `apps/game` klien pertama
+
+### 2.3 `packages/relay` 🚧 (shard registry + gate handoff + identity lintas shard)
+**Kerangka dibuat, file**: `index.ts`, `registry.ts`, `gate.ts`, `identity.ts`, `types.ts`.
+**Arah**: 
+- registry: daftar shard server + claim region (mapping region id -> server addr)
+- gate: koordinasi handoff vessel antar region milik server yang beda
+- identity: pemetaan player id lintas shard (global handle -> per-shard entity)
+Semua TODOs dicatet di file masing-masing. Belum ada konsumen — dimulai saat
+butuh 2+ server (multi-shard) atau handoff.
+
+### 2.4 `apps/game` 🚧 (Electron client 3D)
+**Kerangka dibuat**: `src/main/` (Electron main), `src/renderer/` (3D + input +
+net), `index.ts`, `package.json`. **Arah**:
+- bootstrap Electron + jendela
+- renderer pakai `three` (sama kayak apps/web GraphCanvas3D) buat render vessel
+- input -> netcode -> game server; render event dari server (anti-cheat D-008)
+- belum ada executable; jalan via `npx electron .` sekali kerangka net terisi
+
+### 2.5 Modul platform yang DIPAKAI MMO (jangan dibikin ulang)
+| Paket | Peran di MMO |
+|---|---|
+| `packages/engine/pipeline.ts` | analisis repo → vessel base stats (input `buildVesselModel`) |
+| `packages/db` | persistensi world/region/vessel (dipakai gameserver.persistence) |
+| `packages/provenance` | history vessel/component/ownership |
+| `packages/daemon` + `watcher` | auto-update vessel saat repo berubah |
+| `three` + GraphCanvas3D | fondasi render 3D (dipakai apps/game renderer) |
+| `packages/shell` | extension user-space (optional) |
+
+---
+
+## 3. Checklist implementasi (urutan build plan, tiap item = PR, jangan auto-merge)
+
+### PR #580 ✅ universe — SUDJAH
+### PR #582 ✅ gameserver core (world/validator/sim/combat) — SUDJAH
+### PR berikutnya (urutan)
+- [ ] gameserver: `gate.ts` jump gate routing (handoff eksplisit)
+- [ ] gameserver: `persistence.ts` save/load region (db + RecoveryManager)
+- [ ] gameserver: `netcode.ts` transport intent/events
+- [ ] `packages/relay`: registry + gate handoff + identity
+- [ ] `apps/game`: bootstrap Electron + 3D render vessel dari RegionState
+- [ ] integrasi: `arclux connect` → vessel masuk universe → jump gate → station/community
+- [ ] dynamic safe-zone / governance state (blueprint 06 §13-16) — modifikasi validator
+
+> Setiap kali selesai isi satu modul: update §2 status file + checklist §3,
+> lalu commit/PR terpisah.
+
+---
+
+## 4. Boundary & gotcha (jangan dilanggar)
+
+- **Client TIDAK pernah jadi otoritas** (D-008, invariant I-1). Semua keputusan
+  combat/ownership lewat server + WorldValidator.
+- `apps/web` = developer bridge, BUKAN game. Jangan taruh game loop di web.
+- Engine (code-intelligence) PISAH dari game MMO — game pakai engine sebagai input.
+- Self-host per shard (D-009): tiap region/server punya host sendiri; relay cuma
+  registry/bridge, bukan server game.
+- Repo = 1 vessel (D-007). `connectRepository` (universe) jadi pintu masuk.
+- Konvensi file: header Apache 2.0 8 baris + barrel `index.ts` + komentar fungsi
+  di atas deklarasi. Gak ada package.json/tsconfig per package (flat monorepo,
+  root tsconfig `moduleResolution: bundler`).
+- `docs/` gitignored — semua file docs/blueprint/** di-add dengan `git add -f`.
+
+---
+
+## 5. Log sesi (isi tiap sesi — biar gak lupa & gak tumpang tindih)
+
+| Tanggal | PR / commit | Yang dikerjakan | Status |
+|---|---|---|---|
+| 2026-08-28 | #580 | universe World Model foundation | ✅ merged |
+| 2026-08-28 | #582 | gameserver core (world/validator/sim/combat) | ✅ merged |
+| 2026-08-28 | — | scaffolding relay + apps/game + kerangka gate/netcode/persistence | in progress |

--- a/docs/blueprint/progres/README.md
+++ b/docs/blueprint/progres/README.md
@@ -22,6 +22,7 @@ keputusan engine.
 |---|---|
 | [decisions-mmo.md](decisions-mmo.md) | Semua keputusan desain MMO yang diambil (visi, arsitektur, stack, model) |
 | [arsitektur.md](arsitektur.md) | Peta arsitektur MMO (server authoritative, client, shard registry) |
+| [MMO-IMPLEMENTATION.md](MMO-IMPLEMENTATION.md) | **Peta implementasi anti-lupa** (status tiap modul + arah + checklist + TODO). Baca ini DULU sebelum ngoding MMO |
 
 ## Files blueprint terkait
 

--- a/docs/blueprint/progres/arsitektur.md
+++ b/docs/blueprint/progres/arsitektur.md
@@ -83,10 +83,17 @@ Client TIDAK pernah menjadi otoritas — ia render hasil validated simulation.
 1. **PR #580** — `packages/universe` fondasi World Model ✅ (sudah merged)
 2. **`packages/gameserver`** — server authoritative + WorldModel + Validator
    (region single dulu), sim loop, netcode input-queue, replay
-3. **`packages/relay`** — shard registry + gate handoff + identity lintas shard
-4. **`apps/game`** (Electron) — client 3D + net integration + UI universe
-5. **Integrasi penuh** — `arclux connect` → vessel masuk universe, jump gate
+   - core (world/validator/sim/combat) ✅ PR #582
+   - kerangka tambahan (gate/netcode/persistence) ✅ scaffold
+2. **`packages/relay`** — shard registry + gate handoff + identity lintas shard
+   - scaffold ✅ (registry/gate/identity)
+3. **`apps/game`** (Electron) — client 3D + net integration + UI universe
+   - scaffold ✅ (main/renderer + build script)
+4. **Integrasi penuh** — `arclux connect` → vessel masuk universe, jump gate
    antar region, station/community layer
+
+> **IMPL.** Urutan kerja & status tiap modul yang hidup di
+> [MMO-IMPLEMENTATION.md](MMO-IMPLEMENTATION.md) — baca itu dulu sebelum ngoding.
 
 ---
 

--- a/packages/gameserver/gate.ts
+++ b/packages/gameserver/gate.ts
@@ -1,0 +1,110 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// gate.ts — Jump Gate routing & handoff antar region (D-006: Region + Gates).
+//
+// 🚧 SCAFFOLD — kerangka implementasi, BELUM berfungsi penuh. Bagian yang jadi
+// ditandai `// IMPL:` dengan deskripsi; TODO list di bawah §TODOS.
+//
+// Lifecycle yang mau dicapai (eksplisit dulu, seamless di fase berikutnya):
+//
+// ```
+// GATE REGION A (server A)                 GATE REGION B (server B)
+// ───────────────────────                  ───────────────────────
+// vessel approach gate → intent IN → relay notifies B → B claims vessel
+//   ↘ entity removed from A                     ↙ vessel spawned in B
+//        HANDOFF ACK        (persisted via recovery / relay handshake)
+// ```
+//
+// Prinsip: handoff vessel antar region = transfer kepemilikan sim, WAJIB lewat
+// jalur resmi relay/gate — bukan mutasi langsung state region lain (self-host,
+// D-009). Server tidak bisa mengubah authoritative state milik server lain.
+
+import type { ComponentBinding } from "../universe/types";
+import type { PlayerIntent, Vec3 } from "./types";
+
+/** Deskripsi satu jump gate yang menghubungkan region ini ke region lain. */
+export interface GateLink {
+  /** id unik gate. */
+  id: string;
+  /** id region lokal tempat gate berada. */
+  localRegionId: string;
+  /** id region tujuan (milik shard/server lain). */
+  targetRegionId: string;
+  /** posisi gate di region lokal. */
+  position: Vec3;
+  /** radius aktivasi (vessel yang mendekat dalam radius ini dapat transit). */
+  activationRadius: number;
+  /** otorisasi: komunitas yang boleh transit (kosong = publik). */
+  allowedCommunityIds: string[];
+}
+
+/** Permintaan transit vessel lewat gate (dikirim ke relay/gate handler). */
+export interface GateTransitRequest {
+  gateId: string;
+  vesselId: string;
+  targetRegionId: string;
+  requestedBy: string; // player id yang mengarahkan vessel
+  expectedArrival: Vec3;
+}
+
+/** Hasil handoff: berhasil bawa vessel ke region tujuan, atau ditolak. */
+export interface GateTransitResult {
+  ok: boolean;
+  reason?: string;
+  /** kalau ok, data minimal untuk region tujuan men-spawn vessel. */
+  handoff?: {
+    vesselId: string;
+    owner: string;
+    // IMPL: initial WorldState + VesselModel snapshot dibawa ke region tujuan.
+    //       JANGAN bawa seluruh code — bawa representation/token, bukan source.
+    position: Vec3;
+    hubId?: string;
+  };
+}
+
+export interface GateRouter {
+  transit(req: GateTransitRequest): Promise<GateTransitResult>;
+}
+
+/**
+ * 🚧 Deterministik gate: vessel yang ada dalam activationRadius & berhak
+ * transit (allowedCommunityIds) dilepas dari region lokal, lalu diminta
+ * region tujuan men-spawn. Belum ada transport (relay/netcode) — IMPL pakai
+ * relay ketika tersedia.
+ */
+export function createGateRouter(links: GateLink[]): GateRouter {
+  // IMPL:
+  //  - cari link by gateId & targetRegionId
+  //  - cek allowedCommunityIds vs pemilik vessel/community
+  //  - validasi posisi vessel dalam activationRadius
+  //  - remove vessel dari region lokal (world.removeVessel)
+  //  - notify relay (registry.gate) → region tujuan spawn
+  //  - return GateTransitResult
+  const transit: GateRouter["transit"] = async (req) => {
+    const link = links.find(
+      (l) => l.id === req.gateId && l.targetRegionId === req.targetRegionId,
+    );
+    if (!link) {
+      return { ok: false, reason: `gate ${req.gateId} -> ${req.targetRegionId} not found` };
+    }
+    // TODO: implementasi validasi radius + otorisasi + handoff (lihat TODOS).
+    return { ok: false, reason: "not implemented (scaffold)" };
+  };
+
+  return { transit };
+}
+
+//
+// §TODOS — tinggal isi satu per satu, update check saat selesai
+//
+// TODO(gate)[handoff] implementasi transit(): validasi radius + community + remove vessel
+// TODO(gate)[relay]   hubungkan ke packages/relay untuk notifikasi region tujuan
+// TODO(gate)[persist] simpan handoff token ke persistence sebelum region tujuan spawn (crash-safe)
+// TODO(gate)[event]   emit world event `gate.transit.start` / `gate.transit.complete` (blueprint 06 §14)
+// TODO(gate)[test]    smoke test: dua region, transit vessel, pastikan muncul di tujuan & hilang di asal

--- a/packages/gameserver/index.ts
+++ b/packages/gameserver/index.ts
@@ -17,3 +17,6 @@ export * from "./world";
 export * from "./validator";
 export * from "./simulation";
 export * from "./combat";
+export * from "./gate";
+export * from "./netcode";
+export * from "./persistence";

--- a/packages/gameserver/netcode.ts
+++ b/packages/gameserver/netcode.ts
@@ -1,0 +1,90 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// netcode.ts — transport client ↔ server (D-008 server-authoritative).
+//
+// 🚧 SCAFFOLD — kerangka implementasi. Bagian yang jadi ditandai `// IMPL:`.
+//
+// Alur (mengikuti SimulationEngine yang SUDAH ada):
+//
+// ```
+// CLIENT                       SERVER (SimulationEngine)
+//   │ input intent -----------------▶ enqueue({playerId,...})
+//   │                                step() → validate + sim → events
+//   │ ◀── RegionState snapshot / events / damage
+// ```
+//
+// Client TIDAK menghitung hasil — ia kirim intent, terima events & state,
+// lalu render (invariant I-1: client is not authoritative).
+
+import type { GameEvent, PlayerIntent, RegionSnapshot } from "./types";
+import type { SimulationEngine } from "./simulation";
+
+/** Peta pendengar untuk satu tipe event yang dipancarkan server → client. */
+export type NetEvent = GameEvent;
+
+export interface NetcodeTransport {
+  /** Terima intent dari client (diteruskan ke SimulationEngine.enqueue). */
+  sendIntent(intent: PlayerIntent): void;
+  /** Client meminta snapshot state region untuk pertama render / re-sync. */
+  requestSnapshot(): RegionSnapshot | undefined;
+  /** Daftarkan handler event (combat, move, gate, governance, dst). */
+  onEvent(handler: (ev: NetEvent) => void): void;
+}
+
+export interface NetcodeOptions {
+  engine: SimulationEngine;
+  /**
+   * ambil snapshot terkini region dari engine (IMPLEMENTED via engine.region).
+   * Pemutusan: transport nge-proxy engine.enqueue & event ke handler, plus
+   * polling snapshot. Nanti diganti channel (WebSocket) di apps/game + server.
+   */
+}
+
+/**
+ * 🚧 In-process transport: bridge langsung ke SimulationEngine. Berguna buat
+ * unit-test & prototype client-in-browser sebelum ada transport jaringan beneran.
+ */
+export function createInProcessTransport(opts: NetcodeOptions): NetcodeTransport {
+  const handlers: Array<(ev: NetEvent) => void> = [];
+
+  const sendIntent = (intent: PlayerIntent) => {
+    // IMPL: retain seq ordering + back-pressure (jangan banjiri queue),
+    //       lalu engine.enqueue(intent). Setiap step(), events yang dihasilkan
+    //       engine harus dibagikan ke handlers.
+    opts.engine.enqueue(intent);
+    void opts;
+    // TODO(netcode): jembatani event output engine → handlers tiap step
+  };
+
+  const onEvent = (handler: (ev: NetEvent) => void) => {
+    handlers.push(handler);
+  };
+
+  // IMPL(netcode): panggil ini tiap SimulationEngine.step() selesai — terapkan
+  // list event output engine ke semua handler (lihat TODO(netcode)[events]).
+  const pumpEvents = (evs: NetEvent[]) => {
+    for (const ev of evs) for (const h of handlers) h(ev);
+  };
+  void pumpEvents;
+
+  const requestSnapshot = (): RegionSnapshot | undefined => {
+    return opts.engine.region.snapshot();
+  };
+
+  return { sendIntent, requestSnapshot, onEvent };
+}
+
+//
+// §TODOS — tinggal isi satu per satu, update check saat selesai
+//
+// TODO(netcode)[events]   pipeline: output event SimulationEngine.step() → emit ke handlers
+// TODO(netcode)[auth]     resolver player id: authProvider → actor id sebelum enqueue
+// TODO(netcode)[seq]      ordering: pastikan intent diproses sesuai seq request
+// TODO(netcode)[channel]  ganti in-process → transport jaringan (WebSocket) utk apps/game
+// TODO(netcode)[snapshot] throttle requestSnapshot & delta-sync (jangan kirim full tiap tick)

--- a/packages/gameserver/persistence.ts
+++ b/packages/gameserver/persistence.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// persistence.ts — save/load region world state (D-009 self-host, per-region).
+//
+// 🚧 SCAFFOLD — kerangka implementasi. Bagian yang jadi ditandai `// IMPL:`.
+//
+// RegionSnapshot (dari world.snapshot / dimuat ulang via regionFromState) adalah
+// bentuk serial yang sudah bisa dipersist & di-recovery. Modul ini menambahkan:
+//   - simpan snapshot ke `packages/db` (RepoStore/AnalysisStore turunan / store
+//     baru untuk RegionSnapshot)
+//   - recovery crash-safe: config per-sim simpan "terakhir sukses" + anti-torn-write
+//
+// Relations:
+//   - `world.ts` → snapshot()/regionFromState() → persist/load di sini
+//   - `packages/db` → penyimpanan real (belum ada store RegionSnapshot → IMPL)
+//   - `packages/storage/RecoveryManager` → helper crash-safe (reuse)
+
+import type { RegionSnapshot } from "./types";
+
+export interface PersistenceStore {
+  saveRegion(regionId: string, state: RegionSnapshot): Promise<void>;
+  loadRegion(regionId: string): Promise<RegionSnapshot | null>;
+  deleteRegion(regionId: string): Promise<void>;
+}
+
+/**
+ * 🚧 In-memory stub — buat ganti dengan `packages/db` store (lihat TODOS).
+ * Memungkinkan pipeline persist/load diuji tanpa koneksi DB.
+ */
+export function createInMemoryPersistence(): PersistenceStore {
+  const regions = new Map<string, RegionSnapshot>();
+
+  return {
+    async saveRegion(regionId, state) {
+      // IMPL: normalize timestamps + validasi before write (lihat TODO(persist)[valid])
+      regions.set(regionId, structuredClone(state));
+    },
+    async loadRegion(regionId) {
+      const s = regions.get(regionId);
+      return s ? structuredClone(s) : null;
+    },
+    async deleteRegion(regionId) {
+      regions.delete(regionId);
+    },
+  };
+}
+
+/**
+ * 🚧 Persist ke paket db. Siap memakai store RegionSnapshot yang perlu dibuat
+ * dulu di `packages/db` (lihat TODO(persist)[dbstore]).
+ */
+export function createDbPersistence(
+  // IMPL: terima store db (RepoStore-like) — TODO diisi saat store ada
+  _db?: unknown,
+): PersistenceStore {
+  return {
+    async saveRegion() {
+      throw new Error("db persistence not implemented yet (scaffold)");
+    },
+    async loadRegion() {
+      return null;
+    },
+    async deleteRegion() {
+      // no-op: belum ada store
+    },
+  };
+}
+
+//
+// §TODOS — tinggal isi satu per satu, update check saat selesai
+//
+// TODO(persist)[dbstore]   buat RegionStore di packages/db (schema RegionState v1)
+// TODO(persist)[dbbe]      implementasikan createDbPersistence di atas store tsb
+// TODO(persist)[valid]     validateRegion(state) sebelum save (pakai universe/schema pattern)
+// TODO(persist)[crash]     RecoveryManager: simpan pointer "last-good" + versioned snapshot
+// TODO(persist)[recovery]  regionFromState() dipakai overload setelah load (sudah ada di world)
+// TODO(persist)[test]      smoke: create region → snapshot → save → load → regionFromState == equal

--- a/packages/gameserver/types.ts
+++ b/packages/gameserver/types.ts
@@ -73,6 +73,19 @@ export interface RegionState {
   createdAt: string;
 }
 
+/**
+ * Plain, serializable snapshot of a region — for client render & persistence
+ * (no live `Map`, no live object refs). This is what `WorldRegion.snapshot()`
+ * returns and what `packages/gameserver/persistence` saves/loads.
+ */
+export interface RegionSnapshot {
+  regionId: string;
+  name: string;
+  tick: number;
+  createdAt: string;
+  entities: WorldEntity[];
+}
+
 /** A validated, immutable event that happened in the world. */
 export interface GameEvent {
   id: string;

--- a/packages/gameserver/world.ts
+++ b/packages/gameserver/world.ts
@@ -12,7 +12,7 @@
 // simulation engine). The region owns its entities; external code never
 // mutates the map directly.
 
-import type { GameEntity, RegionState, StationEntity, VesselEntity, WorldEntity } from "./types";
+import type { GameEntity, RegionSnapshot, StationEntity, VesselEntity, WorldEntity } from "./types";
 
 export interface SpawnVesselOptions {
   id: string;
@@ -68,10 +68,12 @@ export class WorldRegion {
   }
 
   /** Returns a plain snapshot (for client render / persistence, no live refs). */
-  snapshot(): { regionId: string; tick: number; entities: WorldEntity[] } {
+  snapshot(): RegionSnapshot {
     return {
       regionId: this.regionId,
+      name: this.name,
       tick: this.tick,
+      createdAt: this.createdAt,
       entities: Array.from(this.entities.values()),
     };
   }
@@ -136,11 +138,11 @@ export class WorldRegion {
   }
 }
 
-/** Rebuild a WorldRegion from a persisted RegionState (for recovery). */
-export function regionFromState(state: RegionState): WorldRegion {
+/** Rebuild a WorldRegion from a persisted RegionSnapshot (for recovery). */
+export function regionFromState(state: RegionSnapshot): WorldRegion {
   const region = new WorldRegion(state.regionId, state.name);
   region.tick = state.tick;
-  for (const e of state.entities.values()) {
+  for (const e of state.entities) {
     region["entities"].set(e.id, e);
   }
   return region;

--- a/packages/relay/gate.ts
+++ b/packages/relay/gate.ts
@@ -1,0 +1,71 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// gate.ts — koordinasi handoff vessel antar region milik server yang BEDA.
+//
+// 🚧 SCAFFOLD — kerangka implementasi. Bagian jadi ditandai `// IMPL:`.
+//
+// Alur (melengkapi packages/gameserver/gate.ts yang ngurus sisi server lokal):
+//
+// ```
+// server A (gameserver.gate.transit)
+//   → relay.gate.requestHandoff({vesselId, fromShardId, toRegionId, token})
+//   → relay temukan toShardId via registry.resolveRegion(toRegionId)
+//   → relay forward request ke server B (via hook/endpoint, IMPL)
+//   → server B: validasi token → spawn vessel → ack
+//   → relay return HandoffResult ke server A
+// ```
+
+import type { HandoffRequest, HandoffResult } from "./types";
+import type { RelayRegistry } from "./registry";
+
+export interface GateCoordinator {
+  requestHandoff(req: HandoffRequest): Promise<HandoffResult>;
+  /** resolusi manual: region tujuan → shard mana (bantu debug & test). */
+  resolveTarget(regionId: string): string | undefined;
+}
+
+export interface GateCoordinatorOptions {
+  registry: RelayRegistry;
+  /** alamat pengirim (relay tahu server A). */
+  fromShardId: string;
+}
+
+/**
+ * 🚧 Koordinator in-process: resolusi lewat registry + validasi token minimal.
+ * Transport aktual ke server tujuan (network) dimasukkan via `deliver` hook
+ * (TODO(gate)[deliver]).
+ */
+export function createGateCoordinator(opts: GateCoordinatorOptions): GateCoordinator {
+  const resolveTarget = (regionId: string) => {
+    const s = opts.registry.resolveRegion(regionId);
+    return s?.shardId;
+  };
+
+  const requestHandoff: GateCoordinator["requestHandoff"] = async (req) => {
+    const toShard = resolveTarget(req.toRegionId);
+    if (!toShard) return { ok: false, reason: `no shard claims ${req.toRegionId}` };
+
+    // IMPL(gate): validasi — token bukan source code, req.seq konsisten, fromShardId cocok
+    // IMPL(gate): kirim ke server tujuan via socket/HOOK (lihat TODO(gate)[deliver])
+    // IMPL(gate): server tujuan spawn vessel (gameserver) → ack kalau berhasil
+    return { ok: false, reason: "delivery to target shard not implemented (scaffold)" };
+  };
+
+  return { requestHandoff, resolveTarget };
+}
+
+//
+// §TODOS
+//
+// TODO(gate)[deliver]   hook transport ke server tujuan (WebSocket/gRPC) — `deliver(req, addr)`
+// TODO(gate)[token]     buat/verifikasi transferToken (anti forgery) — bukan source code
+// TODO(gate)[seq]       ordering & idempotency (retry handoff gak dobel-spawn)
+// TODO(gate)[crash]     simpan in-flight handoff → recovery kalau server A/B mati tengah
+// TODO(gate)[event]     record world/gate event (blueprint 06 §14) di kedua region
+// TODO(gate)[test]      smoke: A→B handoff, simulasikan ack & reject path

--- a/packages/relay/identity.ts
+++ b/packages/relay/identity.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// identity.ts — pemetaan player id lintas shard (global handle → per-shard entity).
+//
+// 🚧 SCAFFOLD — kerangka implementasi. Bagian jadi ditandai `// IMPL:`.
+//
+// Karena multi-shard (D-005), satu pemain bisa punya entity di beberapa region
+// sekaligus. Relay memegang pemetaan global:
+//
+// ```
+// playerId (global) → [{shardId, entityId(s)}, ...]
+// ```
+//
+// Ini dipakai untuk: routing intent antar shard, pasangan di gate handoff,
+// dan mencari entity pemain di region lain.
+
+export interface ShardPresence {
+  shardId: string;
+  entityIds: string[];
+  lastSeen: number;
+}
+
+export interface IdentityMap {
+  attach(playerId: string, presence: ShardPresence): void;
+  detach(playerId: string, shardId: string): void;
+  resolve(playerId: string): ShardPresence[];
+  has(playerId: string): boolean;
+}
+
+/**
+ * 🚧 In-memory map. Untuk self-host skala kecil cukup; pemetaan persisten /
+ * lintas-host → pakai packages/db (TODO(identity)[persist]).
+ */
+export function createIdentityMap(): IdentityMap {
+  const map = new Map<string, ShardPresence[]>();
+
+  const attach = (playerId: string, presence: ShardPresence) => {
+    const list = map.get(playerId) ?? [];
+    const i = list.findIndex((p) => p.shardId === presence.shardId);
+    if (i >= 0) list[i] = presence;
+    else list.push(presence);
+    map.set(playerId, list);
+  };
+  const detach = (playerId: string, shardId: string) => {
+    const list = map.get(playerId);
+    if (!list) return;
+    const next = list.filter((p) => p.shardId !== shardId);
+    if (next.length) map.set(playerId, next);
+    else map.delete(playerId);
+  };
+  const resolve = (playerId: string) => map.get(playerId) ?? [];
+  const has = (playerId: string) => map.has(playerId);
+
+  return { attach, detach, resolve, has };
+}
+
+//
+// §TODOS
+//
+// TODO(identity)[persist]   simpan map ke packages/db (recovery saat relay restart)
+// TODO(identity)[auth]      verifikasi player id asli (bukan spoof) sebelum attach
+// TODO(identity)[gate]      saat handoff, update presence di shard asal & tujuan
+// TODO(identity)[test]      smoke: attach 2 shard, resolve bener, detach satu bersih

--- a/packages/relay/index.ts
+++ b/packages/relay/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// packages/relay — SHARD REGISTRY + BRIDGE (D-005 multi-shard, D-009 self-host).
+//
+// Relay pusat (registry + gate config + identity lintas shard) — BUKAN game
+// server. Scan MMO-IMPLEMENTATION.md §2.3 sebelum implementasi.
+//
+// Barrel: expose semua API relay.
+
+export * from "./types";
+export * from "./registry";
+export * from "./gate";
+export * from "./identity";

--- a/packages/relay/registry.ts
+++ b/packages/relay/registry.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// registry.ts — daftar shard server + claim region (mapping region → server).
+//
+// 🚧 SCAFFOLD — kerangka implementasi. Bagian jadi ditandai `// IMPL:`.
+//
+// Relay menjaga:
+//   - `shards`: siapa yang online & alamatnya
+//   - `claims`: region mana dipegang server mana (anti bentrok)
+
+import type { RegionClaim, ShardRecord, ShardStatus } from "./types";
+
+export interface RelayRegistry {
+  registerShard(shard: ShardRecord): void;
+  unregisterShard(shardId: string): void;
+  setShardStatus(shardId: string, status: ShardStatus): void;
+  listShards(): ShardRecord[];
+  getShard(shardId: string): ShardRecord | undefined;
+
+  claimRegion(regionId: string, shardId: string): boolean;
+  releaseRegion(regionId: string, shardId: string): boolean;
+  resolveRegion(regionId: string): ShardRecord | undefined;
+}
+
+/**
+ * 🚧 In-memory registry — jalurnya pass utk 1 proses (prototype/self-host).
+ * Saat multi-process, ganti state ke pakai packages/db atau key-value terpusat
+ * (lihat TODO(registry)[distributed]).
+ */
+export function createRelayRegistry(): RelayRegistry {
+  const shards = new Map<string, ShardRecord>();
+  const claims = new Map<string, RegionClaim>();
+
+  const registerShard = (shard: ShardRecord) => {
+    shards.set(shard.shardId, { ...shard });
+  };
+  const unregisterShard = (shardId: string) => {
+    for (const [regionId, c] of claims) if (c.shardId === shardId) claims.delete(regionId);
+    shards.delete(shardId);
+  };
+  const listShards = () => [...shards.values()];
+  const getShard = (shardId: string) => shards.get(shardId);
+
+  const claimRegion = (regionId: string, shardId: string) => {
+    const existing = claims.get(regionId);
+    if (existing && existing.shardId !== shardId) return false; // dipegang server lain
+    claims.set(regionId, { regionId, shardId, claimedAt: Date.now() });
+    // IMPL: pastikan shard sudah register sebelum claim
+    if (!shards.has(shardId)) return false;
+    return true;
+  };
+  const releaseRegion = (regionId: string, shardId: string) => {
+    const c = claims.get(regionId);
+    if (!c || c.shardId !== shardId) return false;
+    claims.delete(regionId);
+    return true;
+  };
+  const resolveRegion = (regionId: string) => {
+    const c = claims.get(regionId);
+    return c ? shards.get(c.shardId) : undefined;
+  };
+
+  return {
+    registerShard,
+    unregisterShard,
+    setShardStatus: (shardId, status) => {
+      const s = shards.get(shardId);
+      if (s) s.status = status;
+    },
+    listShards,
+    getShard,
+    claimRegion,
+    releaseRegion,
+    resolveRegion,
+  };
+}
+
+//
+// §TODOS
+//
+// TODO(registry)[renew]     TTL claim + auto-release saat shard down/draining
+// TODO(registry)[hb]        heartbeat: update status berdasarkan last-beat waktu nyata
+// TODO(registry)[distributed] swap in-memory → packages/db (persisten lintas host)
+// TODO(registry)[auth]      authorisasi claim (hanya pemilik self-host region)
+// TODO(registry)[test]      smoke: dua shard claim beda region, bentrok ditolak, resolve bener

--- a/packages/relay/types.ts
+++ b/packages/relay/types.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// packages/relay — SHARD REGISTRY + BRIDGE (D-005 multi-shard, D-009 self-host).
+//
+// Relay adalah pusat DAN BUKAN game server: ia hanya memetakan region → server,
+// mengoordinasikan gate handoff, dan memegang identity lintas shard. Semua sim
+// & keputusan combat tetap di gameserver tiap shard (self-host).
+
+/** Satu instance shard server yang terdaftar di relay. */
+export interface ShardRecord {
+  /** id unik shard/server. */
+  shardId: string;
+  /** alamat jaringan (host:port) tempat gameserver berjalan. */
+  address: string;
+  /** wilayah (region) yang di-claim server ini (1..n). */
+  regionIds: string[];
+  /** health: "up" | "down" | "draining" (mulai stop, tak terima new vessel). */
+  status: ShardStatus;
+  /** metadata bebas (pemilik self-host, community, versi, dst). */
+  meta?: Record<string, unknown>;
+}
+
+export type ShardStatus = "up" | "down" | "draining";
+
+/** Claim: server meng-claim satu region supaya tidak bentrok 2 server. */
+export interface RegionClaim {
+  regionId: string;
+  shardId: string;
+  claimedAt: number;
+  ttlMs?: number; // renewal; expire kalau server mati
+}
+
+/** Permintaan handoff vessel antar region milik server yang BEDA. */
+export interface HandoffRequest {
+  vesselId: string;
+  fromRegionId: string;
+  fromShardId: string;
+  toRegionId: string;
+  toShardId: string;
+  /** token serah-terima — jangan bawa source code, bawa representation/token. */
+  transferToken: string;
+  seq: number;
+}
+
+export interface HandoffResult {
+  ok: boolean;
+  reason?: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,19 @@ importers:
         specifier: ^0.28.0
         version: 0.28.1
 
+  apps/game:
+    dependencies:
+      three:
+        specifier: ^0.169.0
+        version: 0.169.0
+    devDependencies:
+      electron:
+        specifier: ^31.0.0
+        version: 31.7.7
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.1
+
   apps/vscode-extension:
     devDependencies:
       '@types/node':
@@ -374,6 +387,10 @@ packages:
 
   '@dotenvx/primitives@0.8.0':
     resolution: {integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==}
+
+  '@electron/get@2.0.3':
+    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
+    engines: {node: '>=12'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1196,6 +1213,10 @@ packages:
   '@simple-git/argv-parser@1.1.1':
     resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -1205,6 +1226,10 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@tabler/icons-react@3.46.0':
     resolution: {integrity: sha512-CCm7xJWhDT2PH4ZIFkP6AgYKtVhq0gpYkjUN+GVh1AzmIQaa77OW0bQPBPQiTE0PsXMR9oSxFqA3qBglzPyrVQ==}
@@ -1344,6 +1369,9 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1359,11 +1387,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
@@ -1375,6 +1409,9 @@ packages:
 
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
@@ -1390,6 +1427,9 @@ packages:
 
   '@types/webxr@0.5.24':
     resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -1735,6 +1775,10 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
@@ -1751,6 +1795,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -1758,6 +1805,14 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1807,6 +1862,9 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2001,6 +2059,10 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -2023,6 +2085,10 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2051,6 +2117,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
@@ -2077,6 +2146,11 @@ packages:
   electron-to-chromium@1.5.398:
     resolution: {integrity: sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==}
 
+  electron@31.7.7:
+    resolution: {integrity: sha512-HZtZg8EHsDGnswFt0QeV8If8B+et63uD6RJ7I4/xhcXqmTIbI08GoubX/wm+HdY0DwcuPe1/xsgqpmYvjdjRoA==}
+    engines: {node: '>= 12.20.55'}
+    hasBin: true
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -2086,6 +2160,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
@@ -2140,6 +2217,9 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -2320,6 +2400,11 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2351,6 +2436,9 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2429,6 +2517,10 @@ packages:
     resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
     engines: {node: '>=14.14'}
 
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2475,6 +2567,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -2498,6 +2594,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -2513,6 +2613,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2554,9 +2658,16 @@ packages:
     resolution: {integrity: sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==}
     engines: {node: '>=16.9.0'}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2843,6 +2954,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -2851,6 +2965,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -3050,6 +3167,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -3060,6 +3181,10 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -3106,6 +3231,14 @@ packages:
   mimic-function@5.0.1:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -3201,6 +3334,10 @@ packages:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
     engines: {node: '>=18'}
 
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -3284,6 +3421,10 @@ packages:
     resolution: {integrity: sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==}
     engines: {node: '>= 0.4'}
 
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -3348,6 +3489,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3407,6 +3551,10 @@ packages:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3418,6 +3566,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3428,6 +3579,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
@@ -3514,6 +3669,9 @@ packages:
   reselect@5.2.0:
     resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3526,6 +3684,9 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
@@ -3533,6 +3694,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
 
   rolldown@1.2.3:
     resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
@@ -3568,6 +3733,9 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -3580,6 +3748,10 @@ packages:
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -3656,6 +3828,9 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -3746,6 +3921,10 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3781,6 +3960,9 @@ packages:
     engines: {node: '>=12'}
     peerDependencies:
       three: '>=0.179'
+
+  three@0.169.0:
+    resolution: {integrity: sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==}
 
   three@0.185.1:
     resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
@@ -3852,6 +4034,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
+
   type-is@2.1.0:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
@@ -3898,6 +4084,10 @@ packages:
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -4086,6 +4276,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -4375,6 +4568,20 @@ snapshots:
       yocto-spinner: 1.2.2
 
   '@dotenvx/primitives@0.8.0': {}
+
+  '@electron/get@2.0.3':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 2.2.1
+      fs-extra: 8.1.0
+      got: 11.8.6
+      progress: 2.0.3
+      semver: 6.3.1
+      sumchecker: 3.0.1
+    optionalDependencies:
+      global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -5040,6 +5247,8 @@ snapshots:
     dependencies:
       '@simple-git/args-pathspec': 1.0.3
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -5047,6 +5256,10 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@tabler/icons-react@3.46.0(react@19.2.4)':
     dependencies:
@@ -5157,6 +5370,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 20.19.43
+      '@types/responselike': 1.0.3
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -5170,9 +5390,15 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/http-cache-semantics@4.2.0': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 20.19.43
 
   '@types/node@20.19.43':
     dependencies:
@@ -5185,6 +5411,10 @@ snapshots:
   '@types/react@19.2.17':
     dependencies:
       csstype: 3.2.3
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 20.19.43
 
   '@types/stats.js@0.17.4': {}
 
@@ -5202,6 +5432,11 @@ snapshots:
   '@types/vscode@1.125.0': {}
 
   '@types/webxr@0.5.24': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 20.19.43
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -5565,6 +5800,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolean@3.2.0:
+    optional: true
+
   brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
@@ -5586,11 +5824,25 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
+  buffer-crc32@0.2.13: {}
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
 
   bytes@3.1.2: {}
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -5637,6 +5889,10 @@ snapshots:
   cli-spinners@2.9.2: {}
 
   client-only@0.0.1: {}
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   clsx@2.1.1: {}
 
@@ -5814,6 +6070,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   dedent@1.7.2: {}
 
   deep-is@0.1.4: {}
@@ -5826,6 +6086,8 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -5849,6 +6111,9 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  detect-node@2.1.0:
+    optional: true
+
   diff@8.0.4: {}
 
   doctrine@2.1.0:
@@ -5871,11 +6136,23 @@ snapshots:
 
   electron-to-chromium@1.5.398: {}
 
+  electron@31.7.7:
+    dependencies:
+      '@electron/get': 2.0.3
+      '@types/node': 20.19.43
+      extract-zip: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -6005,6 +6282,9 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es6-error@4.1.1:
+    optional: true
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -6330,6 +6610,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -6367,6 +6657,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -6444,6 +6738,12 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
   fsevents@2.3.3:
     optional: true
 
@@ -6493,6 +6793,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.2
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@6.0.1: {}
 
   get-stream@9.0.1:
@@ -6518,6 +6822,16 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.8.5
+      serialize-error: 7.0.1
+    optional: true
+
   globals@14.0.0: {}
 
   globals@16.4.0: {}
@@ -6528,6 +6842,20 @@ snapshots:
       gopd: 1.2.0
 
   gopd@1.2.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
 
@@ -6561,6 +6889,8 @@ snapshots:
 
   hono@4.12.32: {}
 
+  http-cache-semantics@4.2.0: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -6568,6 +6898,11 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
 
   human-signals@2.1.0: {}
 
@@ -6803,11 +7138,18 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1:
+    optional: true
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonfile@6.2.1:
     dependencies:
@@ -6967,6 +7309,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lowercase-keys@2.0.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6978,6 +7322,11 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -7007,6 +7356,10 @@ snapshots:
   mimic-fn@3.1.0: {}
 
   mimic-function@5.0.1: {}
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
 
   minimatch@10.2.6:
     dependencies:
@@ -7090,6 +7443,8 @@ snapshots:
       semver: 6.3.1
 
   node-releases@2.0.51: {}
+
+  normalize-url@6.1.0: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -7205,6 +7560,8 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-cancelable@2.1.1: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -7254,6 +7611,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pend@1.2.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -7299,6 +7658,8 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
+  progress@2.0.3: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -7315,6 +7676,11 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   qs@6.15.3:
@@ -7323,6 +7689,8 @@ snapshots:
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@5.1.1: {}
 
   range-parser@1.3.0: {}
 
@@ -7417,6 +7785,8 @@ snapshots:
 
   reselect@5.2.0: {}
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -7430,12 +7800,26 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
+
   restore-cursor@5.1.0:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
   reusify@1.1.0: {}
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
 
   rolldown@1.2.3:
     dependencies:
@@ -7496,6 +7880,9 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  semver-compare@1.0.0:
+    optional: true
+
   semver@6.3.1: {}
 
   semver@7.8.5: {}
@@ -7515,6 +7902,11 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
 
   serve-static@2.2.1:
     dependencies:
@@ -7677,6 +8069,9 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  sprintf-js@1.1.3:
+    optional: true
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -7778,6 +8173,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.7
 
+  sumchecker@3.0.1:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -7816,6 +8217,8 @@ snapshots:
       three: 0.185.1
     transitivePeerDependencies:
       - preact-render-to-string
+
+  three@0.169.0: {}
 
   three@0.185.1: {}
 
@@ -7887,6 +8290,9 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@0.13.1:
+    optional: true
+
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
@@ -7951,6 +8357,8 @@ snapshots:
   undici@7.29.0: {}
 
   unicorn-magic@0.3.0: {}
+
+  universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 
@@ -8125,6 +8533,11 @@ snapshots:
       powershell-utils: 0.1.0
 
   yallist@3.1.1: {}
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/build-game.mjs
+++ b/scripts/build-game.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Bundles the Electron main process for apps/game into dist/main/main.js
+// (target Electron's node runtime). Renderer is bundled separately by the
+// renderer toolchain / esbuild when the 3D scene is added.
+//
+// This is a SCAFFOLD build script — it only proves the module graph resolves;
+// real packaging (electron-builder, asar, native .wasm handling) comes later.
+
+import { mkdirSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = path.join(root, "apps", "game", "dist");
+
+const __req = createRequire(import.meta.url);
+let esbuildPkg;
+try {
+  esbuildPkg = __req("esbuild");
+} catch {
+  const pnpmDir = path.join(root, "node_modules", ".pnpm");
+  if (existsSync(pnpmDir)) {
+    const esbuildDir = readdirSync(pnpmDir)
+      .filter((d) => d.startsWith("esbuild@"))
+      .sort()
+      .pop();
+    esbuildPkg = __req(path.join(pnpmDir, esbuildDir, "node_modules", "esbuild"));
+  }
+}
+const { build } = esbuildPkg;
+
+mkdirSync(outDir, { recursive: true });
+
+await build({
+  entryPoints: [path.join(root, "apps", "game", "src", "main", "main.ts")],
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  format: "cjs",
+  outfile: path.join(outDir, "main", "main.js"),
+  external: ["electron", "node:*", "fs", "path", "os", "child_process"],
+  logLevel: "info",
+});
+
+console.log("✓ bundled apps/game/dist/main/main.js (Electron main, scaffold)");


### PR DESCRIPTION
Scaffolding MMO lengkap supaya **tinggal isi satu-satu tanpa ngulang**. Ditambah master map anti-lupa + modul kerangka dengan TODO implementasi jelas di tiap file.

> Rebase ke `ARCLUX.main` (V3 #583 sudah merged) → diff PR ini **murni scaffolding**, tidak menyentuh dokumen blueprint yang sudah ada.

## Master map (baca dulu sebelum ngoding)
**`docs/blueprint/progres/MMO-IMPLEMENTATION.md`** — status tiap modul + arah + checklist build plan + log sesi. Anti-lupa semuanya.

## packages/gameserver (perluas)
- `gate.ts` — jump gate routing & handoff antar region (D-006), kerangka + TODO
- `netcode.ts` — transport client↔server (reuse `SimulationEngine.enqueue`), kerangka + TODO
- `persistence.ts` — save/load `RegionSnapshot` via `packages/db`, kerangka + in-memory stub
- `types.ts`/`world.ts` — tambah `RegionSnapshot` (serial plain). `snapshot()`/`regionFromState` kini konsisten (bukan Map), dasar persist/render

## packages/relay (BARU — shard registry + bridge, D-005/D-009)
- `types.ts`, `registry.ts` (register/claim/resolve region), `gate.ts` (handoff coord), `identity.ts` (player lintas shard). Semua in-memory + TODO.

## apps/game (BARU — Electron client 3D, D-008)
- `package.json`/`tsconfig`, `index.ts`, `src/main/main.ts`, `src/renderer/{index.html,renderer,scene3d,net}.ts` + `scripts/build-game.mjs`

## Verifikasi
- ✅ `tsc --noEmit` bersih (gameserver/relay/apps-game/lib)
- ✅ `build-cli` + `build-game` (esbuild) sukses
- ✅ Smoke test end-to-end: snapshot→persist→rebuild roundtrip, relay claim/resolve region, identity lintas shard, gate reject

Per standing rule: **TIDAK auto-merge** — biar direview dulu.