### PR TITLE
feat(mmo): crash-safe jump-gate handoff token (persistence + recovery)

### DIFF
--- a/docs/blueprint/progres/MMO-IMPLEMENTATION.md
+++ b/docs/blueprint/progres/MMO-IMPLEMENTATION.md
@@ -7,7 +7,7 @@
 > Semantic: ✅ = berfungsi & terverifikasi · 🚧 = kerangka/parsial · ⬜ = kosong.
 > Tiap file yang di-update harus isi §Arah sesuai checklist di bawah ini.
 
-Update terakhir: 2026-08-29 (integrasi gate↔relay — gameserver bridge multi-shard, vessel transit lintas shard; PR #591).
+Update terakhir: 2026-08-29 (handoff token crash-safe — vessel gak hilang kalau crash di tengah transit; PR #592).
 
 ---
 
@@ -63,21 +63,23 @@ server-authoritative penuh (D-008), self-host per shard (D-009), multi-shard Reg
 **Sudah diisi (PR #589):**
 - `gate.ts` ✅ — `createGateRouter(links, deps)` + `transit()`: cek link, radius
   aktivasi, otorisasi community (allowedCommunityIds kosong = publik), lepas
-  vessel dari region lokal, notify target region, emit `gate.transit.*` event.
-  TODO lanjut: handoff token crash-safe via PersistenceStore + koneksi ke relay.
+   vessel dari region lokal, notify target region, emit `gate.transit.*` event.
+   + handoff token crash-safe: `persist` deps + save-pending-before-remove,
+   delete-after-deliver, `recoverPendingHandoffs()` (PR #592).
 - `netcode.ts` ✅ — `createInProcessTransport(engine)`: `sendIntent`→engine.enqueue,
   `tick()`→engine.step() + pump accepted/rejected events, `requestSnapshot`→region.snapshot.
   TODO lanjut: transport jaringan beneran (netcode[channel]) + pasang ke `apps/game`.
 - `persistence.ts` ✅ — `validateRegion`, `createInMemoryPersistence`,
   `createDbPersistence` (pakai `packages/db` collection "regions",
-  JSON-file-per-record crash-safe via RecoveryManager). TODO: last-good/partial
-  recovery lintas shard (crash di tengah handoff).
+  JSON-file-per-record crash-safe via RecoveryManager). + pending handoff
+  store (`savePendingHandoff`/`loadPendingHandoffs`/`deletePendingHandoff`,
+  collection "handoffs", index list utk recovery) (PR #592).
 
 **Arah (prioritas isi berikutnya):**
 1. ~~`packages/relay`~~ hubungkan `gate.notifyTarget` — SELESAI via bridge (PR #591,
    jalur eksplisit D-006). Runtime terpisah (bukan in-process) tetap TODO #592.
-2. gameserver: handoff token crash-safe di `gate.ts` (pakai `persistence.ts`,
-   biar vessel gak hilang kalau crash di tengah transit).
+2. ~~gameserver: handoff token crash-safe di `gate.ts`~~ — SELESAI via PR #592
+   (pending handoff persist sblm remove, recovery `recoverPendingHandoffs()`).
 3. `netcode.ts` transport jaringan beneran + pasang ke `apps/game` klien pertama
    (render RegionState → kirim intent → render events, anti-cheat D-008).
 4. V4 capability (07): usage_count + component_condition + depletion di
@@ -136,9 +138,9 @@ net), `index.ts`, `package.json`. **Arah**:
 ### PR #589 ✅ gameserver core impl (gate/persistence/netcode) — SUDJAH
 ### PR #590 ✅ relay impl (registry claim bugfix + gate coordinator handoff + identity move) — SUDJAH
 ### PR #591 ✅ integrasi gate↔relay (gameserver bridge multi-shard, vessel transit lintas shard) — SUDJAH
+### PR #592 ✅ handoff token crash-safe (persistence.ts + gate.ts + bridge.ts) — SUDJAH
 ### PR berikutnya (urutan)
 - [ ] runtime terpisah (bukan in-process): tiap shard = proses/host sendiri via netcode jaringan (D-009)
-- [ ] handoff token crash-safe (persistence.ts) — vessel gak hilang kalau crash di tengah transit
 - [ ] netcode transport jaringan beneran pasang ke `apps/game`
 - [ ] `apps/game`: bootstrap Electron + 3D render vessel dari RegionState
 - [ ] integrasi: `arclux connect` → vessel masuk universe → jump gate → station/community

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -67,4 +67,26 @@ export interface RegionRecord {
   updatedAt: string;
 }
 
-export type CollectionName = "repos" | "analyses" | "issues" | "regions";
+/**
+ * Pending jump-gate handoff (gameserver). Persisted BEFORE the vessel is removed
+ * from the origin region and BEFORE the target is notified, so a crash mid-transit
+ * cannot lose the vessel — recovery re-delivers leftover handoffs (crash-safe,
+ * D-009 self-host / D-013 restart≠reset).
+ */
+export interface PendingHandoffRecord {
+  id: string;
+  /** origin region id (the shard that owns the vessel). */
+  fromRegionId: string;
+  /** id region tujuan (milik shard/server lain). */
+  toRegionId: string;
+  /** gate id tempat transit dimulai. */
+  gateId: string;
+  /** handoff payload (gameserver GateTransitResult.handoff) — fully serializable. */
+  handoff: unknown;
+  /** kapan transit di-start (untuk audit/recovery TTL). */
+  startedAt: string;
+  /** updatedAt alias — crash-safe "last-good" pointer. */
+  updatedAt: string;
+}
+
+export type CollectionName = "repos" | "analyses" | "issues" | "regions" | "handoffs";

--- a/packages/gameserver/bridge.ts
+++ b/packages/gameserver/bridge.ts
@@ -27,6 +27,7 @@
 import type { Vec3, VesselEntity } from "./types";
 import { WorldRegion } from "./world";
 import { createGateRouter, type GateLink, type GateRouter } from "./gate";
+import type { PersistenceStore } from "./persistence";
 import {
   createGateCoordinator,
   type GateCoordinator,
@@ -55,6 +56,8 @@ export interface GameBridgeOptions {
   vesselModels: Map<string, VesselModel>;
   /** Semua shard yang ikut bridge (agar deliver bisa spawn di mana saja). */
   shards: GameBridgeShard[];
+  /** Opsional: persistence untuk handoff token crash-safe (diteruskan ke gate). */
+  persistence?: PersistenceStore;
 }
 
 export interface GameBridgeShardRuntime {
@@ -121,6 +124,7 @@ export function createGameBridge(opts: GameBridgeOptions): GameBridge {
 
     const router = createGateRouter(shard.gateLinks, {
       region: shard.region,
+      persist: opts.persistence,
       notifyTarget: (targetRegionId, handoff) => {
         const toShard = coordinator.resolveTarget(targetRegionId);
         if (!toShard || toShard === shard.shardId) return; // target bukan shard ini / belum dikenal

--- a/packages/gameserver/gate.ts
+++ b/packages/gameserver/gate.ts
@@ -22,6 +22,7 @@
 
 import type { Vec3, VesselEntity } from "./types";
 import { WorldRegion } from "./world";
+import type { PersistenceStore, PendingHandoff } from "./persistence";
 
 /** Jarak euclidean antara dua titik (meter). */
 function vecDist(a: Vec3, b: Vec3): number {
@@ -88,6 +89,8 @@ export interface GateRouterDeps {
   onEvent?: (ev: GateEvent) => void;
   /** Opsional: hub entity/faction lookup untuk otorisasi lanjutan. */
   resolveFaction?: (vesselId: string) => string | undefined;
+  /** Opsional: persistence untuk handoff token crash-safe (kalau ada). */
+  persist?: PersistenceStore;
 }
 
 /** Ambil reference vessel kering (id, posisi) untuk handoff tanpa bawa state hidup. */
@@ -110,6 +113,12 @@ function authorized(link: GateLink, vessel: VesselEntity, faction?: string): boo
 
 export interface GateRouter {
   transit(req: GateTransitRequest): Promise<GateTransitResult>;
+  /**
+   * Recovery crash-safe (D-013 restart ≠ reset): muat semua pending handoff yang
+   * tersisa dari crash dan re-deliver ke region tujuan. Kembalikan jumlah yang
+   * berhasil di-resume.
+   */
+  recoverPendingHandoffs(): Promise<number>;
 }
 
 export function createGateRouter(links: GateLink[], deps: GateRouterDeps): GateRouter {
@@ -176,11 +185,33 @@ export function createGateRouter(links: GateLink[], deps: GateRouterDeps): GateR
 
     const handoff = toHandoff(vessel);
 
+    // Crash-safe: persist pending handoff SEBELUM vessel dilepas dari region asal.
+    // Kalau crash di tengah (after save, before delete), handoff tersisa di disk dan
+    // recovery akan re-deliver vessel ke tujuan — vessel tidak hilang.
+    const pending: PendingHandoff = {
+      vesselId: handoff.vesselId,
+      owner: handoff.owner,
+      position: handoff.position,
+      hubId: handoff.hubId,
+      gateId: req.gateId,
+      fromRegionId: deps.region.regionId,
+      toRegionId: req.targetRegionId,
+      startedAt: new Date().toISOString(),
+    };
+    if (deps.persist) {
+      await deps.persist.savePendingHandoff(pending);
+    }
+
     // lepas vessel dari region lokal (authoritative transfer).
     deps.region.remove(req.vesselId);
 
     // notify region tujuan (via relay/netcode) untuk men-spawn.
     deps.notifyTarget?.(req.targetRegionId, handoff);
+
+    // deliver sukses → hapus pending handoff (tidak lagi in-flight).
+    if (deps.persist) {
+      await deps.persist.deletePendingHandoff(req.vesselId, req.gateId);
+    }
 
     deps.onEvent?.({
       type: "gate.transit.complete",
@@ -195,7 +226,25 @@ export function createGateRouter(links: GateLink[], deps: GateRouterDeps): GateR
     return { ok: true, handoff };
   };
 
-  return { transit };
+  return {
+    transit,
+    async recoverPendingHandoffs() {
+      if (!deps.persist) return 0;
+      const pending = await deps.persist.loadPendingHandoffs();
+      let recovered = 0;
+      for (const h of pending) {
+        deps.notifyTarget?.(h.toRegionId, {
+          vesselId: h.vesselId,
+          owner: h.owner,
+          position: h.position,
+          hubId: h.hubId,
+        });
+        await deps.persist.deletePendingHandoff(h.vesselId, h.gateId);
+        recovered++;
+      }
+      return recovered;
+    },
+  };
 }
 
 //

--- a/packages/gameserver/persistence.ts
+++ b/packages/gameserver/persistence.ts
@@ -18,14 +18,51 @@
 
 import type { RegionSnapshot } from "./types";
 import { putRecord, getRecord, deleteRecord } from "../db/client";
-import type { CollectionName, RegionRecord } from "../db/schema";
+import type { CollectionName, RegionRecord, PendingHandoffRecord } from "../db/schema";
 
 const COLLECTION: CollectionName = "regions";
+const HANDOFF_COLLECTION: CollectionName = "handoffs";
+
+/**
+ * Pending handoff yang disimpan before vessel di-remove dari region asal, supaya
+ * kalau crash di tengah transit vessel tidak hilang (handoff token crash-safe).
+ * `handoff` = payload `GateTransitResult.handoff` (id vessel, owner, position...).
+ */
+export interface PendingHandoff {
+  vesselId: string;
+  owner?: string;
+  position: { x: number; y: number; z: number };
+  hubId?: string;
+  gateId: string;
+  fromRegionId: string;
+  toRegionId: string;
+  startedAt: string;
+}
+
+/** Validasi minimal pending handoff sebelum disimpan. */
+export function validatePendingHandoff(h: PendingHandoff): boolean {
+  return (
+    !!h &&
+    typeof h.vesselId === "string" &&
+    h.vesselId.length > 0 &&
+    typeof h.gateId === "string" &&
+    typeof h.fromRegionId === "string" &&
+    typeof h.toRegionId === "string" &&
+    !!h.position && typeof h.position.x === "number" &&
+    typeof h.position.y === "number" && typeof h.position.z === "number"
+  );
+}
 
 export interface PersistenceStore {
   saveRegion(regionId: string, state: RegionSnapshot): Promise<void>;
   loadRegion(regionId: string): Promise<RegionSnapshot | null>;
   deleteRegion(regionId: string): Promise<void>;
+  /** Simpan pending handoff in-flight (crash-safe sebelum remove vessel). */
+  savePendingHandoff(h: PendingHandoff): Promise<void>;
+  /** Semua pending handoff yang tersisa (untuk recovery setelah crash/restart). */
+  loadPendingHandoffs(): Promise<PendingHandoff[]>;
+  /** Hapus pending handoff setelah deliver/diselesaikan. */
+  deletePendingHandoff(vesselId: string, gateId: string): Promise<void>;
 }
 
 /** Validasi snapshot minimal sebelum disimpan (huruf anti-torn/garbage write). */
@@ -45,6 +82,9 @@ export function validateRegion(state: RegionSnapshot): boolean {
  */
 export function createInMemoryPersistence(): PersistenceStore {
   const regions = new Map<string, RegionSnapshot>();
+  const pending = new Map<string, PendingHandoff>();
+
+  const pendingKey = (vesselId: string, gateId: string) => `${gateId}::${vesselId}`;
 
   return {
     async saveRegion(regionId, state) {
@@ -57,6 +97,16 @@ export function createInMemoryPersistence(): PersistenceStore {
     },
     async deleteRegion(regionId) {
       regions.delete(regionId);
+    },
+    async savePendingHandoff(h) {
+      if (!validatePendingHandoff(h)) throw new Error("invalid PendingHandoff");
+      pending.set(pendingKey(h.vesselId, h.gateId), structuredClone(h));
+    },
+    async loadPendingHandoffs() {
+      return Array.from(pending.values()).map((h) => structuredClone(h));
+    },
+    async deletePendingHandoff(vesselId, gateId) {
+      pending.delete(pendingKey(vesselId, gateId));
     },
   };
 }
@@ -92,5 +142,67 @@ export function createDbPersistence(
     deleteRecord(COLLECTION, regionId);
   };
 
-  return { saveRegion, loadRegion, deleteRegion };
+  const savePendingHandoff = async (h: PendingHandoff): Promise<void> => {
+    if (!validatePendingHandoff(h)) throw new Error("invalid PendingHandoff");
+    const id = `${h.gateId}::${h.vesselId}`;
+    const rec: PendingHandoffRecord = {
+      id,
+      fromRegionId: h.fromRegionId,
+      toRegionId: h.toRegionId,
+      gateId: h.gateId,
+      handoff: structuredClone(h),
+      startedAt: h.startedAt,
+      updatedAt: new Date().toISOString(),
+    };
+    putRecord<PendingHandoffRecord>(HANDOFF_COLLECTION, rec);
+    // kelola index id untuk recovery list-all (collection JSON-file-per-record).
+    const indexKey = "__list__";
+    const prev = getRecord<{ ids: string[] }>(HANDOFF_COLLECTION, indexKey);
+    const ids = prev && Array.isArray(prev.ids) ? prev.ids : [];
+    if (!ids.includes(id)) {
+      ids.push(id);
+      putRecord<{ id: string; ids: string[] }>(HANDOFF_COLLECTION, {
+        id: indexKey,
+        ids,
+      });
+    }
+  };
+
+  const loadPendingHandoffs = async (): Promise<PendingHandoff[]> => {
+    const indexKey = "__list__";
+    const index = getRecord<{ ids: string[] }>(HANDOFF_COLLECTION, indexKey);
+    if (!index || !Array.isArray(index.ids)) return [];
+    const out: PendingHandoff[] = [];
+    for (const id of index.ids) {
+      const rec = getRecord<PendingHandoffRecord>(HANDOFF_COLLECTION, id);
+      if (rec && rec.handoff && validatePendingHandoff(rec.handoff as PendingHandoff)) {
+        out.push(structuredClone(rec.handoff as PendingHandoff));
+      }
+    }
+    return out;
+  };
+
+  const deletePendingHandoff = async (vesselId: string, gateId: string): Promise<void> => {
+    const id = `${gateId}::${vesselId}`;
+    deleteRecord(HANDOFF_COLLECTION, id);
+    // bersihkan dari index.
+    const indexKey = "__list__";
+    const prev = getRecord<{ ids: string[] }>(HANDOFF_COLLECTION, indexKey);
+    if (prev && Array.isArray(prev.ids) && prev.ids.includes(id)) {
+      prev.ids = prev.ids.filter((x) => x !== id);
+      putRecord<{ id: string; ids: string[] }>(HANDOFF_COLLECTION, {
+        id: indexKey,
+        ids: prev.ids,
+      });
+    }
+  };
+
+  return {
+    saveRegion,
+    loadRegion,
+    deleteRegion,
+    savePendingHandoff,
+    loadPendingHandoffs,
+    deletePendingHandoff,
+  };
 }


### PR DESCRIPTION
## Ringkasan
Handoff token crash-safe untuk jump gate: vessel gak hilang kalau crash di tengah transit. Melanjutkan PR #589/#590/#591 (gate + relay + bridge), menutup TODO lanjut di gate.ts.

## Perubahan
- `packages/db/schema.ts`: collection `"handoffs"` baru + `PendingHandoffRecord` (fromRegionId/toRegionId/gateId/handoff/startedAt).
- `packages/gameserver/persistence.ts`: `PendingHandoff` type + 3 method (`savePendingHandoff`/`loadPendingHandoffs`/`deletePendingHandoff`) di `PersistenceStore`, impl in-memory + db (index `__list__` utk recovery list-all).
- `packages/gameserver/gate.ts`:
  - deps.persist opsional → transit() **persist pending SEBELUM vessel di-remove** dari region asal, delete **setelah** notifyTarget sukses.
  - `recoverPendingHandoffs()` — muat sisa pending dari crash → re-deliver ke region tujuan (D-013 restart ≠ reset).
- `packages/gameserver/bridge.ts`: option `persistence` diteruskan ke tiap gate router.

## Verification
- `npx tsc --noEmit` PASS (gameserver+relay+db+universe+storage).
- Smoke test 3 skenario PASS:
  1) transit normal → delivered, pending cleared, vessel pindah.
  2) crash mid-transit (notifyTarget throws) → pending tersisa 1, vessel gak "hilang".
  3) recovery (`recoverPendingHandoffs`) → re-deliver v-2, pending cleared.

Docs MMO-IMPLEMENTATION.md di-update (item #2 centang, header, gate/persistence notes).

D-012: no auto-merge — owner merge manual.
