### PR TITLE
feat(license+directory): revise MMO BOLEH community + Universe Directory live

### DIFF
--- a/LICENSE-MMO
+++ b/LICENSE-MMO
@@ -4,21 +4,26 @@ Copyright 2026 GSF-001 (Mikatoshi)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of the MMO Product (packages/gameserver, packages/relay, packages/universe,
-apps/game, and related MMO docs/blueprint), to use, copy, modify, and merge
-copies for the purposes of:
+packages/directory, apps/game, and related MMO docs/blueprint), to use, copy,
+modify, and merge copies for the purposes of:
 
-- Reading, learning, and auditing source code
-- Contributing pull requests to GSF-001/ARCLUX under this license
-- Running a private non-commercial instance for testing and review
+🟢 PERMITTED — Community Self-Host & Gameplay (D-009 self-host per shard):
+- Reading, learning, auditing source code and contributing PRs to GSF-001/ARCLUX
+- Clone, install, modify for personal, community, campus, lab, and private use
+- Self-host shard/server and run persistent regions for actual gameplay (non-commercial)
+- Community server for friends, org, campus, lab — federation via Gate Protocol (OPT-IN)
+- Private universe, development/testing, education, and non-commercial community operation
+- Federated connection between trusted shards that opt-in to Federation Mode
 
-RESTRICTION — No Commercial Game Clone:
-You may NOT, without prior written permission from GSF-001, deploy, host,
-operate, sell, or offer as a service any MMO game that reuses, in whole or
-in substantial part, the MMO Product's vessel/gate/economy/thermal/cosmic
-simulation logic (including but not limited to packages/gameserver,
-packages/relay, packages/universe game model, and apps/game client) to
-provide a competing commercial game service. This includes SaaS hosting per
-shard (D-009) for third-party commercial use.
+🔴 RESTRICTED — No Commercial Competing MMO (without written permission from GSF-001):
+- Selling, licensing, or offering the MMO Product as your own product/service
+- Creating a competing commercial game from substantial MMO logic (vessel/gate/economy/thermal/cosmic simulation in packages/gameserver, relay, universe, directory, apps/game)
+- Offering commercial hosted MMO/shard service for third parties (SaaS per shard, D-009 commercial)
+- Rebranding and reselling ARCLUX MMO as a competing product
+
+Federation Directory (packages/directory) is part of MMO Product — discovery only, DIRECTORY ≠ AUTHORITY (not authoritative simulation).
+
+RESTRICTION — No Commercial Game Clone (details): You may NOT deploy/host/operate/sell/offer as a service any competing commercial MMO that reuses substantial MMO Product logic without permission. Non-commercial self-host and community gameplay are explicitly ALLOWED above.
 
 The ARCLUX Platform (apps/web, apps/cli, packages/engine, parser, graph,
 db, etc.) remains under Apache License 2.0 (see LICENSE-ENGINE). The MMO

--- a/packages/directory/index.ts
+++ b/packages/directory/index.ts
@@ -1,0 +1,8 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
+
+export * from "./types";
+export * from "./registry";

--- a/packages/directory/registry.ts
+++ b/packages/directory/registry.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
+//
+// registry.ts — Directory registry live (register/heartbeat/list/get) — DIRECTORY ≠ AUTHORITY.
+
+import type { ServerHealth, ServerIdentity, ServerManifest, ServerStatus } from "./types";
+
+const servers = new Map<string, ServerManifest>();
+const health = new Map<string, ServerHealth>();
+const identity = new Map<string, ServerIdentity>();
+
+export function registerServer(manifest: ServerManifest, id?: ServerIdentity): { ok: boolean; reason?: string } {
+  if (!manifest.serverId || !manifest.endpoint) return { ok: false, reason: "serverId/endpoint required" };
+  const verOk = isCompatible(manifest.version);
+  if (!verOk) return { ok: false, reason: `incompatible version ${manifest.version}` };
+  servers.set(manifest.serverId, { ...manifest });
+  if (id) identity.set(manifest.serverId, { ...id });
+  health.set(manifest.serverId, { serverId: manifest.serverId, status: "ONLINE", population: manifest.population ?? 0, regions: manifest.regions, federation: manifest.federation, updatedAt: new Date().toISOString() });
+  return { ok: true };
+}
+
+export function unregisterServer(serverId: string): boolean { return servers.delete(serverId) && health.delete(serverId); }
+
+export function heartbeat(serverId: string, h: Partial<ServerHealth>): ServerHealth | null {
+  const cur = health.get(serverId);
+  if (!cur) return null;
+  const next: ServerHealth = { ...cur, ...h, serverId, updatedAt: new Date().toISOString() } as ServerHealth;
+  health.set(serverId, next);
+  const m = servers.get(serverId);
+  if (m && typeof h.population === "number") m.population = h.population;
+  return { ...next };
+}
+
+export function listServers(filter?: { visibility?: string; federation?: string; status?: ServerStatus }): ServerManifest[] {
+  let out = Array.from(servers.values());
+  if (filter?.visibility) out = out.filter((s) => s.visibility === filter.visibility);
+  if (filter?.federation) out = out.filter((s) => s.federation === filter.federation);
+  if (filter?.status) out = out.filter((s) => health.get(s.serverId)?.status === filter.status);
+  return out.map((s) => ({ ...s }));
+}
+
+export function getServer(serverId: string): { manifest?: ServerManifest; health?: ServerHealth; identity?: ServerIdentity } {
+  return { manifest: servers.get(serverId) ? { ...servers.get(serverId)! } : undefined, health: health.get(serverId) ? { ...health.get(serverId)! } : undefined, identity: identity.get(serverId) ? { ...identity.get(serverId)! } : undefined };
+}
+
+export function getHealth(serverId: string): ServerHealth | undefined { const h = health.get(serverId); return h ? { ...h } : undefined; }
+
+function isCompatible(version: string): boolean {
+  // Simple: 0.x compatible with 0.x, major mismatch rejected
+  if (!version) return false;
+  const major = version.split(".")[0];
+  return major === "0" || major === "1";
+}
+
+export function clearDirectory(): void { servers.clear(); health.clear(); identity.clear(); }

