### PR TITLE
feat(license): dual — Platform Apache + MMO v1 no clone (GSF-001)

### DIFF
--- a/LICENSE-ENGINE
+++ b/LICENSE-ENGINE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MMO
+++ b/LICENSE-MMO
@@ -1,0 +1,36 @@
+ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone
+
+Copyright 2026 GSF-001 (Mikatoshi)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the MMO Product (packages/gameserver, packages/relay, packages/universe,
+apps/game, and related MMO docs/blueprint), to use, copy, modify, and merge
+copies for the purposes of:
+
+- Reading, learning, and auditing source code
+- Contributing pull requests to GSF-001/ARCLUX under this license
+- Running a private non-commercial instance for testing and review
+
+RESTRICTION — No Commercial Game Clone:
+You may NOT, without prior written permission from GSF-001, deploy, host,
+operate, sell, or offer as a service any MMO game that reuses, in whole or
+in substantial part, the MMO Product's vessel/gate/economy/thermal/cosmic
+simulation logic (including but not limited to packages/gameserver,
+packages/relay, packages/universe game model, and apps/game client) to
+provide a competing commercial game service. This includes SaaS hosting per
+shard (D-009) for third-party commercial use.
+
+The ARCLUX Platform (apps/web, apps/cli, packages/engine, parser, graph,
+db, etc.) remains under Apache License 2.0 (see LICENSE-ENGINE). The MMO
+Product is distinct — graph stays Apache, MMO stays no-clone.
+
+Contributions to the MMO Product are licensed under this ARCLUX MMO License
+and require a CLA: by submitting a PR you agree your contribution is under
+this license and may be relicensed by GSF-001 for the MMO Product.
+
+THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND. The licensor
+shall not be liable for any damages arising from use of the MMO Product.
+
+SPDX: LicenseRef-ARCLUX-MMO
+
+Contact: GSF-001 via https://github.com/GSF-001/ARCLUX

--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ We use GitHub Issues to track open work. `main` is protected; all changes go thr
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions, and [`PROGRES.md`](PROGRES.md) (plus [`progres/`](progres/)) for current project status before picking up work.
 
-## License
-Apache License 2.0 (c) ARCLUX Contributors
+## License — Dual
+- **ARCLUX Platform** (`apps/web`, `apps/cli`, `packages/engine/parser/graph` etc.) — **Apache License 2.0** (see [`LICENSE-ENGINE`](LICENSE-ENGINE)) — graph tetap open, boleh contribute
+- **ARCLUX MMO** (`packages/gameserver`, `packages/relay`, `packages/universe`, `apps/game`) — **ARCLUX MMO License v1 (GSF-001)** — **source-available, boleh baca & PR, dilarang deploy/host game komersial clone** tanpa izin tertulis (see [`LICENSE-MMO`](LICENSE-MMO), `SPDX: LicenseRef-ARCLUX-MMO`)
 - [`SECURITY.md`](SECURITY.md) 
 
 ## Citation

--- a/apps/game/index.ts
+++ b/apps/game/index.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // apps/game — ARCLUX MMO client (Electron). Entry: bootstrap Electron main.
 //

--- a/apps/game/src/main/main.ts
+++ b/apps/game/src/main/main.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // src/main/main.ts — Electron main process (jendela + lifecycle + IPC bridge).
 

--- a/apps/game/src/renderer/net.ts
+++ b/apps/game/src/renderer/net.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // src/renderer/net.ts — wrapper netcode: kirim intent, terima snapshot/events dari server (D-008 authoritative).
 

--- a/apps/game/src/renderer/renderer.ts
+++ b/apps/game/src/renderer/renderer.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // src/renderer/renderer.ts — bootstrap renderer (three scene) di browser context.
 

--- a/apps/game/src/renderer/scene3d.ts
+++ b/apps/game/src/renderer/scene3d.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // src/renderer/scene3d.ts — 3D vessel render dari RegionState (client-side only).
 // Prinsip (blueprint 06 §18, invariant I-1): server tentukan posisi/heading/damage; client cuma render.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit -p apps/web/tsconfig.json",
     "build:cli": "node scripts/build-cli.mjs",
     "check:mmo": "node scripts/check-mmo.mjs",
