### PR TITLE
chore(cli): add check:cli script to verify bundle not stale

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "check:diary": "npx tsx scripts/check-diary.ts",
     "typecheck": "tsc --noEmit -p apps/web/tsconfig.json",
-    "build:cli": "node scripts/build-cli.mjs"
+    "build:cli": "node scripts/build-cli.mjs",
+    "check:cli": "node scripts/build-cli.mjs && node -e \"const fs=require('fs');const c=fs.readFileSync('apps/cli/dist/arclux.mjs','utf8');if(c.includes('getModuleById')){console.error('STALE: dist contains getModuleById');process.exit(1)}else console.log('CLI bundle OK (no stale getModuleById)')\""
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.30.0",


### PR DESCRIPTION
Add pnpm check:cli (build + verify no getModuleById). Rebuilt dist with fix/mcp-arclux. Workflow guard for .github/workflows/ci.yml siap lokal tapi push butuh workflow scope — lihat branch untuk file workflow.