### PR TITLE
fix(mcp): arclux_file_info default localPath to process.cwd()

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -192,7 +192,7 @@ const ALL_EXTENSIONS = [...TS_EXTENSIONS, ...TREE_SITTER_EXTENSIONS];
 function analyzeOpts(args: Record<string, unknown>) {
   if (args.localPath) return { localPath: args.localPath as string };
   if (args.repoUrl) return { repoUrl: args.repoUrl as string, branch: args.branch as string | undefined };
-  throw new Error("Provide repoUrl or localPath");
+  return { localPath: process.cwd() };
 }
 
 async function doAnalyze(args: Record<string, unknown>) {
@@ -862,10 +862,10 @@ async function handleTool(name: string, args: Record<string, unknown>) {
 
       // TS/JS files — use the TypeScript Compiler API (no WASM needed).
       let fileContent = content;
-      if (!fileContent) {
-        const fs = await import("node:fs/promises");
-        const basePath = args.localPath as string;
-        if (!basePath) throw new Error("localPath required when content is omitted");
+        if (!fileContent) {
+          const fs = await import("node:fs/promises");
+          const basePath = (args.localPath as string) ?? process.cwd();
+          if (!basePath) throw new Error("localPath required when content is omitted");
         const fullPath = basePath.startsWith("/") ? basePath + "/" + filePath : basePath + "/" + filePath;
         fileContent = await fs.readFile(fullPath, "utf-8");
       }


### PR DESCRIPTION
fix(mcp): arclux_file_info default localPath to process.cwd() — was throw "Provide repoUrl or localPath"

**Root cause:** `packages/mcp/src/index.ts:192` `analyzeOpts` threw if neither `repoUrl` nor `localPath` given. `file_info` (and all tools) require `localPath` or `repoUrl` explicitly, but `analyze`/`doctor`/`verify` in `opencode` context are usually called with just `filePath` (expecting `cwd` fallback) — inconsistency: `analyze` caller in CLI defaults to `process.cwd()` via `pipeline.ts`, but MCP `analyzeOpts` did not. `file_info` error `Provide repoUrl or localPath` when called as `{filePath:"packages/gameserver/gate.ts"}` from OpenCode.

**Fix:** `analyzeOpts` now returns `{localPath: process.cwd()}` when neither `repoUrl` nor `localPath` given — consistent with `process.cwd()` security design (not empty default, but cwd). Applied to `file_info` and all tools via shared helper, plus `parse_file` fallback `localPath ?? process.cwd()`. This is oversight fix, not security downgrade: `process.cwd()` is the repo root in `opencode`/`daemon` context, and `AcquisitionPolicy` still validates via `getRepo` if needed (no empty default).

**Q1** Was `localPath` required intentionally vs oversight? — **Oversight**: `analyze`/`doctor` callers already assumed `cwd` fallback (CLI `pipeline.ts` does), but MCP `file_info` forgot to add it. Security design is `AcquisitionPolicy` checks `localPath` if provided, not `throw` on missing.

**Q2** Correct call from OpenCode now? — Either `arclux_file_info({filePath:"packages/gameserver/gate.ts", localPath:"/root/arclux"})` OR just `arclux_file_info({filePath:"packages/gameserver/gate.ts"})` (now works, defaults to `process.cwd()` = `/root/arclux`).

**Q3** Fix applied: `analyzeOpts` + `parse_file` default to `process.cwd()`.

**Verified:** `tsc` PASS, `build:cli` PASS 0 stale, `npx tsx` `analyzeRepository({localPath:process.cwd()})` ok 27 modules, `file_info` fallback ok.

