### PR TITLE
feat(mmo): integrate gate with relay — multi-shard vessel transit bridge

### DIFF
--- a/docs/blueprint/progres/MMO-IMPLEMENTATION.md
+++ b/docs/blueprint/progres/MMO-IMPLEMENTATION.md
@@ -7,7 +7,7 @@
 > Semantic: ✅ = berfungsi & terverifikasi · 🚧 = kerangka/parsial · ⬜ = kosong.
 > Tiap file yang di-update harus isi §Arah sesuai checklist di bawah ini.
 
-Update terakhir: 2026-08-29 (relay impl — registry claim bugfix, gate coordinator handoff, identity move; PR #590).
+Update terakhir: 2026-08-29 (integrasi gate↔relay — gameserver bridge multi-shard, vessel transit lintas shard; PR #591).
 
 ---
 
@@ -74,8 +74,8 @@ server-authoritative penuh (D-008), self-host per shard (D-009), multi-shard Reg
   recovery lintas shard (crash di tengah handoff).
 
 **Arah (prioritas isi berikutnya):**
-1. `packages/relay` — hubungkan `gate.notifyTarget` ke relay registry + identity
-   lintas shard (D-006 handoff jalur eksplisit, 🔜 seamless).
+1. ~~`packages/relay`~~ hubungkan `gate.notifyTarget` — SELESAI via bridge (PR #591,
+   jalur eksplisit D-006). Runtime terpisah (bukan in-process) tetap TODO #592.
 2. gameserver: handoff token crash-safe di `gate.ts` (pakai `persistence.ts`,
    biar vessel gak hilang kalau crash di tengah transit).
 3. `netcode.ts` transport jaringan beneran + pasang ke `apps/game` klien pertama
@@ -103,8 +103,11 @@ server-authoritative penuh (D-008), self-host per shard (D-009), multi-shard Reg
   tujuan. TODO: token cryptograph, in-flight recovery, event record.
 - `identity.ts` — pemetaan player lintas shard + method `move` (update presence
   saat gate handoff). TODO: persist ke db, auth player id.
-**Belum ada konsumen** — `gameserver/gate.notifyTarget` belum nyambung ke relay
-(hanya callback lokal). Sinyal utama: butuh 2+ server / handoff lintas host.
+**Konsumen pertama (PR #591):** `packages/gameserver/bridge.ts` — `createGameBridge`
+menghubungkan jump gate (gameserver) → relay handoff lintas shard: registry/claim
+semua shard, deliver materialkan vessel di region tujuan (token anti-clone),
+update identity.move. Prototype in-process (2 shard, 1 proses). Runtime terpisah
+benar (proses/host berbeda) masih TODO — self-host per shard (D-009).
 
 ### 2.4 `apps/game` 🚧 (Electron client 3D)
 **Kerangka dibuat**: `src/main/` (Electron main), `src/renderer/` (3D + input +
@@ -132,8 +135,10 @@ net), `index.ts`, `package.json`. **Arah**:
 ### PR #582 ✅ gameserver core (world/validator/sim/combat) — SUDJAH
 ### PR #589 ✅ gameserver core impl (gate/persistence/netcode) — SUDJAH
 ### PR #590 ✅ relay impl (registry claim bugfix + gate coordinator handoff + identity move) — SUDJAH
+### PR #591 ✅ integrasi gate↔relay (gameserver bridge multi-shard, vessel transit lintas shard) — SUDJAH
 ### PR berikutnya (urutan)
-- [ ] integrasi: hubungkan `gameserver/gate.notifyTarget` → `relay.gate.requestHandoff` (2 shard nyata)
+- [ ] runtime terpisah (bukan in-process): tiap shard = proses/host sendiri via netcode jaringan (D-009)
+- [ ] handoff token crash-safe (persistence.ts) — vessel gak hilang kalau crash di tengah transit
 - [ ] netcode transport jaringan beneran pasang ke `apps/game`
 - [ ] `apps/game`: bootstrap Electron + 3D render vessel dari RegionState
 - [ ] integrasi: `arclux connect` → vessel masuk universe → jump gate → station/community
@@ -202,7 +207,8 @@ net), `index.ts`, `package.json`. **Arah**:
 | 2026-08-28 | #580 | universe World Model foundation | ✅ merged |
 | 2026-08-28 | #582 | gameserver core (world/validator/sim/combat) | ✅ merged |
 | 2026-08-28 | #589 | gameserver core impl: gate.ts transit (radius+community), persistence.ts (db regions store), netcode.ts transport (intent/events/snapshot) | ✅ merged |
-| 2026-08-29 | #590 | relay impl: registry claim bugfix + gate coordinator handoff (token anti-clone, idempotency seq, deliver hook) + identity move | in progress |
+| 2026-08-29 | #590 | relay impl: registry claim bugfix + gate coordinator handoff (token anti-clone, idempotency seq, deliver hook) + identity move | ✅ merged |
+| 2026-08-29 | #591 | integrasi gate↔relay: gameserver/bridge.ts multi-shard (vessel transit lintas shard, deliver materialkan vessel, identity.move) | in progress |
 | 2026-08-28 | — | scaffolding relay + apps/game + kerangka gate/netcode/persistence | in progress |
 | 2026-08-28 | — | blueprint V4 (07), V5 HUD (01 §20), V6 persistent (08) + D-013/D-014 + respawn-open | in progress |
 | 2026-08-28 | — | blueprint cosmic: 01 §2 living environment + fase lunar + 3 lapis body; 03 I.9 collision damage; 04 source wreckage; arsitektur environs/collision/cosmic-event | in progress |

--- a/packages/gameserver/bridge.ts
+++ b/packages/gameserver/bridge.ts
@@ -1,0 +1,158 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// bridge.ts — hubungkan `packages/gameserver` (jump gate) ke `packages/relay`
+// (handoff lintas shard). Konsumen pertama relay + gameserver jadi satu.
+//
+// Alur (2 shard, D-005/D-009 self-host):
+//
+//   SHARD A                              SHARD B
+//   ────────────────────────             ────────────────────────
+//   vessel approach gate → transit()      (relay.deliver →)
+//     → remove dari region A              → spawn vessel di region B
+//     → notifyTarget → coordinator        → identity.move(A→B)
+//        .requestHandoff (relay)          → ack {ok:true}
+//
+// PRINSIP: handoff TIDAK membawa source code (token anti-clone, D ship=code).
+// Region tujuan mematerialkan VesselModel dari `vesselModels` (bridge) — di
+// runtime nyata yang terpisah, shard tujuan materialkan dari source repo yang
+// sudah didaftarkan pemain (vesselId + source → VesselModel). Bridge in-process
+// menggantikan "shard tujuan punya source vessel" dengan map vesselId→model.
+
+import type { Vec3, VesselEntity } from "./types";
+import { WorldRegion } from "./world";
+import { createGateRouter, type GateLink, type GateRouter } from "./gate";
+import {
+  createGateCoordinator,
+  type GateCoordinator,
+  type DeliverFn,
+} from "../relay/gate";
+import type { RelayRegistry } from "../relay/registry";
+import type { IdentityMap } from "../relay/identity";
+import type { VesselModel } from "../universe/types";
+import type { HandoffRequest, HandoffResult } from "../relay/types";
+
+/** Satu shard yang ikut dalam bridge (1 region per shard utk sekarang). */
+export interface GameBridgeShard {
+  shardId: string;
+  address: string;
+  region: WorldRegion;
+  /** Jump gate yang menghubungkan shard ini ke shard lain. */
+  gateLinks: GateLink[];
+}
+
+export interface GameBridgeOptions {
+  /** Relay registry bersama (di-share kedua shard). */
+  registry: RelayRegistry;
+  /** Identity lintas shard bersama. */
+  identity: IdentityMap;
+  /** Definisi vessel (VesselModel) per vesselId — materialized di shard tujuan. */
+  vesselModels: Map<string, VesselModel>;
+  /** Semua shard yang ikut bridge (agar deliver bisa spawn di mana saja). */
+  shards: GameBridgeShard[];
+}
+
+export interface GameBridgeShardRuntime {
+  shard: GameBridgeShard;
+  coordinator: GateCoordinator;
+  router: GateRouter;
+  /** pemain yang vessel-nya ada di shard ini + posisi entity (buat handoff). */
+  vesselPositions: Map<string, Vec3>;
+}
+
+export interface GameBridge {
+  /** Per-shard runtime (router + coordinator) — dipakai server tiap shard. */
+  runtimes: Map<string, GameBridgeShardRuntime>;
+  attachVessel(shardId: string, vessel: VesselEntity): void;
+}
+
+export function createGameBridge(opts: GameBridgeOptions): GameBridge {
+  const runtimes = new Map<string, GameBridgeShardRuntime>();
+  const pendingPositions = new Map<string, Vec3>();
+  let seq = 0;
+
+  // daftarkan & claim semua shard ke relay registry.
+  for (const shard of opts.shards) {
+    opts.registry.registerShard({
+      shardId: shard.shardId,
+      address: shard.address,
+      regionIds: [shard.region.regionId],
+      status: "up",
+    });
+    opts.registry.claimRegion(shard.region.regionId, shard.shardId);
+  }
+
+  // deliver hook: dipanggil relay utk mengirim vessel ke region tujuan.
+  const deliver: DeliverFn = async (req: HandoffRequest, toShardId: string): Promise<HandoffResult> => {
+    const shard = opts.shards.find((s) => s.shardId === toShardId);
+    if (!shard) return { ok: false, reason: `unknown target shard ${toShardId}` };
+
+    const model = opts.vesselModels.get(req.vesselId);
+    if (!model) return { ok: false, reason: `no vessel model for ${req.vesselId}` };
+
+    const position = pendingPositions.get(req.vesselId) ?? { x: 0, y: 0, z: 0 };
+    shard.region.spawnVessel({
+      id: req.vesselId,
+      owner: req.transferToken.split(":")[2] ?? undefined,
+      vessel: model,
+      position,
+    });
+
+    // update presence lintas shard (asal → tujuan). playerId = token[2] lihat notifyTarget.
+    const playerId = req.transferToken.split(":")[2] ?? "";
+    opts.identity.move(playerId, req.fromShardId, req.toShardId, req.vesselId);
+
+    pendingPositions.delete(req.vesselId);
+    return { ok: true };
+  };
+
+  // bangun runtime per shard.
+  for (const shard of opts.shards) {
+    const coordinator = createGateCoordinator({
+      registry: opts.registry,
+      fromShardId: shard.shardId,
+      deliver,
+    });
+
+    const router = createGateRouter(shard.gateLinks, {
+      region: shard.region,
+      notifyTarget: (targetRegionId, handoff) => {
+        const toShard = coordinator.resolveTarget(targetRegionId);
+        if (!toShard || toShard === shard.shardId) return; // target bukan shard ini / belum dikenal
+        pendingPositions.set(handoff.vesselId, handoff.position);
+        void coordinator.requestHandoff({
+          vesselId: handoff.vesselId,
+          fromRegionId: shard.region.regionId,
+          fromShardId: shard.shardId,
+          toRegionId: targetRegionId,
+          toShardId: toShard,
+          transferToken: `v:${handoff.vesselId}:${handoff.owner ?? ""}:${targetRegionId}`,
+          seq: ++seq,
+        });
+      },
+    });
+
+    runtimes.set(shard.shardId, {
+      shard,
+      coordinator,
+      router,
+      vesselPositions: new Map(),
+    });
+  }
+
+  return {
+    runtimes,
+    attachVessel(shardId, vessel) {
+      const rt = runtimes.get(shardId);
+      if (rt) {
+        rt.vesselPositions.set(vessel.id, { ...vessel.position });
+        opts.identity.attach(vessel.owner ?? "", { shardId, entityIds: [vessel.id], lastSeen: Date.now() });
+      }
+    },
+  };
+}

--- a/packages/gameserver/index.ts
+++ b/packages/gameserver/index.ts
@@ -20,3 +20,4 @@ export * from "./combat";
 export * from "./gate";
 export * from "./netcode";
 export * from "./persistence";
+export * from "./bridge";


### PR DESCRIPTION
## Ringkasan
Integrasi `gameserver` (jump gate) dengan `relay` (handoff lintas shard) — vessel transit antar region di shard yang berbeda. D-005 multi-shard, D-006 jalur eksplisit, D-009 self-host. Konsumen pertama `packages/gameserver` + `packages/relay` nyatu.

## Perubahan
- packages/gameserver/bridge.ts (BARU) — createGameBridge:
  - register + claim semua shard ke relay registry
  - jump gate (GateRouter) notifyTarget -> relay GateCoordinator.requestHandoff
  - deliver hook: materialize vessel di region tujuan dari vesselModels (token anti-clone, D ship=code) + update identity.move
  - attachVessel: catat posisi vessel + attach identity ke shard asal
- packages/gameserver/index.ts — export bridge.
- docs/blueprint/progres/MMO-IMPLEMENTATION.md — status integrasi + checklist + log.

## Verifikasi
- tsc --noEmit (gameserver + relay + dependensi) bersih.
- Smoke test multi-shard 7/7 PASS: vessel transit dari shard A -> relay -> muncul di region B (posisi x=5 kebawa), vessel hilang dari A, identity pindah A->B.

## Prinsip desain
Token handoff TIDAK membawa VesselModel (source code) — anti-clone. Region tujuan mematerialkan VesselModel dari vesselModels (bridge). Di runtime terpisah (TODO lanjut), shard tujuan materialkan dari source repo pemain yang sudah didaftarkan.

## TODO lanjutan
- runtime terpisah (bukan in-process): tiap shard = proses/host sendiri via netcode jaringan.
- handoff token crash-safe via persistence.ts (vessel tak hilang kalau crash di tengah transit).
- netcode jaringan -> apps/game.

D-012: no auto-merge — reviewer (owner) merge manual.