--- a/packages/directory/types.ts
+++ b/packages/directory/types.ts
@@ -1,0 +1,46 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
+//
+// types.ts — ARCLUX Universe Directory types (Phase 1+2 live, DIRECTORY ≠ AUTHORITY).
+
+export type Visibility = "public" | "community" | "private" | "organization" | "development";
+export type FederationMode = "OFF" | "PRIVATE" | "PUBLIC" | "COMMUNITY";
+export type ServerStatus = "ONLINE" | "DEGRADED" | "MAINTENANCE" | "OFFLINE";
+
+export interface ServerManifest {
+  serverId: string;
+  name: string;
+  endpoint: string;
+  visibility: Visibility;
+  version: string;
+  regions: number;
+  population?: number;
+  federation: FederationMode;
+  trustedPeers?: string[];
+  gateAvailable?: boolean;
+  community?: string;
+  ruleset?: string;
+  operator?: string;
+}
+
+export interface ServerIdentity {
+  serverId: string;
+  publicKey?: string;
+  version: string;
+  protocolVersion: string;
+  operator?: string;
+}
+
+export interface ServerHealth {
+  serverId: string;
+  status: ServerStatus;
+  tickRate?: number;
+  latencyMs?: number;
+  population: number;
+  regions: number;
+  federation: FederationMode;
+  updatedAt: string;
+}


### PR DESCRIPTION
feat(license+directory): revise MMO v1 BOLEH self-host community + Universe Directory live (DIRECTORY ≠ AUTHORITY)

**1 PR 2 commit — live kayak engine, no MVP placeholder:**

**Commit 1 — LICENSE-MMO revise (D-009 self-host per shard sinkron):**
- `LICENSE-MMO` — dari `Running a private non-commercial instance for testing and review` → **🟢 BOLEH: clone/modify, self-host shard/server komunitas non-komersial untuk gameplay beneran, private universe, federation OPT-IN via Gate (D-009), audit/testing/contribute** + **🔴 TIDAK BOLEH tanpa izin: jual MMO Product sebagai produk sendiri, competing commercial game dari substantial logic, commercial hosted shard service, rebrand** — sesuai plan awal `user provides the server, ARCLUX provides architecture`
- `DIRECTORY ≠ AUTHORITY` jelas — discovery bukan authoritative simulation

**Commit 2 — ARCLUX Universe Directory live (federated server discovery):**
- `packages/directory/types.ts` — `ServerManifest` (serverId/name/endpoint/visibility/version/regions/federation/trustedPeers/gateAvailable), `ServerIdentity`, `ServerHealth` (ONLINE/DEGRADED/MAINTENANCE/OFFLINE, tickRate/latency/population)
- `packages/directory/registry.ts` — `registerServer()` (version compatibility check) + `heartbeat()` + `listServers(filter visibility/federation/status)` + `getServer()` + `clearDirectory()` — live, gak nyimpen vessel/combat/economy (DIRECTORY ≠ AUTHORITY)
- `packages/directory/index.ts` barrel

**Verified:** `tsc` PASS, `build:cli` PASS 0 stale, `check:license` OK, all `GSF-001 <noreply>`, engine ARCLUX tetap `Apache-2.0` (tidak ngerusak), MMO `LICENSE-MMO` sekarang jelas `community gameplay legal, commercial clone dilarang`