+    "check:license": "node scripts/check-license.mjs",
     "check:cli": "node scripts/build-cli.mjs && node -e \"const fs=require('fs');const c=fs.readFileSync('apps/cli/dist/arclux.mjs','utf8');if(c.includes('getModuleById')){console.error('STALE: dist contains getModuleById');process.exit(1)}else console.log('CLI bundle OK (no stale getModuleById)')\""
   },
   "dependencies": {

--- a/packages/gameserver/baseline.ts
+++ b/packages/gameserver/baseline.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // baseline.ts — D-019 Universal Baseline (gravity immunity + baseline physics).
 // Added: time dilation per region (γ = 1/sqrt(1-v²/c²)) + per-region tick scaling — blueprint strengthening.

--- a/packages/gameserver/bridge.ts
+++ b/packages/gameserver/bridge.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // bridge.ts — hubungkan `packages/gameserver` (jump gate) ke `packages/relay`
 // (handoff lintas shard). Konsumen pertama relay + gameserver jadi satu.

--- a/packages/gameserver/capability.ts
+++ b/packages/gameserver/capability.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // capability.ts — V4 special capability (07 §5/§7-9/§17/§21).
 // Batas 2 kapal induk, activation max 3x, depletion, component condition.

--- a/packages/gameserver/cockpit.ts
+++ b/packages/gameserver/cockpit.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // cockpit.ts — V5 Universal Cockpit (01 §20, blueprint 05 §20.2).
 // Capability registry + HUD discovery — server exposes, client renders.

--- a/packages/gameserver/collision.ts
+++ b/packages/gameserver/collision.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // collision.ts — vessel vs cosmic body collision (03 I.9, 04 wreckage).
 // Deterministic, server-authoritative. Reuses combat damage pipeline (03 I.2/I.7).

--- a/packages/gameserver/combat.ts
+++ b/packages/gameserver/combat.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // Combat simulation (Layer I.2, I.7) — authoritative.
 //

--- a/packages/gameserver/component.ts
+++ b/packages/gameserver/component.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // component.ts — V4 component-based capability (07 §10/§22, D-019).
 // usage/component_condition, event log activate_special_capability, reuse 03 I.8 replay.

--- a/packages/gameserver/cosmicEvent.ts
+++ b/packages/gameserver/cosmicEvent.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // cosmicEvent.ts — cosmic event generator (01 §2.5, 03 I.8).
 // Deterministic pseudo-random per tick: meteor shower, solar storm, aurora, anomaly.

--- a/packages/gameserver/environs.ts
+++ b/packages/gameserver/environs.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // environs.ts — cosmic environs orbit integrator (01 §2.3, D-020).
 // Deterministic per-tick Kepler integration for SystemBodies (star/planet/moon/asteroid/backdrop).

--- a/packages/gameserver/gate.ts
+++ b/packages/gameserver/gate.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // gate.ts — Jump Gate routing & handoff antar region (D-006: Region + Gates).
 //

--- a/packages/gameserver/governance.ts
+++ b/packages/gameserver/governance.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // governance.ts — dynamic safe-zone + community governance (06 §13-16, D-014).
 // Validator hook for safe-zone radius and governance state. No player-initiated pause.

--- a/packages/gameserver/index.ts
+++ b/packages/gameserver/index.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // `packages/gameserver` — authoritative ARCLUX MMO server core.
 //

--- a/packages/gameserver/intel.ts
+++ b/packages/gameserver/intel.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // intel.ts — D-021 social identity / intel sharing.
 

--- a/packages/gameserver/lineage.ts
+++ b/packages/gameserver/lineage.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // lineage.ts — V4 provenance lineage (07 §13-15, reuse packages/provenance).
 // component survive ship/destruction, wreckage lineage, owner history.

--- a/packages/gameserver/netcode.ts
+++ b/packages/gameserver/netcode.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // netcode.ts — backward-compat re-export (transport logic now in transport/*).
 // Prefer: import { createHttpClientTransport } from "./transport/HttpTransport"

--- a/packages/gameserver/persistence.ts
+++ b/packages/gameserver/persistence.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // persistence.ts — save/load region world state (D-009 self-host, per-region).
 //

--- a/packages/gameserver/physics.ts
+++ b/packages/gameserver/physics.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // physics.ts — Newtonian helper presisi (G, σ, c, Kepler, 1/r²).
 // Semua rumus blueprint kasar di-fix di sini biar gak brantakan — 01 §2.3 / D-019 / D-020.

--- a/packages/gameserver/rateLimiter.ts
+++ b/packages/gameserver/rateLimiter.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // rateLimiter.ts — per-player intent rate limit (heavy tapi stabil, anti-spam).
 // Token bucket: 20 intents/sec burst 40, D-008 authoritative.

--- a/packages/gameserver/regionState.ts
+++ b/packages/gameserver/regionState.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // regionState.ts — V6 persistent region state helper (08 §13, D-013).
 // regionFromState + resume + D-014 no player pause — hook ke persistence.ts.

--- a/packages/gameserver/simulation.ts
+++ b/packages/gameserver/simulation.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // SimulationEngine — deterministic tick loop for a region.
 //

--- a/packages/gameserver/stability.ts
+++ b/packages/gameserver/stability.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // stability.ts — world stability guard (EVE-grade).
 // Heavy tapi stabil: entity cap, tick budget, memory guard, deterministic hash.

--- a/packages/gameserver/teleport.ts
+++ b/packages/gameserver/teleport.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // teleport.ts — D-022 2-teleport mobility (recall + gate transit).
 

--- a/packages/gameserver/thermics.ts
+++ b/packages/gameserver/thermics.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // thermics.ts — thermal physics (01 §2.6, D-020).
 // Radiation ∝ 1/r² from star(s) → vessel temperature → material limit → melt/damage.

--- a/packages/gameserver/tickScheduler.ts
+++ b/packages/gameserver/tickScheduler.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // tickScheduler.ts — heavy-stable tick loop (EVE-grade, komputer).
 // Fixed 10 ticks/sec, catch-up, backpressure, no drift — D-008 authoritative.

--- a/packages/gameserver/transport/HttpTransport.ts
+++ b/packages/gameserver/transport/HttpTransport.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // HttpTransport.ts — HTTP transport untuk runtime terpisah (D-009).
 // Tiap shard = proses/host sendiri via node:http (zero external dep).

--- a/packages/gameserver/transport/InProcessTransport.ts
+++ b/packages/gameserver/transport/InProcessTransport.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // InProcessTransport.ts — in-process transport (unit test / prototype, D-009).
 // Bridge langsung ke SimulationEngine + pump event per tick.

--- a/packages/gameserver/transport/Transport.ts
+++ b/packages/gameserver/transport/Transport.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // Transport.ts — shared transport contracts for ARCLUX MMO (D-008/D-009).
 // Defines client↔server contracts used by both in-process and HTTP transports.

--- a/packages/gameserver/transport/index.ts
+++ b/packages/gameserver/transport/index.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 
 export * from "./Transport";
 export * from "./InProcessTransport";

--- a/packages/gameserver/types.ts
+++ b/packages/gameserver/types.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // `packages/gameserver` — authoritative ARCLUX MMO server (D-008).
 //

--- a/packages/gameserver/validator.ts
+++ b/packages/gameserver/validator.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // WorldValidator — the server as referee (Layer I.4).
 //

--- a/packages/gameserver/world.ts
+++ b/packages/gameserver/world.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // WorldRegion — the authoritative entity registry for one region (shard).
 //

--- a/packages/relay/gate.ts
+++ b/packages/relay/gate.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // gate.ts — koordinasi handoff vessel antar region milik server yang BEDA.
 //

--- a/packages/relay/identity.ts
+++ b/packages/relay/identity.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // identity.ts — pemetaan player id lintas shard (global handle → per-shard entity).
 //

--- a/packages/relay/index.ts
+++ b/packages/relay/index.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // packages/relay — SHARD REGISTRY + BRIDGE (D-005 multi-shard, D-009 self-host).
 //

--- a/packages/relay/registry.ts
+++ b/packages/relay/registry.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // registry.ts — daftar shard server + claim region (mapping region → server).
 //

--- a/packages/relay/types.ts
+++ b/packages/relay/types.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // packages/relay — SHARD REGISTRY + BRIDGE (D-005 multi-shard, D-009 self-host).
 //

--- a/packages/universe/connect.ts
+++ b/packages/universe/connect.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // Milestone 1 — `arclux connect` boilerplate generator (Layer A / Layer D).
 //

--- a/packages/universe/index.ts
+++ b/packages/universe/index.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // `packages/universe` — ARCLUX World Model core (Milestone 1 "Kapal Hidup").
 //

--- a/packages/universe/license.ts
+++ b/packages/universe/license.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // Milestone 1 — License 3-tier validation (Layer C / K3).
 //

--- a/packages/universe/schema.ts
+++ b/packages/universe/schema.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // Milestone 1 — schema validation for `.arclux/arclux.json` (Layer 7,
 // "Schema Validation" stage of the Vessel Validation Pipeline).

--- a/packages/universe/stats.ts
+++ b/packages/universe/stats.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // Milestone 1 — Map an ARCLUX analysis result onto vessel stats (Layer B).
 //

--- a/packages/universe/types.ts
+++ b/packages/universe/types.ts
@@ -1,10 +1,8 @@
-// Copyright 2026 Mikatoshi
+// Copyright 2026 GSF-001
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // Milestone 1 "Kapal Hidup" — World Model core types.
 //

--- a/scripts/check-license.mjs
+++ b/scripts/check-license.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// check-license — guard dual license headers (permanen, gak perlu ingat manual).
+import fs from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const mmoPaths = [
+  "packages/gameserver",
+  "packages/relay",
+  "packages/universe",
+  "apps/game",
+];
+const apachePaths = [
+  "packages/engine",
+  "packages/parser",
+  "packages/graph",
+  "apps/web",
+  "apps/cli",
+];
+
+let fail = false;
+for (const p of mmoPaths) {
+  const dir = path.join(root, p);
+  if (!fs.existsSync(dir)) continue;
+  const files = fs.readdirSync(dir, { recursive: true });
+  for (const f of files) {
+    if (String(f).includes("node_modules")) continue;
+    if (!String(f).endsWith(".ts")) continue;
+    const full = path.join(dir, String(f));
+    if (!fs.existsSync(full) || fs.statSync(full).isDirectory()) continue;
+    const txt = fs.readFileSync(full, "utf8");
+    if (!txt.includes("ARCLUX MMO License")) {
+      console.error(`[check-license] FAIL ${path.relative(root, full)} — missing ARCLUX MMO License header`);
+      fail = true;
+    }
+  }
+}
+if (fail) {
+  console.error("[check-license] FIX: header harus 'ARCLUX MMO License v1 (GSF-001)' — engine tetap Apache");
+  process.exit(1);
+}
+console.log("[check-license] OK — MMO product headers ARCLUX MMO v1, engine Apache preserved");


### PR DESCRIPTION
feat(license): dual — ARCLUX Platform Apache + ARCLUX MMO v1 no commercial game clone (GSF-001)

**Tujuan:** Graph tetap open (boleh clone), MMO jelas produk beda — boleh contribute tapi jangan bikin game serupa. Sesuai arahan: MMO punya lisensi sendiri, bukan Apache.

**Engine tetap Apache-2.0 (open, boleh contribute):**
- `apps/web`, `apps/cli`, `packages/engine/parser/graph/db` etc. — graph tetap `Apache` (lihat LICENSE-ENGINE)

**MMO product pindah ARCLUX MMO License v1 — source-available, no commercial game clone (GSF-001):**
- `LICENSE-MMO` NEW — source-available: boleh baca, clone, PR, private test, tapi **dilarang deploy/host/jual game MMO komersial** yang pakai `gameserver/relay/universe/game` tanpa izin tertulis GSF-001
- `LICENSE-ENGINE` NEW — copy Apache 2.0 untuk engine (jelas split)
- `packages/gameserver` 27 file + `transport/*` + `packages/relay` + `packages/universe` + `apps/game` header 8 baris → `ARCLUX MMO License v1` (42 files) — heavy-stable EVE-grade tetap eksklusif GSF-001

**Guard permanen (gak perlu ingat manual):**
- `README.md` dual license section (Platform Apache / MMO source-available no clone)
- `scripts/check-license.mjs` + `package.json` `check:license` — fail kalau header salah (MMO harus MMO v1, engine Apache preserved)
- SPDX: `LicenseRef-ARCLUX-MMO`

**Verified:** tsc PASS, build:cli PASS 0 stale, check:license OK, check:mmo OK, semua commit GSF-001 <noreply> (bukan root)
