### PR TITLE
feat(game): blueprint §2 cosmic client — star system, settings, bloom, audio, ESC menu, controls

### DIFF
--- a/apps/game/src/renderer/audio.ts
+++ b/apps/game/src/renderer/audio.ts
@@ -1,0 +1,170 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
+//
+// src/renderer/audio.ts — WebAudio engine room. Self-contained (CSP default-src
+// 'self': no asset, semua synthesized). Konsumen settings (master/sfx/music,
+// muted). §28 soundscape kinetik, bukan dashboard beep.
+
+import { loadSettings } from "./settings";
+
+export interface AudioHandle {
+  /** Kunci user gesture (autoplay policy) — panggil setelah klik. */
+  unlock(): void;
+  /** Update engine hum pitch ∝ vessel speed (0..1). */
+  setSpeed(r: number): void;
+  /** Sfx HUD/combat singkat. */
+  ui(kind: "hover" | "click" | "alert" | "boost"): void;
+  setEnabled(muted: boolean, masterVolume: number): void;
+  dispose(): void;
+}
+
+/** Generate noise buffer (satu-satu, gak pernah blocking). */
+function makeNoiseBuffer(ctx: AudioContext, seconds = 1): AudioBuffer {
+  const buf = ctx.createBuffer(1, ctx.sampleRate * seconds, ctx.sampleRate);
+  const d = buf.getChannelData(0);
+  for (let i = 0; i < d.length; i++) d[i] = Math.random() * 2 - 1;
+  return buf;
+}
+
+export function initAudio(): AudioHandle {
+  const s0 = loadSettings();
+  let muted = s0.muted;
+  let master = s0.masterVolume;
+  let ctx: AudioContext | null = null;
+  let engineOsc: OscillatorNode | null = null;
+  let engineGain: GainNode | null = null;
+  let noiseGain: GainNode | null = null;
+  let noiseSrc: AudioBufferSourceNode | null = null;
+  let sfxGain: GainNode | null = null;
+  let musicGain: GainNode | null = null;
+  let musicTimer: ReturnType<typeof setInterval> | null = null;
+
+  const ensure = (): AudioContext | null => {
+    if (ctx) return ctx;
+    if (typeof window === "undefined" || typeof AudioContext === "undefined") return null;
+    ctx = new AudioContext();
+    // Master bus → destination (mute/set master via satu gain di sini).
+    const masterBus = ctx.createGain();
+    masterBus.gain.value = muted ? 0 : master;
+    masterBus.connect(ctx.destination);
+
+    sfxGain = ctx.createGain();
+    sfxGain.gain.value = 0.7;
+    sfxGain.connect(masterBus);
+
+    musicGain = ctx.createGain();
+    musicGain.gain.value = 0.35;
+    musicGain.connect(masterBus);
+
+    // Engine hum: osc + filtered noise, pitch ∝ speed.
+    engineOsc = ctx.createOscillator();
+    engineOsc.type = "sawtooth";
+    engineOsc.frequency.value = 40;
+    engineGain = ctx.createGain();
+    engineGain.gain.value = 0.0001;
+    const lp = ctx.createBiquadFilter();
+    lp.type = "lowpass";
+    lp.frequency.value = 240;
+    engineOsc.connect(lp);
+    lp.connect(engineGain);
+    engineGain.connect(masterBus);
+
+    noiseSrc = ctx.createBufferSource();
+    noiseSrc.buffer = makeNoiseBuffer(ctx, 2);
+    noiseSrc.loop = true;
+    noiseGain = ctx.createGain();
+    noiseGain.gain.value = 0.001;
+    const hp = ctx.createBiquadFilter();
+    hp.type = "highpass";
+    hp.frequency.value = 800;
+    noiseSrc.connect(hp);
+    hp.connect(noiseGain);
+    noiseGain.connect(masterBus);
+    noiseSrc.start();
+    engineOsc.start();
+    return ctx;
+  };
+
+  // Noise/Music diredam sesuai muted & master — kita simpan gain terakhir.
+  const ramp = (node: AudioNode | GainNode | null, target: number, t: number): void => {
+    if (node && "gain" in node) (node as GainNode).gain.setTargetAtTime(target, t, 0.1);
+  };
+
+  const scheduleMusic = (): void => {
+    const c = ctx;
+    if (!c || !musicGain || muted) return;
+    const now = c.currentTime;
+    const notes = [220, 277.18, 329.63, 440, 329.63, 277.18, 220, 246.94];
+    const base = (s0.musicVolume || 0.5) * 0.06;
+    for (let i = 0; i < 4; i++) {
+      const o = c.createOscillator();
+      o.type = "triangle";
+      o.frequency.value = notes[(stepIdx + i) % notes.length] * (0.97 + 0.03 * ((s0.musicVolume || 0.5) % 1));
+      const og = c.createGain();
+      og.gain.setValueAtTime(muted ? 0 : base, now + i * 2.5);
+      og.gain.exponentialRampToValueAtTime(muted ? 0.0001 : base, now + i * 2.5 + 1.4);
+      og.gain.exponentialRampToValueAtTime(muted ? 0.0001 : 0.0003, now + i * 2.5 + 2.4);
+      o.connect(og);
+      og.connect(musicGain);
+      o.start(now + i * 2.5);
+      o.stop(now + i * 2.5 + 2.5);
+    }
+    stepIdx += 1;
+  };
+
+  return {
+    unlock() {
+      ensure();
+      if (ctx && ctx.state === "suspended") { void ctx.resume(); }
+      if (!musicTimer) {
+        scheduleMusic();
+        musicTimer = setInterval(scheduleMusic, 10000);
+      }
+    },
+    setSpeed(r) {
+      const rr = Math.max(0, Math.min(1, r));
+      if (!engineOsc || !engineGain) return;
+      engineOsc.frequency.value = 38 + rr * 46;
+      ramp(engineGain, muted ? 0 : 0.05 + rr * 0.12, ctx?.currentTime ?? 0);
+      ramp(noiseGain, muted ? 0 : 0.004 + rr * 0.05, ctx?.currentTime ?? 0);
+    },
+    ui(kind) {
+      const c = ensure();
+      if (!c || !sfxGain) return;
+      const osc = c.createOscillator();
+      const g = c.createGain();
+      const f = kind === "hover" ? 660 : kind === "click" ? 880 : kind === "alert" ? 220 : 990;
+      osc.type = kind === "alert" ? "square" : "sine";
+      osc.frequency.value = f;
+      const vol = (muted ? 0 : 0.12) * (s0.sfxVolume || 0.7);
+      g.gain.setValueAtTime(0.0001, c.currentTime);
+      g.gain.exponentialRampToValueAtTime(Math.max(0.0001, vol), c.currentTime + 0.01);
+      g.gain.exponentialRampToValueAtTime(0.0001, c.currentTime + 0.18);
+      osc.connect(g);
+      g.connect(sfxGain);
+      osc.start();
+      osc.stop(c.currentTime + 0.2);
+    },
+    setEnabled(m, v) {
+      muted = m; master = v;
+      if (ctx) {
+        // Master bus = destination path; dorong ulang gain pada semua bus.
+        ramp(musicGain, muted ? 0 : 0.35 * (v * 0.7), ctx.currentTime);
+      }
+    },
+    dispose() {
+      if (musicTimer) clearInterval(musicTimer);
+      musicTimer = null;
+      try {
+        engineOsc?.stop(); noiseSrc?.stop();
+        if (ctx) void ctx.close();
+      } catch {}
+      ctx = null; engineOsc = null; engineGain = null; noiseSrc = null; noiseGain = null; sfxGain = null; musicGain = null;
+    },
+  };
+}
+
+let stepIdx = 0;

--- a/apps/game/src/renderer/input.ts
+++ b/apps/game/src/renderer/input.ts
@@ -5,11 +5,12 @@
 // Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
 // src/renderer/input.ts — FREE-FLIGHT control binding (01 §4/§6).
-// WASD/arrows/throttle + pointer-look → kirim `move` intent ke server.
-// Server-authoritative (D-008): client cuma ngirim intent, posisi datang dari sim.
-// Tidak ada teleport/hack posisi: intent `move` = target thrust, server yang integrasi.
+// W maju · S mundur · A/D strafe · Q/E vertikal · Shift boost · Space brake ·
+// pointer-look (mouse). Configurable via settings (rebind dari controls panel).
+// Server-authoritative (D-008): client ngirim intent `move`, server yang integrasi.
 
 import type { PlayerIntent, Vec3, VesselEntity } from "../../../../packages/gameserver/types";
+import { loadSettings } from "./settings";
 
 export interface InputHandle {
   /** Bind DOM listeners ke window. panggil sekali saat game jalan. */
@@ -21,46 +22,76 @@ export interface InputHandle {
   /** Intent terakhir yang dikirim (untuk debug/otomatis poll). */
   currentIntent(): PlayerIntent | undefined;
   /** Kunci arah yang sedang ditekan (debug). */
-  state(): { up: boolean; down: boolean; left: boolean; right: boolean; boost: boolean };
+  state(): { up: boolean; down: boolean; left: boolean; right: boolean; boost: boolean; brake: boolean };
 }
 
-const KEY_W = "KeyW", KEY_A = "KeyA", KEY_S = "KeyS", KEY_D = "KeyD", KEY_ARROW_UP = "ArrowUp", KEY_ARROW_DOWN = "ArrowDown", KEY_ARROW_LEFT = "ArrowLeft", KEY_ARROW_RIGHT = "ArrowRight", KEY_SHIFT = "ShiftLeft", KEY_SPACE = "Space", KEY_CTRL = "ControlLeft";
-
-export function initInput(opts: { send: (intent: PlayerIntent) => void; onLocalVessel?: (v: VesselEntity) => void }): InputHandle {
+export function initInput(opts: {
+  send: (intent: PlayerIntent) => void;
+  /** Yaw/pitch deltas dari mouse-look → scene.setLookYawPitch. */
+  onLook?: (yaw: number, pitch: number) => void;
+}): InputHandle {
   const keys = new Set<string>();
   let playerId = "player-1";
   let entityId = "vessel-1";
   let hasLocal = false;
   let lastSeq = 0;
   let lastSentAt = 0;
-  let lastState = JSON.stringify(keys);
   let localVessel: VesselEntity | undefined;
+  let lookYaw = 0, lookPitch = 0;
+  let pointerLocked = false;
+
+  const bindings = (): ReturnType<typeof loadSettings> => loadSettings();
+  const k = (): ReturnType<typeof loadSettings> => bindings();
+
+  const isBound = (code: string): boolean => {
+    const s = k();
+    return code === s.keyForward || code === s.keyReverse || code === s.keyStrafeLeft ||
+      code === s.keyStrafeRight || code === s.keyUp || code === s.keyDown ||
+      code === s.keyBoost || code === s.keyBrake;
+  };
+
+  /** Terjemahkan key → offset thrust (best-effort; server clamp & normalisasi). */
+  const offsets = (): { tx: number; ty: number; tz: number; boost: boolean; brake: boolean } => {
+    const s = k();
+    const STEP = 2600;
+    let tx = 0, ty = 0, tz = 0;
+    if (keys.has(s.keyForward)) tz -= STEP * (KeyStep[s.keyForward] ?? 1.5);
+    if (keys.has(s.keyReverse)) tz += STEP * (KeyStep[s.keyReverse] ?? 1.0);
+    if (keys.has(s.keyStrafeLeft)) tx -= STEP * (KeyStep[s.keyStrafeLeft] ?? 1.0);
+    if (keys.has(s.keyStrafeRight)) tx += STEP * (KeyStep[s.keyStrafeRight] ?? 1.0);
+    if (keys.has(s.keyUp)) ty += STEP * (KeyStep[s.keyUp] ?? 0.8);
+    if (keys.has(s.keyDown)) ty -= STEP * (KeyStep[s.keyDown] ?? 0.8);
+    const boost = keys.has(s.keyBoost);
+    const brake = keys.has(s.keyBrake) && !boost;
+    return { tx, ty, tz, boost, brake };
+  };
 
   const sendMove = (now: number): void => {
     if (!hasLocal || !localVessel) return;
-    const thrust = 1; // unit m/s^2 target offset (server clamps via Newton)
+    const { tx, ty, tz, boost, brake } = offsets();
     const base = localVessel.position;
-    let tx = base.x, ty = base.y, tz = base.z;
-    if (keys.has(KEY_W) || keys.has(KEY_ARROW_UP)) tz -= 2600;
-    if (keys.has(KEY_S) || keys.has(KEY_ARROW_DOWN)) tz += 2600;
-    if (keys.has(KEY_A) || keys.has(KEY_ARROW_LEFT)) tx -= 2600;
-    if (keys.has(KEY_D) || keys.has(KEY_ARROW_RIGHT)) tx += 2600;
-    if (keys.has(KEY_SPACE)) ty += 2600;
-    if (keys.has(KEY_CTRL)) ty -= 2600;
-    const boost = keys.has(KEY_SHIFT) ? 2.2 : 1;
-    // Hanya kirim saat ada movement aktif (hemat bandwidth, deterministic).
-    if (tx === base.x && ty === base.y && tz === base.z) return;
-    void thrust;
-    const target: Vec3 = { x: tx, y: ty, z: tz };
-    const intent: PlayerIntent = { playerId, entityId, type: "move", seq: ++lastSeq, payload: { ...target } };
+    // Speed per §6: maju kuat, boost klaim 2.2× (~550 m/s).
+    const boostFactor = boost ? 2.2 : 1;
+    const target: Vec3 = brake
+      ? { ...base } // brake → server lihat jarak<1 → reverse thrust (cap mati)
+      : {
+          x: base.x + tx * boostFactor,
+          y: base.y + ty * boostFactor,
+          z: base.z + tz * boostFactor,
+        };
+    // Brake selalu dikirim (diperlukan biar vessel berhenti); gerak cuma saat ada input.
+    if (!brake && tx === 0 && ty === 0 && tz === 0) return;
+    const intent: PlayerIntent = {
+      playerId, entityId, type: "move", seq: ++lastSeq,
+      payload: { ...target },
+    };
     opts.send(intent);
     lastSentAt = now;
-    lastState = JSON.stringify(keys);
-    opts.onLocalVessel?.(localVessel);
   };
 
   const onKeyDown = (e: KeyboardEvent): void => {
-    if ([KEY_W, KEY_A, KEY_S, KEY_D, KEY_ARROW_UP, KEY_ARROW_DOWN, KEY_ARROW_LEFT, KEY_ARROW_RIGHT, KEY_SHIFT, KEY_SPACE, KEY_CTRL].includes(e.code)) {
+    if (e.code === "Escape") { if (pointerLocked) return; }
+    if (isBound(e.code)) {
       e.preventDefault();
       keys.add(e.code);
       sendMove(Date.now());
@@ -75,22 +106,49 @@ export function initInput(opts: { send: (intent: PlayerIntent) => void; onLocalV
 
   const throttledPoll = (): void => {
     const now = Date.now();
-    // Kirim ulang ~25Hz kalau arah masih ditekan (server drift-correct). 
+    // Resend ~25Hz kalau arah masih ditekan (server drift-correct).
     if (now - lastSentAt > 40) sendMove(now);
   };
   let timer: ReturnType<typeof setInterval> | null = null;
+
+  // Mouse-look (pointer lock). Yaw/pitch terakumulasi → scene.
+  const onMouseMove = (e: MouseEvent): void => {
+    if (!pointerLocked) return;
+    const s = k();
+    const sens = (s.lookSensitivity || 0.6) * 0.0022;
+    const invY = s.invertLookY ? -1 : 1;
+    lookYaw -= e.movementX * sens;
+    lookPitch += e.movementY * sens * invY;
+    opts.onLook?.(lookYaw, lookPitch);
+  };
+  const onCanvasClick = (): void => {
+    const s = k();
+    if (s.keyLook === "pointer-lock") {
+      const el = document.body;
+      el.requestPointerLock?.();
+    }
+  };
+  const onLockChange = (): void => {
+    pointerLocked = document.pointerLockElement === document.body;
+  };
 
   return {
     attach() {
       window.addEventListener("keydown", onKeyDown);
       window.addEventListener("keyup", onKeyUp);
       window.addEventListener("blur", onBlur);
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("click", onCanvasClick);
+      document.addEventListener("pointerlockchange", onLockChange);
       timer = setInterval(throttledPoll, 40);
     },
     detach() {
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", onBlur);
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("click", onCanvasClick);
+      document.removeEventListener("pointerlockchange", onLockChange);
       if (timer) clearInterval(timer); timer = null;
       keys.clear();
     },
@@ -103,7 +161,29 @@ export function initInput(opts: { send: (intent: PlayerIntent) => void; onLocalV
       return hasLocal ? { playerId, entityId, type: "move", seq: lastSeq, payload: {} } : undefined;
     },
     state() {
-      return { up: keys.has(KEY_W) || keys.has(KEY_ARROW_UP), down: keys.has(KEY_S) || keys.has(KEY_ARROW_DOWN), left: keys.has(KEY_A) || keys.has(KEY_ARROW_LEFT), right: keys.has(KEY_D) || keys.has(KEY_ARROW_RIGHT), boost: keys.has(KEY_SHIFT) };
+      const s = k();
+      return {
+        up: keys.has(s.keyForward),
+        down: keys.has(s.keyReverse),
+        left: keys.has(s.keyStrafeLeft),
+        right: keys.has(s.keyStrafeRight),
+        boost: keys.has(s.keyBoost),
+        brake: keys.has(s.keyBrake),
+      };
     },
   };
 }
+
+// Map preset key → step multiplier (forward lebih panjang daripada strafe).
+const KeyStep: Record<string, number> = {
+  KeyW: 1.5,
+  ArrowUp: 1.5,
+  KeyS: 1.0,
+  ArrowDown: 1.0,
+  KeyA: 1.0,
+  ArrowLeft: 1.0,
+  KeyD: 1.0,
+  ArrowRight: 1.0,
+  KeyQ: 0.8,
+  KeyE: 0.8,
+};

--- a/apps/game/src/renderer/menu.ts
+++ b/apps/game/src/renderer/menu.ts
@@ -1,0 +1,350 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
+//
+// src/renderer/menu.ts — Escape/Settings menu (01 §28 command-interface).
+// Sidebar tabs: GRAPHICS · AUDIO · CONTROLS. Persist ke localStorage via
+// settings engine (settings.ts). Visual berubah live by renderer via callbacks
+// (scene.applyQuality, audio.setEnabled). XSS-safe: hanya static innerHTML /
+// literal; SEMUA nilai dinamis lewat textContent/value, tidak ada concat HTML.
+
+import { colors, typography, glow } from "../ui/tokens";
+import {
+  loadSettings, saveSettings, applyPreset, updateSettings,
+  type GameSettings, type QualityPreset, type FpsCap, type BloomQuality,
+} from "./settings";
+
+export type MenuCameraMode = "free" | "follow" | "tactical" | "cinematic";
+
+export interface MenuHandle {
+  toggle(): void;
+  open(): void;
+  close(): void;
+  readonly isOpen: boolean;
+  dispose(): void;
+}
+
+export interface MenuCallbacks {
+  onQuality(s: GameSettings): void;
+  onAudio(s: GameSettings): void;
+  onCameraMode(mode: MenuCameraMode): void;
+  onSfx?(kind: "hover" | "click"): void;
+}
+
+const PRESET_OPTS: QualityPreset[] = ["LOW", "MEDIUM", "HIGH", "ULTRA", "CINEMATIC"];
+const FPS_OPTS: FpsCap[] = [30, 60, 90, 120, 240, 0];
+const BLOOM_OPTS: BloomQuality[] = ["off", "low", "high"];
+
+export function initMenu(callbacks: MenuCallbacks): MenuHandle {
+  const root = typeof document !== "undefined" ? document.body : null;
+  if (!root) {
+    return { toggle: () => {}, open: () => {}, close: () => {}, isOpen: false, dispose: () => {} };
+  }
+
+  let isOpen = false;
+  const els = new Map<string, HTMLElement>();
+
+  const wrap = document.createElement("div");
+  wrap.id = "arclux-menu";
+  wrap.style.cssText = [
+    "position:fixed", "inset:0", "z-index:80",
+    "background:rgba(2,3,10,0.55)", "backdrop-filter:blur(2px)",
+    "display:none", "align-items:center", "justify-content:flex-end",
+  ].join(";");
+  root.appendChild(wrap);
+
+  const panel = document.createElement("div");
+  panel.style.cssText = [
+    `width:380px`, "height:100%",
+    "background:linear-gradient(180deg,rgba(10,16,28,0.92),rgba(6,9,18,0.96))",
+    `border-left:1px solid ${colors.edge}`,
+    `font-family:${typography.mono}`, `color:${colors.foreground}`,
+    "padding:22px", "box-sizing:border-box", "overflow-y:auto",
+    `letter-spacing:${typography.letterspacing}`,
+  ].join(";");
+  wrap.appendChild(panel);
+
+  // Header
+  const head = document.createElement("div");
+  head.style.cssText = `display:flex;justify-content:space-between;align-items:center;border-bottom:1px solid ${colors.edge};padding-bottom:12px;margin-bottom:14px`;
+  panel.appendChild(head);
+  const title = document.createElement("div");
+  title.style.cssText = `font-family:${typography.display};letter-spacing:${typography.displaySpacing};font-weight:700`;
+  title.textContent = "SYSTEM SETTINGS";
+  head.appendChild(title);
+  const closeBtn = document.createElement("button");
+  closeBtn.textContent = "ESC ×";
+  closeBtn.style.cssText = `background:${glow.panelBg};border:1px solid ${colors.edge};color:${colors.tactical};padding:4px 10px;cursor:pointer;font-family:inherit`;
+  head.appendChild(closeBtn);
+
+  // Tabs
+  const tabs = document.createElement("div");
+  tabs.style.cssText = "display:flex;gap:8px;margin-bottom:18px";
+  panel.appendChild(tabs);
+  const tabIds = ["GRAPHICS", "AUDIO", "CONTROLS"] as const;
+  const tabBtns = new Map<string, HTMLButtonElement>();
+  const sections = new Map<string, HTMLElement>();
+  for (const id of tabIds) {
+    const b = document.createElement("button");
+    b.textContent = id;
+    b.style.cssText = `padding:6px 14px;border:1px solid ${colors.edge};background:${glow.panelBg};color:${colors.muted};cursor:pointer;font-family:inherit;font-size:11px`;
+    tabs.appendChild(b);
+    tabBtns.set(id, b);
+    const sec = document.createElement("div");
+    sec.style.display = "none";
+    panel.appendChild(sec);
+    sections.set(id, sec);
+  }
+
+  const activate = (id: string): void => {
+    for (const [k, b] of tabBtns) {
+      const on = k === id;
+      b.style.color = on ? colors.tech : colors.muted;
+      b.style.borderColor = on ? colors.tech : colors.edge;
+      b.style.textShadow = on ? glow.textTech : "none";
+      sections.get(k)!.style.display = k === id ? "block" : "none";
+    }
+  };
+  for (const [id, b] of tabBtns) {
+    b.addEventListener("click", () => { activate(id); callbacks.onSfx?.("click"); });
+  }
+
+  // Builder
+  const row = (labelText: string): HTMLElement => {
+    const r = document.createElement("div");
+    r.style.cssText = "display:flex;justify-content:space-between;align-items:center;padding:7px 0;border-bottom:1px dashed rgba(90,110,146,0.25);margin-bottom:6px";
+    const lb = document.createElement("span");
+    lb.style.cssText = "font-size:11px;color:" + colors.body;
+    lb.textContent = labelText;
+    r.appendChild(lb);
+    return r;
+  };
+  const paintList = (container: HTMLElement, current: string): void => {
+    for (const b of Array.from(container.querySelectorAll("button"))) {
+      const bt = b as HTMLButtonElement;
+      const on = bt.getAttribute("aria-checked") === current;
+      bt.style.color = on ? colors.tech : colors.muted;
+      bt.style.borderColor = on ? colors.tech : colors.edge;
+      bt.style.textShadow = on ? glow.textTech : "none";
+    }
+  };
+  const optsRow = (sec: HTMLElement, labelText: string, values: readonly string[], current: string, onPick: (v: string) => void): void => {
+    const r = row(labelText);
+    const list = document.createElement("span");
+    list.style.cssText = "display:flex;gap:6px;flex-wrap:wrap";
+    for (const v of values) {
+      const b = document.createElement("button");
+      b.textContent = v;
+      b.setAttribute("aria-checked", v);
+      const vv = v;
+      b.style.cssText = `padding:3px 8px;border:1px solid ${colors.edge};background:${glow.panelBg};color:${colors.muted};cursor:pointer;font-family:inherit;font-size:10px`;
+      b.addEventListener("click", () => {
+        callbacks.onSfx?.("click");
+        onPick(vv);
+      });
+      b.addEventListener("mouseenter", () => callbacks.onSfx?.("hover"));
+      list.appendChild(b);
+    }
+    r.appendChild(list);
+    sec.appendChild(r);
+    els.set(labelText, list);
+    paintList(list, current);
+  };
+
+  // ===================== GRAPHICS =====================
+  const g = sections.get("GRAPHICS")!;
+  let cached = loadSettings();
+  const commit = (patch: Partial<GameSettings> | ((s: GameSettings) => GameSettings)): GameSettings => {
+    const next = typeof patch === "function" ? (patch as (s: GameSettings) => GameSettings)(cached) : { ...cached, ...patch };
+    saveSettings(next);
+    cached = next;
+    callbacks.onQuality(next);
+    return next;
+  };
+
+  const pickPreset = (v: string): void => {
+    const next = applyPreset(v as QualityPreset);
+    saveSettings(next);
+    cached = next;
+    callbacks.onQuality(next);
+    refreshControls();
+    refreshAudio();
+  };
+  function refreshControls(): void {
+    const s = loadSettings();
+    for (const meta of ctrlMeta) {
+      const btn = els.get("K:" + meta.key) as HTMLButtonElement | undefined;
+      if (btn) btn.textContent = prettyKey(s[meta.key]);
+    }
+  }
+  function refreshAudio(): void {
+    const s = loadSettings();
+    mutedCache = s.muted;
+    sensCache = s.lookSensitivity;
+  }
+
+  optsRow(g, "PRESET", PRESET_OPTS, cached.preset, pickPreset);
+  optsRow(g, "FPS CAP", FPS_OPTS.map(String), String(cached.fpsCap), (v) => commit({ fpsCap: Number(v) as FpsCap }));
+  optsRow(g, "BLOOM", BLOOM_OPTS, cached.bloom, (v) => commit({ bloom: v as BloomQuality }));
+
+  const sliderRow = (sec: HTMLElement, labelText: string, get: (s: GameSettings) => number, set: (s: GameSettings, v: number) => GameSettings): void => {
+    const r = row(labelText);
+    const input = document.createElement("input");
+    input.type = "range";
+    input.min = "0"; input.max = "1"; input.step = "0.05";
+    input.value = String(get(cached));
+    input.style.cssText = "width:120px;accent-color:" + colors.tactical;
+    input.addEventListener("input", () => {
+      commit(() => set(cached, Number(input.value)));
+      callbacks.onSfx?.("click");
+    });
+    r.appendChild(input);
+    sec.appendChild(r);
+  };
+
+  sliderRow(g, "NEBULA", (s) => s.nebulaDensity / 12, (s, v) => ({ ...s, nebulaDensity: Math.round(v * 12) }));
+  sliderRow(g, "BELT", (s) => s.beltDensity / 10000, (s, v) => ({ ...s, beltDensity: Math.round(v * 10000) }));
+  sliderRow(g, "STARS", (s) => s.starBodies / 3, (s, v) => ({ ...s, starBodies: Math.round(v * 3) }));
+
+  // ===================== AUDIO =====================
+  const a = sections.get("AUDIO")!;
+  let mutedCache = cached.muted;
+  const vol = (sec: HTMLElement, labelText: string, key: "masterVolume" | "sfxVolume" | "musicVolume"): void => {
+    const r = row(labelText);
+    const input = document.createElement("input");
+    input.type = "range";
+    input.min = "0"; input.max = "1"; input.step = "0.05";
+    input.value = String(cached[key]);
+    input.style.cssText = "width:120px;accent-color:" + colors.tactical;
+    input.addEventListener("input", () => {
+      const s = commit({ [key]: Number(input.value) });
+      callbacks.onAudio(s);
+    });
+    r.appendChild(input);
+    sec.appendChild(r);
+  };
+  vol(a, "MASTER", "masterVolume");
+  vol(a, "SFX", "sfxVolume");
+  vol(a, "MUSIC", "musicVolume");
+
+  const mRow = row("MUTE");
+  const mBtn = document.createElement("button");
+  mBtn.style.cssText = `padding:3px 10px;border:1px solid ${colors.edge};background:${glow.panelBg};color:${colors.tactical};cursor:pointer;font-family:inherit;font-size:10px`;
+  const paintMute = (): void => {
+    mBtn.textContent = mutedCache ? "MUTED" : "LIVE";
+  };
+  paintMute();
+  mBtn.addEventListener("click", () => {
+    const s = commit({ muted: !mutedCache });
+    mutedCache = s.muted;
+    paintMute();
+    callbacks.onAudio(s);
+  });
+  mRow.appendChild(mBtn);
+  a.appendChild(mRow);
+
+  // ===================== CONTROLS =====================
+  const c = sections.get("CONTROLS")!;
+  let sensCache = cached.lookSensitivity;
+  let capturing: string | null = null;
+  const ctrlMeta: { label: string; key: "keyForward" | "keyReverse" | "keyStrafeLeft" | "keyStrafeRight" | "keyUp" | "keyDown" | "keyBoost" | "keyBrake" }[] = [
+    { label: "FORWARD", key: "keyForward" },
+    { label: "REVERSE", key: "keyReverse" },
+    { label: "STRAFE L", key: "keyStrafeLeft" },
+    { label: "STRAFE R", key: "keyStrafeRight" },
+    { label: "VERTICAL ↑", key: "keyUp" },
+    { label: "VERTICAL ↓", key: "keyDown" },
+    { label: "BOOST", key: "keyBoost" },
+    { label: "BRAKE", key: "keyBrake" },
+  ];
+
+  const bindRow = (sec: HTMLElement, meta: { label: string; key: string }): void => {
+    const r = row(meta.label);
+    const btn = document.createElement("button");
+    btn.textContent = prettyKey(cached[meta.key as keyof GameSettings] as string);
+    btn.style.cssText = `padding:3px 10px;border:1px solid ${colors.edge};background:${glow.panelBg};color:${colors.tech};cursor:pointer;font-family:inherit;font-size:10px`;
+    btn.addEventListener("click", () => {
+      callbacks.onSfx?.("click");
+      const target = meta.key as keyof GameSettings;
+      capturing = target;
+      btn.textContent = "PRESS...";
+      const grab = (e: KeyboardEvent): void => {
+        e.preventDefault();
+        e.stopPropagation();
+        const code = e.code || (e.key === " " ? "Space" : "");
+        if (!code) return;
+        capturing = null;
+        const s = commit({ [target]: code });
+        btn.textContent = prettyKey(s[target] as string);
+        window.removeEventListener("keydown", grab);
+      };
+      window.addEventListener("keydown", grab);
+    });
+    r.appendChild(btn);
+    sec.appendChild(r);
+    els.set("K:" + meta.key, btn);
+  };
+  for (const meta of ctrlMeta) bindRow(c, meta);
+
+  const sensRow = row("SENSITIVITY");
+  const sensIn = document.createElement("input");
+  sensIn.type = "range"; sensIn.min = "0.1"; sensIn.max = "2"; sensIn.step = "0.1"; sensIn.value = String(sensCache);
+  sensIn.style.cssText = "width:120px;accent-color:" + colors.tactical;
+  sensIn.addEventListener("input", () => {
+    const s = commit({ lookSensitivity: Number(sensIn.value) });
+    sensCache = s.lookSensitivity;
+  });
+  sensRow.appendChild(sensIn);
+  c.appendChild(sensRow);
+
+  const invRow = row("INVERT LOOK Y");
+  const invBtn = document.createElement("button");
+  invBtn.style.cssText = `padding:3px 10px;border:1px solid ${colors.edge};background:${glow.panelBg};color:${colors.tech};cursor:pointer;font-family:inherit;font-size:10px`;
+  const paintInv = (): void => { invBtn.textContent = cached.invertLookY ? "ON" : "OFF"; };
+  paintInv();
+  invBtn.addEventListener("click", () => {
+    const s = commit({ invertLookY: !cached.invertLookY });
+    cached = s;
+    paintInv();
+    callbacks.onSfx?.("click");
+  });
+  invRow.appendChild(invBtn);
+  c.appendChild(invRow);
+
+  const camRow = row("CAMERA MODE");
+  const camSel = document.createElement("select");
+  const cams: MenuCameraMode[] = ["follow", "tactical", "cinematic", "free"];
+  for (const m of cams) {
+    const o = document.createElement("option");
+    o.value = m; o.textContent = m.toUpperCase();
+    camSel.appendChild(o);
+  }
+  camSel.value = "follow";
+  camSel.style.cssText = `background:${glow.panelBg};color:${colors.tech};border:1px solid ${colors.edge};font-family:inherit`;
+  camSel.addEventListener("change", () => { callbacks.onCameraMode(camSel.value as MenuCameraMode); callbacks.onSfx?.("click"); });
+  camRow.appendChild(camSel);
+  c.appendChild(camRow);
+
+  // ===================== Open/Close =====================
+  const open = (): void => { isOpen = true; wrap.style.display = "flex"; };
+  const close = (): void => { isOpen = false; wrap.style.display = "none"; };
+  const toggle = (): void => { if (isOpen) close(); else open(); };
+
+  activate("GRAPHICS");
+  wrap.addEventListener("click", (e) => { if (e.target === wrap) close(); });
+  closeBtn.addEventListener("click", close);
+  const dispose = (): void => { wrap.remove(); };
+
+  return { toggle, open, close, isOpen, dispose };
+}
+
+function prettyKey(code: string): string {
+  const map: Record<string, string> = {
+    KeyW: "W", KeyS: "S", KeyA: "A", KeyD: "D", KeyQ: "Q", KeyE: "E",
+    ShiftLeft: "SHIFT", Space: "SPACE", ControlLeft: "CTRL", ControlRight: "CTRL",
+    ArrowUp: "↑", ArrowDown: "↓", ArrowLeft: "←", ArrowRight: "→",
+  };
+  return map[code] ?? code.replace("Key", "").toUpperCase();
+}

--- a/apps/game/src/renderer/renderer.ts
+++ b/apps/game/src/renderer/renderer.ts
@@ -8,13 +8,16 @@
 // di browser context. Server-authoritative: client render snapshot + kirim intent.
 //
 // Layering (D-008):
-//   input (WASD) → intent `move` → server /intent
-//   server tick → /snapshot → scene + HUD render
+//   input (WASD/QE + look) → intent `move` → server /intent
+//   server tick → /snapshot → scene + HUD render (+ rAF smooth interpolation)
 
 import { initScene3D, type Scene3D } from "./scene3d";
 import { initHud, type Hud } from "./hud";
 import { connectNet, type NetHandle } from "./net";
 import { initInput, type InputHandle } from "./input";
+import { initAudio, type AudioHandle } from "./audio";
+import { initMenu, type MenuHandle, type MenuCameraMode } from "./menu";
+import { loadSettings } from "./settings";
 import type { RegionSnapshot, VesselEntity, WorldEntity } from "../../../../packages/gameserver/types";
 
 export interface RendererHandle {
@@ -22,6 +25,8 @@ export interface RendererHandle {
   hud: Hud;
   net: NetHandle;
   input: InputHandle;
+  audio: AudioHandle;
+  menu: MenuHandle;
   dispose(): void;
 }
 
@@ -37,33 +42,68 @@ function toRegionState(snap: RegionSnapshot) {
 }
 
 export function bootstrapRenderer(opts?: { serverUrl?: string }): RendererHandle {
-  const scene = initScene3D();
+  const settings = loadSettings();
+  const scene = initScene3D(undefined, settings);
   const hud = initHud();
   const net = connectNet(opts?.serverUrl);
-  const input = initInput({ send: (intent) => { void net.send(intent); } });
+  const audio = initAudio();
+  const input = initInput({
+    send: (intent) => { void net.send(intent); },
+    onLook: (yaw, pitch) => scene.setLookYawPitch(yaw, pitch),
+  });
+  const menu = initMenu({
+    onQuality: (s) => scene.applyQuality(s),
+    onAudio: (s) => audio.setEnabled(s.muted, s.masterVolume),
+    onCameraMode: (mode) => scene.setCameraMode(mode as Parameters<Scene3D["setCameraMode"]>[0]),
+    onSfx: (kind) => audio.ui(kind === "click" ? "click" : "hover"),
+  });
 
-  // Wire snapshot → scene + HUD + input (server-authoritative, D-008).
-  // Server posisi = meters (skala cosmo). Renderer pakai skala stylized (scene units);
-  // konversi posisi dilakukan di sini supaya renderer nggak bawa seluruh otoritas.
+  // Skena mulai dari settings tersimpan; audio unlock pertama interaksi.
+  scene.applyQuality(settings);
+
+  let lastSpeed = 0;
   const stop = net.onState((snap) => {
     const state = toRegionState(snap);
     scene.renderRegion(state);
     hud.update(state);
     // Setiap vessel dari server → input mengenali pilot local (entity pertama).
-    const vessels = state.entities.values();
-    for (const e of vessels) {
-      if (e.kind === "vessel") { input.setLocalVessel(e as VesselEntity); break; }
+    let localVessel: VesselEntity | undefined;
+    for (const e of state.entities.values()) {
+      if (e.kind === "vessel") { localVessel = e as VesselEntity; break; }
+    }
+    input.setLocalVessel(localVessel);
+    // Audio: engine hum ∝ kecepatan normalized.
+    if (localVessel) {
+      const v = localVessel.velocity;
+      const sp = Math.min(1, Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z) / 250);
+      if (Math.abs(sp - lastSpeed) > 0.01) { audio.setSpeed(sp); lastSpeed = sp; }
     }
   });
 
+  // Unlock audio + buka menu di ESC (interaction-driven, autoplay policy).
+  const onDocClick = (): void => { audio.unlock(); };
+  const onKeyDown = (e: KeyboardEvent): void => {
+    if (e.code === "Escape" && !menu.isOpen) { e.preventDefault(); menu.open(); audio.ui("click"); }
+  };
+  document.addEventListener("click", onDocClick, { once: true });
+  window.addEventListener("keydown", onKeyDown);
+
   input.attach();
 
-  const dispose = () => { stop(); input.detach(); scene.dispose(); hud.dispose(); };
+  const dispose = () => {
+    stop();
+    input.detach();
+    window.removeEventListener("keydown", onKeyDown);
+    scene.dispose();
+    hud.dispose();
+    menu.dispose();
+    audio.dispose();
+  };
 
   // Expose for manual control in devtools
-  if (typeof window !== "undefined") (window as any).__arcluxRenderer = { scene, net, hud, input };
+  if (typeof window !== "undefined") (window as any).__arcluxRenderer = { scene, net, hud, input, audio, menu };
 
-  return { scene, hud, net, input, dispose };
+  return { scene, hud, net, input, audio, menu, dispose };
 }
 
 if (typeof document !== "undefined") {

--- a/apps/game/src/renderer/scene3d.ts
+++ b/apps/game/src/renderer/scene3d.ts
@@ -4,25 +4,44 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 // Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
 //
-// src/renderer/scene3d.ts — SUPER HD cinematic render (server-authoritative D-008:
-// visual ≠ otoritas posisi). Desain game-native, bukan skin apps/web.
-// Blueprint 01 §2.5 dua skala · §2.6 fisika (sun emissive ∝ aktivitas, planet termal) ·
-// §22 LOD · §2.1) objek COLLIDABLE/ATMOSPHERIC/BACKDROP.
+// src/renderer/scene3d.ts — LIVING COSMIC SYSTEM (blueprint 01 §2, D-008:
+// visual ≠ otoritas posisi). Render cinematic, orbit deterministik.
 //
-// KONSEP: Ark-Librarieschip — satu vessel-world raksasa tempat semua sejarah
-// kembali (06 §18.5). Semua efek dari inti THREE (no examples import, raw module
-// di Electron renderer, CSP default-src 'self').
+// §2.1  Sistem bintang per region (star + planets + moons + belt + events)
+// §2.2  Tiga lapis: COLLIDABLE / ATMOSPHERIC / BACKDROP
+// §2.3  Orbit Kepler deterministik per tick; fase bulan dari geometri
+// §2.4  Cosmic events: meteor shower · star flare · aurora (bergerak)
+// §2.5  Dua skala koordinat: SYSTEM (benda langit) vs LOCAL (vessel)
+// §2.6  Termal ∝ 1/r² — emissive planet naik saat dekat matahari
+// §21   Camera modes: free · follow · tactical · cinematic
+// §22   LOD — FAR/MID/NEAR adaptif (detail naik saat dekat)
+//
+// Post-processing: EffectComposer + UnrealBloomPass + OutputPass (core THREE,
+// no CDN — CSP default-src 'self'). Semua texture dari Canvas (no asset).
 
 import type { RegionState, VesselEntity, StationEntity } from "../../../../packages/gameserver/types";
 import * as THREE from "three";
+import { EffectComposer } from "three/examples/jsm/postprocessing/EffectComposer.js";
+import { RenderPass } from "three/examples/jsm/postprocessing/RenderPass.js";
+import { UnrealBloomPass } from "three/examples/jsm/postprocessing/UnrealBloomPass.js";
+import { OutputPass } from "three/examples/jsm/postprocessing/OutputPass.js";
 import { colors, threeColor, nebulaSeed } from "../ui/tokens";
+import { effPixelRatio, type GameSettings } from "./settings";
+
+export type CameraMode = "free" | "follow" | "tactical" | "cinematic";
 
 export interface Scene3D {
   renderRegion(region: RegionState): void;
   updateVessel(v: VesselEntity): void;
+  setCameraMode(mode: CameraMode): void;
+  applyQuality(settings: GameSettings): void;
+  setLookYawPitch(yaw: number, pitch: number): void;
   dispose(): void;
 }
 
+// ---------------------------------------------------------------------------
+// Deterministic RNG & orbit math (client-side — sama deterministik server §2.3)
+// ---------------------------------------------------------------------------
 function mulberry32(seed: number): () => number {
   let a = seed >>> 0;
   return () => {
@@ -33,204 +52,436 @@ function mulberry32(seed: number): () => number {
   };
 }
 
-export function initScene3D(container?: HTMLElement): Scene3D {
+interface OrbitSpec {
+  /** semi-major axis (render units). */
+  semimajor: number;
+  /** eccentricity 0..<1. */
+  eccentricity: number;
+  /** rotation per tick (rad). */
+  omega: number;
+  /** phase offset (rad). */
+  phase: number;
+  inclination: number;
+}
+
+function keplerPosition(o: OrbitSpec, tick: number): THREE.Vector3 {
+  const M = o.phase + tick * o.omega;
+  const e = o.eccentricity;
+  // Iterasi 3× buat Mean→Eccentric anomaly (cukup buat e<0.4; deterministik).
+  let E = M;
+  for (let i = 0; i < 3; i++) E = M + e * Math.sin(E);
+  const x = o.semimajor * (Math.cos(E) - e);
+  const z = o.semimajor * Math.sqrt(1 - e * e) * Math.sin(E);
+  // Rossi ke bidang miring (inclination).
+  const ci = Math.cos(o.inclination);
+  const y = z * Math.sin(o.inclination);
+  return new THREE.Vector3(x, y, z * ci);
+}
+
+// ---------------------------------------------------------------------------
+// Body catalogue (blueprint §2.1/§2.2) — tipe berbeda, bukan bolak warna.
+// ---------------------------------------------------------------------------
+type PlanetKind = "gasGiant" | "gasGiantRinged" | "ice" | "ocean" | "desert" | "volcanic";
+
+interface PlanetSpec {
+  kind: PlanetKind;
+  baseColor: string;
+  emissive: string;
+  roughness: number;
+  metalness: number;
+  /** yang menyusun ring (Torus) — hanya gas giant ringed. */
+  hasRing?: boolean;
+  moons: number;
+}
+
+const PLANET_CATALOG: PlanetSpec[] = [
+  { kind: "gasGiant", baseColor: colors.planetGasGiant, emissive: "#000000", roughness: 0.9, metalness: 0.0, moons: 2 },
+  { kind: "gasGiantRinged", baseColor: colors.planetGasGiant, emissive: "#5a3a1a", roughness: 0.85, metalness: 0.1, hasRing: true, moons: 3 },
+  { kind: "ice", baseColor: colors.planetIce, emissive: "#000000", roughness: 0.3, metalness: 0.5, moons: 1 },
+  { kind: "ocean", baseColor: colors.planetOcean, emissive: "#000000", roughness: 0.2, metalness: 0.4, moons: 1 },
+  { kind: "desert", baseColor: colors.planetDesert, emissive: "#000000", roughness: 0.95, metalness: 0.05, moons: 0 },
+  { kind: "volcanic", baseColor: colors.planetLava, emissive: colors.lavaGlow, roughness: 0.8, metalness: 0.3, moons: 0 },
+];
+
+export function initScene3D(container?: HTMLElement, settings?: GameSettings): Scene3D {
   const target = container ?? (typeof document !== "undefined" ? document.getElementById("app") : null);
   const width = target?.clientWidth ?? 800;
   const height = target?.clientHeight ?? 600;
+  const DPR = typeof window !== "undefined" ? window.devicePixelRatio || 1 : 1;
 
   const scene = new THREE.Scene();
   scene.background = new THREE.Color(threeColor(colors.voidDeep));
-  scene.fog = new THREE.FogExp2(threeColor(colors.void), 0.00004);
 
-  const camera = new THREE.PerspectiveCamera(70, width / height, 0.1, 260000);
-  camera.position.set(0, 2600, 5200);
-  camera.lookAt(0, -200, 0);
+  // =================== CAMERA (perspektif pilot, §21 camera modes) ==========
+  const camera = new THREE.PerspectiveCamera(70, width / height, 1, 1_000_000);
+  camera.position.set(0, 1600, 6400);
+  camera.lookAt(0, 0, 0);
+  let camMode: CameraMode = "follow";
 
+  // =================== RENDERER + POST (glow real, bukan sprite) ============
   const renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: "high-performance" });
   renderer.setSize(width, height);
-  renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
   renderer.toneMapping = THREE.ACESFilmicToneMapping;
-  renderer.toneMappingExposure = 1.2;
+  renderer.toneMappingExposure = 1.15;
   if (target) target.appendChild(renderer.domElement);
+
+  const composer = new EffectComposer(renderer);
+  const renderPass = new RenderPass(scene, camera);
+  composer.addPass(renderPass);
+  const bloomPass = new UnrealBloomPass(new THREE.Vector2(width, height), 1.15, 0.45, 0.65);
+  composer.addPass(bloomPass);
+  const outputPass = new OutputPass(); // menangani tone mapping di akhir
+  composer.addPass(outputPass);
 
   const rand = mulberry32(nebulaSeed);
 
-  // ================= STARFIELD (InstancedMesh, §22 FAR) =================
-  const starCount = 8000;
+  // =================== STARFIELD (FAR §22, instanced) =======================
   const starDummy = new THREE.Object3D();
   const starGeom = new THREE.SphereGeometry(1, 4, 4);
   const starMat = new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.85 });
-  const stars = new THREE.InstancedMesh(starGeom, starMat, starCount);
-  for (let i = 0; i < starCount; i++) {
-    const r = 30000 + rand() * 80000;
-    const theta = rand() * Math.PI * 2;
-    const phi = Math.acos(2 * rand() - 1);
-    starDummy.position.set(r * Math.sin(phi) * Math.cos(theta), r * Math.cos(phi), r * Math.sin(phi) * Math.sin(theta));
-    const s = 1 + rand() * 3;
-    starDummy.scale.set(s, s, s);
-    starDummy.updateMatrix();
-    stars.setMatrixAt(i, starDummy.matrix);
-  }
-  stars.instanceMatrix.needsUpdate = true;
-  scene.add(stars);
+  const makeStars = (count: number): THREE.InstancedMesh => {
+    const mesh = new THREE.InstancedMesh(starGeom, starMat, count);
+    for (let i = 0; i < count; i++) {
+      const r = 20000 + rand() * 120000;
+      const theta = rand() * Math.PI * 2;
+      const phi = Math.acos(2 * rand() - 1);
+      starDummy.position.set(r * Math.sin(phi) * Math.cos(theta), r * Math.cos(phi), r * Math.sin(phi) * Math.sin(theta));
+      starDummy.scale.set(1 + rand() * 3, 1 + rand() * 3, 1 + rand() * 3);
+      starDummy.updateMatrix();
+      mesh.setMatrixAt(i, starDummy.matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    scene.add(mesh);
+    return mesh;
+  };
+  makeStars(6000);
 
-  // Bintang panas berwarna (depth, spectral accent)
+  // Bintang panas spectral (depth)
   const hotGeom = new THREE.SphereGeometry(1, 6, 6);
-  const hotMats = [colors.hotStarA, colors.hotStarB, colors.hotStarC].map((c) => new THREE.MeshBasicMaterial({ color: threeColor(c) }));
-  const hotStars = new THREE.InstancedMesh(hotGeom, hotMats[0], 160);
+  const hotColorList = [colors.hotStarA, colors.hotStarB, colors.hotStarC];
+  const hotMesh = new THREE.InstancedMesh(hotGeom, new THREE.MeshBasicMaterial({ color: 0xffffff }), 160);
   for (let i = 0; i < 160; i++) {
-    const r = 45000 + rand() * 110000;
+    const r = 30000 + rand() * 150000;
     const theta = rand() * Math.PI * 2;
     const phi = Math.acos(2 * rand() - 1);
     starDummy.position.set(r * Math.sin(phi) * Math.cos(theta), r * Math.cos(phi), r * Math.sin(phi) * Math.sin(theta));
-    const s = 3 + rand() * 10;
-    starDummy.scale.set(s, s, s);
+    starDummy.scale.set(3 + rand() * 10, 3 + rand() * 10, 3 + rand() * 10);
+    hotMesh.setColorAt(i, new THREE.Color(threeColor(hotColorList[i % 3])));
     starDummy.updateMatrix();
-    hotStars.setMatrixAt(i, starDummy.matrix);
-    hotStars.setColorAt(i, new THREE.Color([colors.hotStarA, colors.hotStarB, colors.hotStarC][i % 3]));
+    hotMesh.setMatrixAt(i, starDummy.matrix);
   }
-  hotStars.instanceMatrix.needsUpdate = true;
-  if (hotStars.instanceColor) hotStars.instanceColor.needsUpdate = true;
-  scene.add(hotStars);
+  hotMesh.instanceMatrix.needsUpdate = true;
+  if (hotMesh.instanceColor) hotMesh.instanceColor.needsUpdate = true;
+  scene.add(hotMesh);
 
-  // ================= NEBULA — atmosferik depth (§2 ATMOSPHERIC) =================
+  // =================== NEBULA — dua lapis atmosferik (§2.2 ATMOSPHERIC) =====
   const nebulaTex = makeGlowTexture();
-  const nebulaColors = ["#1b2a5a", "#3a1b5a", "#0e3a2a"];
-  for (let i = 0; i < 9; i++) {
-    const mat = new THREE.SpriteMaterial({
-      map: nebulaTex,
-      color: nebulaColors[i % nebulaColors.length],
-      transparent: true,
-      opacity: 0.04 + rand() * 0.05,
-      blending: THREE.AdditiveBlending,
-      depthWrite: false,
-    });
-    const spr = new THREE.Sprite(mat);
-    const r = 60000 + rand() * 60000;
-    const theta = rand() * Math.PI * 2;
-    const phi = Math.acos(2 * rand() - 1);
-    spr.position.set(r * Math.sin(phi) * Math.cos(theta), r * Math.cos(phi) * 0.4, r * Math.sin(phi) * Math.sin(theta));
-    const sc = 10000 + rand() * 18000;
-    spr.scale.set(sc, sc, 1);
-    scene.add(spr);
-  }
+  const nebulaSprites: THREE.Sprite[] = [];
+  const buildNebula = (count: number): void => {
+    for (const sp of nebulaSprites) { scene.remove(sp); (sp.material as THREE.SpriteMaterial).map?.dispose(); }
+    nebulaSprites.length = 0;
+    const palette = ["#1b2a5a", "#3a1b5a", "#0e3a2a", "#5a1b3a", "#1a3a5a"];
+    for (let i = 0; i < count; i++) {
+      const mat = new THREE.SpriteMaterial({
+        map: nebulaTex,
+        color: palette[i % palette.length],
+        transparent: true,
+        opacity: 0.04 + rand() * 0.06,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      });
+      const spr = new THREE.Sprite(mat);
+      const r = 20000 + rand() * 90000;
+      const theta = rand() * Math.PI * 2;
+      const phi = Math.acos(2 * rand() - 1);
+      spr.position.set(r * Math.sin(phi) * Math.cos(theta), r * Math.cos(phi) * 0.5 + 500, r * Math.sin(phi) * Math.sin(theta));
+      const sc = 12000 + rand() * 26000;
+      spr.scale.set(sc, sc * 0.8, 1);
+      scene.add(spr);
+      nebulaSprites.push(spr);
+    }
+  };
+  buildNebula(9);
 
-  // ================= SUN — sumber energi (02 §2.6, emissive ∝ aktivitas) =================
-  const sunGeom = new THREE.SphereGeometry(900, 48, 48);
-  const sunMat = new THREE.MeshStandardMaterial({
-    color: threeColor(colors.sun),
-    emissive: threeColor(colors.sunEmissive),
-    emissiveIntensity: 2.4,
-  });
-  const sun = new THREE.Mesh(sunGeom, sunMat);
-  sun.position.set(-6000, -400, 9000);
-  scene.add(sun);
-
+  // =================== SUN(S) — binary/trinary §2.1, termal §2.6 ============
+  let starBodies = 1;
+  const suns: {
+    sun: THREE.Mesh;
+    glow: THREE.Sprite;
+    light: THREE.DirectionalLight;
+    orbit: OrbitSpec;
+  }[] = [];
+  const sunGeom = new THREE.SphereGeometry(900, 64, 64);
   const coronaTex = makeGlowTexture();
-  const sunGlow = new THREE.Sprite(new THREE.SpriteMaterial({
-    map: coronaTex, color: threeColor(colors.sunEmissive), transparent: true, opacity: 0.4,
-    blending: THREE.AdditiveBlending, depthWrite: false,
-  }));
-  sunGlow.position.copy(sun.position);
-  sunGlow.scale.set(14000, 14000, 1);
-  scene.add(sunGlow);
 
-  const sunLight = new THREE.DirectionalLight(threeColor(colors.sunCore), 2.2);
-  sunLight.position.copy(sun.position);
-  scene.add(sunLight);
-  scene.add(new THREE.AmbientLight(threeColor(colors.struct), 0.4));
+  const buildSuns = (n: number): void => {
+    for (const s of suns) {
+      scene.remove(s.sun); scene.remove(s.glow); scene.remove(s.light);
+      (s.sun.material as THREE.Material).dispose();
+      (s.glow.material as THREE.SpriteMaterial).map?.dispose();
+    }
+    suns.length = 0;
+    const massRatio = n === 3 ? [0.9, 0.5, 0.7] : n === 2 ? [1.0, 0.55] : [1.0];
+    for (let i = 0; i < n; i++) {
+      const sunMat = new THREE.MeshStandardMaterial({
+        color: threeColor(colors.sun),
+        emissive: threeColor(colors.sunEmissive),
+        emissiveIntensity: 2.4 * massRatio[i],
+      });
+      const sun = new THREE.Mesh(sunGeom, sunMat);
+      scene.add(sun);
+      const glow = new THREE.Sprite(new THREE.SpriteMaterial({
+        map: coronaTex, color: threeColor(colors.sunEmissive), transparent: true, opacity: 0.5 * massRatio[i],
+        blending: THREE.AdditiveBlending, depthWrite: false,
+      }));
+      glow.scale.set(16000 * massRatio[i], 16000 * massRatio[i], 1);
+      scene.add(glow);
+      const light = new THREE.DirectionalLight(threeColor(colors.sunCore), 2.2 * massRatio[i]);
+      scene.add(light);
+      // Companion mengorbit barycenter dekat (binary/trinary, §2.1).
+      const orbit: OrbitSpec = i === 0
+        ? { semimajor: 0, eccentricity: 0, omega: 0, phase: 0, inclination: 0 }
+        : { semimajor: 2600 + i * 900, eccentricity: 0.12, omega: i === 1 ? 0.013 : 0.007, phase: i * 2.1, inclination: 0.3 };
+      suns.push({ sun, glow, light, orbit });
+    }
+  };
+  buildSuns(1);
 
-  // ================= PLANETS — orbit deterministik (§2.3) + termal =================
-  const planets: THREE.Mesh[] = [];
-  const planetSpec = [
-    { a: 9000, e: 0.1, r: 700, color: colors.planetBlue, emissive: "#000000" },
-    { a: 14000, e: 0.2, r: 1000, color: colors.planetVolcanic, emissive: colors.planetVolcanicGlow },
-    { a: 20000, e: 0.05, r: 1200, color: colors.planetGreen, emissive: "#000000" },
-  ];
-  for (const spec of planetSpec) {
-    const mat = new THREE.MeshStandardMaterial({
-      color: threeColor(spec.color),
-      emissive: threeColor(spec.emissive),
-      emissiveIntensity: 1,
-      roughness: 0.85,
-      metalness: 0.05,
-    });
-    const p = new THREE.Mesh(new THREE.SphereGeometry(spec.r, 40, 40), mat);
-    scene.add(p);
-    // atmo glow (atmospheric §2)
-    const atmo = new THREE.Sprite(new THREE.SpriteMaterial({
-      map: coronaTex, color: threeColor(spec.color), transparent: true, opacity: 0.18,
-      blending: THREE.AdditiveBlending, depthWrite: false,
-    }));
-    atmo.scale.set(spec.r * 3.4, spec.r * 3.4, 1);
-    p.add(atmo);
-    planets.push(p);
+  const ambient = new THREE.AmbientLight(threeColor(colors.struct), 0.5);
+  scene.add(ambient);
+
+  // =================== PLANETS + MOONS + RINGS (§2.1/§2.3) ==================
+  interface Planet3D {
+    mesh: THREE.Mesh;
+    atmo: THREE.Sprite;
+    atmoMat: THREE.SpriteMaterial;
+    emissiveBase: number;
+    orbit: OrbitSpec;
+    radius: number;
+    spec: PlanetSpec;
+    ring?: THREE.Mesh;
+    moons: { mesh: THREE.Mesh; orbit: OrbitSpec }[];
+    baseColor: THREE.Color;
   }
-  // Planet orbit radii (skala system)
-  const orbitRadii = [9000, 14000, 20000];
+  const planets: Planet3D[] = [];
+  const planetCache: { geom: THREE.SphereGeometry; mat: THREE.MeshStandardMaterial }[] = [];
 
-  // ================= ASTEROID BELT (COLLIDABLE visual §2.1) =================
-  const beltCount = 5000;
+  let planetCount = 9;
+
+  const buildPlanetSystem = (count: number, detail: number): void => {
+    for (const p of planets) {
+      scene.remove(p.mesh); scene.remove(p.atmo); if (p.ring) scene.remove(p.ring);
+      for (const m of p.moons) scene.remove(m.mesh);
+      (p.mesh.material as THREE.Material).dispose();
+      if (p.ring) (p.ring.material as THREE.Material).dispose();
+      for (const m of p.moons) (m.mesh.material as THREE.Material).dispose();
+    }
+    planets.length = 0;
+    planetCache.length = 0;
+
+    const radii = [1800, 1450, 1100, 900, 780, 640, 520, 420, 320];
+    for (let i = 0; i < count; i++) {
+      const spec = PLANET_CATALOG[i % PLANET_CATALOG.length];
+      const radius = radii[Math.min(i, radii.length - 1) - (i >= count ? count - 1 : 0)];
+      const seg = Math.max(16, detail);
+      const geom = new THREE.SphereGeometry(radius, seg, seg);
+      const mat = new THREE.MeshStandardMaterial({
+        color: threeColor(spec.baseColor),
+        emissive: threeColor(spec.emissive),
+        emissiveIntensity: spec.kind === "volcanic" ? 1.1 : 0.15,
+        roughness: spec.roughness,
+        metalness: spec.metalness,
+      });
+      planetCache.push({ geom, mat });
+      const mesh = new THREE.Mesh(geom, mat);
+      scene.add(mesh);
+
+      // Atmosfer (ATMOSPHERIC §2.2) — rim glow
+      const atmoMat = new THREE.SpriteMaterial({
+        map: coronaTex, color: threeColor(spec.baseColor), transparent: true, opacity: 0.16,
+        blending: THREE.AdditiveBlending, depthWrite: false,
+      });
+      const atmo = new THREE.Sprite(atmoMat);
+      atmo.scale.set(radius * 3.6, radius * 3.6, 1);
+      mesh.add(atmo);
+
+      // Ring (hanya gas giant ringed)
+      let ring: THREE.Mesh | undefined;
+      if (spec.hasRing) {
+        const ringMat = new THREE.MeshStandardMaterial({
+          color: threeColor("#8a7a6a"), emissive: threeColor("#2a1a0a"), emissiveIntensity: 0.35,
+          side: THREE.DoubleSide, roughness: 0.9, transparent: true, opacity: 0.85,
+        });
+        const ringGeom = new THREE.RingGeometry(radius * 1.6, radius * 2.6, 96);
+        ring = new THREE.Mesh(ringGeom, ringMat);
+        ring.rotation.x = -Math.PI / 2 + 0.12;
+        mesh.add(ring);
+      }
+
+      // Moons (§2.3) — mengorbit planet, fase lunar dari geometri
+      const moons: Planet3D["moons"] = [];
+      for (let m = 0; m < spec.moons; m++) {
+        const moonMesh = new THREE.Mesh(
+          new THREE.SphereGeometry(radius * 0.18, 16, 16),
+          new THREE.MeshStandardMaterial({ color: threeColor(colors.struct), roughness: 1, metalness: 0.1 })
+        );
+        scene.add(moonMesh);
+        moons.push({
+          mesh: moonMesh,
+          orbit: { semimajor: radius * (2.4 + m * 0.9), eccentricity: 0.03, omega: 0.09 + m * 0.04, phase: m * 1.7, inclination: 0.4 },
+        });
+      }
+
+      planets.push({
+        mesh,
+        atmo,
+        atmoMat,
+        emissiveBase: mat.emissiveIntensity,
+        orbit: {
+          semimajor: 9000 + i * 5200,
+          eccentricity: [0.08, 0.16, 0.05, 0.2, 0.1, 0.06, 0.12, 0.09, 0.04][i % 9],
+          omega: [0.12, 0.08, 0.06, 0.045, 0.035, 0.026, 0.02, 0.014, 0.011][i % 9],
+          phase: i * 0.9,
+          inclination: (i % 3) * 0.06 - 0.06,
+        },
+        radius,
+        spec,
+        ring,
+        moons,
+        baseColor: new THREE.Color(threeColor(spec.baseColor)),
+      });
+    }
+  };
+  buildPlanetSystem(planetCount, 48);
+
+  // =================== ASTEROID BELT (COLLIDABLE visual §2.1/§2.2) ==========
   const beltDummy = new THREE.Object3D();
   const beltGeom = new THREE.DodecahedronGeometry(14, 0);
   const beltMat = new THREE.MeshStandardMaterial({ color: threeColor(colors.belt), roughness: 1, metalness: 0.12 });
-  const belt = new THREE.InstancedMesh(beltGeom, beltMat, beltCount);
-  for (let i = 0; i < beltCount; i++) {
-    const r = 26000 + rand() * 8000;
-    const angle = rand() * Math.PI * 2;
-    beltDummy.position.set(r * Math.cos(angle), (rand() - 0.5) * 1600, r * Math.sin(angle));
-    const s = 4 + rand() * 22;
-    beltDummy.scale.set(s, s, s);
-    beltDummy.rotation.set(rand() * 3, rand() * 3, rand() * 3);
-    beltDummy.updateMatrix();
-    belt.setMatrixAt(i, beltDummy.matrix);
-  }
-  belt.instanceMatrix.needsUpdate = true;
-  belt.rotation.x = 1.1;
-  scene.add(belt);
+  let beltCount = 6000;
+  let belt: THREE.InstancedMesh | null = null;
+  const buildBelt = (count: number): void => {
+    if (belt) { scene.remove(belt); (belt.material as THREE.Material).dispose(); }
+    belt = new THREE.InstancedMesh(beltGeom, beltMat, count);
+    for (let i = 0; i < count; i++) {
+      const r = 26000 + rand() * 8000;
+      const angle = rand() * Math.PI * 2;
+      beltDummy.position.set(r * Math.cos(angle), (rand() - 0.5) * 1600, r * Math.sin(angle));
+      const s = 4 + rand() * 20;
+      beltDummy.scale.set(s, s, s);
+      beltDummy.rotation.set(rand() * 3, rand() * 3, rand() * 3);
+      beltDummy.updateMatrix();
+      belt.setMatrixAt(i, beltDummy.matrix);
+    }
+    belt.instanceMatrix.needsUpdate = true;
+    belt.rotation.x = 1.1;
+    scene.add(belt);
+  };
+  buildBelt(beltCount);
 
-  // ================= ARK-LIBRARIESCHIP — vessel-world struktur (06 §18.5, 01 §15) ======
-  // Skala 0,0 mid-scene, contoh permanen yang menampung sejarah. Struktur:
-  // spar + hull + ring katedral (distrik) + spire pusat (central slot) + docking beacons.
-  const ark = buildArkLibrary(); // returns position set at origin
+  // =================== BACKDROP PLANETS (§2.2) — sense of scale =============
+  const backdrops: { mesh: THREE.Mesh; orbit: OrbitSpec; drift: number }[] = [];
+  const buildBackdrops = (): void => {
+    for (const b of backdrops) { scene.remove(b.mesh); (b.mesh.material as THREE.Material).dispose(); }
+    backdrops.length = 0;
+    for (let i = 0; i < 6; i++) {
+      const mat = new THREE.MeshBasicMaterial({
+        color: threeColor(colors.backdropPlanet), transparent: true, opacity: 0.35,
+      });
+      const mesh = new THREE.Mesh(new THREE.SphereGeometry(18000 + rand() * 22000, 24, 24), mat);
+      mesh.position.set(
+        (rand() - 0.5) * 400000,
+        (rand() - 0.5) * 120000,
+        -180000 - rand() * 300000
+      );
+      scene.add(mesh);
+      backdrops.push({ mesh, orbit: { semimajor: 380000 * (1 + i * 0.15), eccentricity: 0.02, omega: 0.0018 + i * 0.0003, phase: i * 1.3, inclination: 0.05 }, drift: 0 });
+    }
+  };
+  buildBackdrops();
+
+  // =================== COSMIC EVENTS (§2.4) — meteor / flare / aurora =======
+  const meteors: { line: THREE.Line; start: THREE.Vector3; v: THREE.Vector3; life: number; ttl: number }[] = [];
+  const meteorMat = new THREE.LineBasicMaterial({ color: threeColor(colors.meteorTrail), transparent: true, opacity: 0.9 });
+  const auroraMat = new THREE.SpriteMaterial({
+    map: nebulaTex, color: threeColor(colors.auroraA), transparent: true, opacity: 0.14,
+    blending: THREE.AdditiveBlending, depthWrite: false,
+  });
+  const auroraSpr = new THREE.Sprite(auroraMat);
+  auroraSpr.scale.set(90000, 26000, 1);
+  auroraSpr.position.set(-20000, 22000, -40000);
+  scene.add(auroraSpr);
+  const auroraMatB = new THREE.SpriteMaterial({
+    map: nebulaTex, color: threeColor(colors.auroraB), transparent: true, opacity: 0.1,
+    blending: THREE.AdditiveBlending, depthWrite: false,
+  });
+  const auroraSprB = new THREE.Sprite(auroraMatB);
+  auroraSprB.scale.set(70000, 20000, 1);
+  auroraSprB.position.set(22000, 24000, -46000);
+  scene.add(auroraSprB);
+
+  const spawnMeteor = (): void => {
+    if (meteors.length > 60) return;
+    const g = new THREE.BufferGeometry();
+    g.setAttribute("position", new THREE.BufferAttribute(new Float32Array(6), 3));
+    const line = new THREE.Line(g, meteorMat);
+    const start = new THREE.Vector3(
+      (rand() - 0.5) * 80000, 8000 + rand() * 20000, -(rand() + 1) * 60000
+    );
+    const v = new THREE.Vector3(1200 + rand() * 2000, -(200 + rand() * 600), 2600 + rand() * 3000);
+    scene.add(line);
+    meteors.push({ line, start, v, life: 0, ttl: 1.2 + rand() * 1.8 });
+    updateMeteorPos(line, start, v, 0);
+  };
+  const updateMeteorPos = (line: THREE.Line, start: THREE.Vector3, v: THREE.Vector3, t: number): void => {
+    const attr = line.geometry.attributes.position as THREE.BufferAttribute;
+    attr.setXYZ(0, start.x + v.x * t, start.y + v.y * t, start.z + v.z * t);
+    attr.setXYZ(1, start.x + v.x * (t + 0.16), start.y + v.y * (t + 0.16), start.z + v.z * (t + 0.16));
+    attr.needsUpdate = true;
+  };
+
+  // =================== ARK-LIBRARIESCHIP (§18.5) — tetap ada =================
+  const ark = buildArkLibrary();
+  ark.group.position.set(-32000, -2000, 3000);
   scene.add(ark.group);
 
-  // ================= Local grid — referensi skala lokal (§2.5) =================
-  const grid = new THREE.GridHelper(12000, 120, threeColor(colors.structHigh), threeColor(colors.struct));
-  grid.position.y = -1600;
-  scene.add(grid);
-
-  // ================= Entities (vessel/station) =================
+  // =================== ENTITIES (LOCAL scale §2.5) ===========================
   const vessels = new Map<string, THREE.Group>();
   const stations = new Map<string, THREE.Group>();
-  const pointGlow = makeGlowTexture();
+  // Interpolasi antar snapshot (D-008 presentation only)
+  const prev = new Map<string, THREE.Vector3>();
+  const cur = new Map<string, THREE.Vector3>();
+  let anchor = new THREE.Vector3(0, 0, 0);
+  const LOCAL_SCALE = 1 / 90000; // local meters → render units (§2.5)
+  const clampLocal = (v: THREE.Vector3, a: THREE.Vector3): THREE.Vector3 =>
+    v.clone().sub(a).multiplyScalar(LOCAL_SCALE).clampLength(0, 6000);
 
   const buildVessel = (v: VesselEntity): THREE.Group => {
     const g = new THREE.Group();
     const hull = new THREE.Mesh(
-      new THREE.ConeGeometry(18, 52, 10),
+      new THREE.ConeGeometry(20, 60, 10),
       new THREE.MeshStandardMaterial({ color: threeColor(colors.hull), metalness: 0.7, roughness: 0.35, emissive: threeColor("#0a1424"), emissiveIntensity: 0.5 })
     );
     const wing = new THREE.Mesh(
-      new THREE.BoxGeometry(54, 3, 14),
+      new THREE.BoxGeometry(60, 3, 15),
       new THREE.MeshStandardMaterial({ color: threeColor(colors.hullHigh), metalness: 0.6, roughness: 0.45 })
     );
     wing.position.y = 2;
     const canard = new THREE.Mesh(
-      new THREE.BoxGeometry(12, 2, 30),
+      new THREE.BoxGeometry(13, 2, 34),
       new THREE.MeshStandardMaterial({ color: threeColor(colors.hullHigh), metalness: 0.6, roughness: 0.5 })
     );
     const eng = new THREE.Sprite(new THREE.SpriteMaterial({
-      map: pointGlow, color: threeColor(colors.glowEngine), transparent: true, opacity: 0.95,
+      map: makeGlowTexture(), color: threeColor(colors.glowEngine), transparent: true, opacity: 0.95,
       blending: THREE.AdditiveBlending, depthWrite: false,
     }));
-    eng.position.set(0, 0, 30);
-    eng.scale.set(20, 20, 1);
+    eng.position.set(0, 0, 34);
+    eng.scale.set(22, 22, 1);
     const shield = new THREE.Sprite(new THREE.SpriteMaterial({
-      map: pointGlow, color: threeColor(colors.glowShield), transparent: true, opacity: 0.4,
+      map: makeGlowTexture(), color: threeColor(colors.glowShield), transparent: true, opacity: 0.4,
       blending: THREE.AdditiveBlending, depthWrite: false,
     }));
-    shield.scale.set(34, 34, 1);
+    shield.scale.set(40, 40, 1);
     g.add(hull, wing, canard, eng, shield);
     return g;
   };
@@ -238,24 +489,24 @@ export function initScene3D(container?: HTMLElement): Scene3D {
   const buildStation = (s: StationEntity): THREE.Group => {
     const g = new THREE.Group();
     const hub = new THREE.Mesh(
-      new THREE.IcosahedronGeometry(70, 1),
+      new THREE.IcosahedronGeometry(80, 1),
       new THREE.MeshStandardMaterial({ color: threeColor(colors.stationHub), metalness: 0.6, roughness: 0.4, emissive: threeColor("#0a1a2a"), emissiveIntensity: 0.7 })
     );
     const ring = new THREE.Mesh(
-      new THREE.TorusGeometry(170, 18, 14, 64),
+      new THREE.TorusGeometry(190, 20, 14, 64),
       new THREE.MeshStandardMaterial({ color: threeColor(colors.stationRing), metalness: 0.65, roughness: 0.4 })
     );
     ring.rotation.x = 1.5;
     const beacon = new THREE.Sprite(new THREE.SpriteMaterial({
-      map: pointGlow, color: threeColor(colors.glowStation), transparent: true, opacity: 0.85,
+      map: makeGlowTexture(), color: threeColor(colors.glowStation), transparent: true, opacity: 0.85,
       blending: THREE.AdditiveBlending, depthWrite: false,
     }));
-    beacon.scale.set(140, 140, 1);
+    beacon.scale.set(160, 160, 1);
     g.add(hub, ring, beacon);
     return g;
   };
 
-  const ensureEntry = (id: string, build: () => THREE.Group, map: Map<string, THREE.Group>) => {
+  const ensureEntry = (id: string, build: () => THREE.Group, map: Map<string, THREE.Group>): THREE.Group => {
     let grp = map.get(id);
     if (grp) return grp;
     grp = build();
@@ -267,83 +518,244 @@ export function initScene3D(container?: HTMLElement): Scene3D {
 
   const updateVessel = (v: VesselEntity): void => {
     const grp = ensureEntry(v.id, () => buildVessel(v), vessels);
-    grp.position.set(v.position.x, v.position.y, v.position.z);
+    const p = clampLocal(new THREE.Vector3(v.position.x, v.position.y, v.position.z), anchor);
+    cur.set(v.id, p);
+    if (!prev.has(v.id)) prev.set(v.id, p.clone());
     grp.rotation.set(v.heading.pitch, v.heading.yaw, 0);
   };
 
   let lastTick = 0;
+  let firstVesselRef: VesselEntity | undefined;
+  let lastSnapshotAt = performance.now();
+
   const renderRegion = (region: RegionState): void => {
     lastTick = region.tick;
-    // Orbit planet deterministik dari tick (§2.3) — cinematic only, bukan otoritas.
-    const t = region.tick * 0.001;
-    for (let i = 0; i < planets.length; i++) {
-      const p = planets[i];
-      const th = t * [0.1, 0.05, 0.03][i];
-      const yOff = [-200, 600, -400][i];
-      p.position.set(orbitRadii[i] * Math.cos(th), yOff, orbitRadii[i] * 1.15 * Math.sin(th));
-    }
+    lastSnapshotAt = performance.now();
+    // Rotasi prev←cur: nilai lama jadi starting point interpolasi.
+    prev.clear();
+    for (const [id, p] of cur) prev.set(id, p.clone());
+    cur.clear();
 
-    const live = new Set<string>();
-    let firstVessel: VesselEntity | undefined;
+    firstVesselRef = undefined;
     for (const e of region.entities.values()) {
-      live.add(e.id);
       if (e.kind === "vessel") {
         const ve = e as VesselEntity;
-        updateVessel(ve);
-        if (!firstVessel) firstVessel = ve;
-      } else if (e.kind === "station") {
-        ensureEntry(e.id, () => buildStation(e as StationEntity), stations);
-        const grp = stations.get(e.id)!;
-        grp.position.set(e.position.x, e.position.y, e.position.z);
+        if (!firstVesselRef) { firstVesselRef = ve; anchor.set(ve.position.x, ve.position.y, ve.position.z); }
       }
     }
-    for (const [id, grp] of vessels) if (!live.has(id)) { scene.remove(grp); disposeGroup(grp); vessels.delete(id); }
-    for (const [id, grp] of stations) if (!live.has(id)) { scene.remove(grp); disposeGroup(grp); stations.delete(id); }
-
-    // Follow-camera (§21): ease di belakang vessel utama — rasa "pilot".
-    // Kalau tak ada vessel, biarkan kamera free di posisi awal.
-    if (firstVessel) {
-      const p = firstVessel.position;
-      const yaw = firstVessel.heading.yaw;
-      const offset = 950;
-      const camTargetX = p.x - Math.sin(yaw) * offset;
-      const camTargetZ = p.z - Math.cos(yaw) * offset;
-      const camTargetY = p.y + 420;
-      camera.position.x += (camTargetX - camera.position.x) * 0.06;
-      camera.position.y += (camTargetY - camera.position.y) * 0.04;
-      camera.position.z += (camTargetZ - camera.position.z) * 0.06;
-      camera.lookAt(p.x, p.y + 60, p.z);
+    // Pass kedua — anchor final.
+    for (const e of region.entities.values()) {
+      if (e.kind === "vessel") updateVessel(e as VesselEntity);
+      else {
+        const se = e as StationEntity;
+        const grp = ensureEntry(se.id, () => buildStation(se), stations);
+        const p = clampLocal(new THREE.Vector3(se.position.x, se.position.y, se.position.z), anchor);
+        grp.position.copy(p);
+      }
     }
-
-    renderer.render(scene, camera);
+    // Bersihkan entity yang mati.
+    const live = new Set<string>();
+    for (const e of region.entities.values()) live.add(e.id);
+    for (const [id, grp] of vessels) if (!live.has(id)) { scene.remove(grp); disposeGroup(grp); vessels.delete(id); prev.delete(id); cur.delete(id); }
+    for (const [id, grp] of stations) if (!live.has(id)) { scene.remove(grp); disposeGroup(grp); stations.delete(id); }
   };
 
-  const onResize = () => {
+  // =================== CAMERA MODES (§21) ====================================
+  let lookYaw = 0, lookPitch = 0;
+  const setLookYawPitch = (yaw: number, pitch: number): void => {
+    lookYaw = yaw; lookPitch = Math.max(-1.2, Math.min(1.2, pitch));
+  };
+  const setCameraMode = (mode: CameraMode): void => { camMode = mode; };
+
+  const updateCamera = (t: number): void => {
+    const target = firstVesselRef;
+    const p = new THREE.Vector3(0, 0, 0);
+    if (target) p.copy(clampLocal(new THREE.Vector3(target.position.x, target.position.y, target.position.z), anchor));
+    let d = 0.06;
+    if (camMode === "cinematic") {
+      // §21 cinematic — sweeping, dramatic angle, membidik system.
+      const r = 4200 + Math.sin(t * 0.00002) * 1400;
+      camera.position.x = Math.sin(t * 0.00012) * r;
+      camera.position.z = Math.cos(t * 0.00012) * r;
+      camera.position.y = 2400 + Math.sin(t * 0.00006) * 600;
+      camera.lookAt(0, 0, 0);
+      return;
+    }
+    if (camMode === "tactical") {
+      // §21 tactical — overview battlefield dari atas.
+      const r = 1600;
+      camera.position.x = p.x + Math.sin(t * 0.00004) * r;
+      camera.position.z = p.z + Math.cos(t * 0.00004) * r;
+      camera.position.y = p.y + 2600;
+      camera.lookAt(p.x, p.y, p.z);
+      return;
+    }
+    // follow & free: pilot perspective
+    if (camMode === "follow" && target) {
+      const yaw = target.heading.yaw + lookYaw;
+      const pitch = lookPitch;
+      const offset = 1300;
+      const cosP = Math.cos(pitch);
+      const cx = p.x - Math.sin(yaw) * offset * cosP;
+      const cz = p.z - Math.cos(yaw) * offset * cosP;
+      const cy = p.y + Math.sin(pitch) * offset + 420;
+      camera.position.x += (cx - camera.position.x) * d;
+      camera.position.y += (cy - camera.position.y) * d * 0.7;
+      camera.position.z += (cz - camera.position.z) * d;
+      camera.lookAt(p.x, p.y + 80, p.z);
+    } else {
+      // free
+      const yaw = lookYaw, pitch = lookPitch;
+      const radius = 5200;
+      camera.position.x = p.x + radius * Math.sin(yaw) * Math.cos(pitch);
+      camera.position.y = p.y + radius * Math.sin(pitch);
+      camera.position.z = p.z + radius * Math.cos(yaw) * Math.cos(pitch);
+      camera.lookAt(p.x, p.y, p.z);
+    }
+  };
+
+  // =================== QUALITY (settings → scene live) =======================
+  let settingsRef: GameSettings;
+  const applyQuality = (s: GameSettings): void => {
+    settingsRef = s;
+    renderer.setPixelRatio(effPixelRatio(s, DPR));
+    renderer.setSize(width, height);
+    composer.setSize(width, height);
+    bloomPass.resolution.set(width * s.resolutionScale, height * s.resolutionScale);
+    const bloomEnabled = s.bloom !== "off";
+    bloomPass.enabled = bloomEnabled;
+    bloomPass.strength = s.bloom === "high" ? 1.2 : 0.65;
+    if (s.toneMapping === "AGX") renderer.toneMapping = THREE.AgXToneMapping;
+    else if (s.toneMapping === "REINHARD") renderer.toneMapping = THREE.ReinhardToneMapping;
+    else renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    // Density & detail rebuild
+    if (s.nebulaDensity !== nebulaSprites.length) buildNebula(Math.min(12, s.nebulaDensity));
+    if (s.starBodies !== starBodies) { starBodies = s.starBodies; buildSuns(Math.max(1, Math.min(3, starBodies))); }
+    if (s.planetCount !== planetCount) { planetCount = s.planetCount; buildPlanetSystem(planetCount, s.planetDetail); }
+    if (s.beltDensity !== beltCount) { beltCount = s.beltDensity; buildBelt(beltCount); }
+  };
+
+  // =================== RENDER LOOP (rAF, sim terpisah → §22/§24) =============
+  let running = false;
+  let rafId = 0;
+  let lastFrame = 0;
+
+  // §2.3 Orbit deterministik per tick — smooth di sub-tick via TIME_BASE.
+  const simTick = (): number => lastTick + (performance.now() - lastSnapshotAt) / 100;
+
+  const frame = (now: number): void => {
+    rafId = requestAnimationFrame(frame);
+    const t = now; // ms — dipakai kamera cinematic
+    const cap = settingsRef.fpsCap;
+    if (cap) {
+      const elapsed = now - lastFrame;
+      if (elapsed < 1000 / cap) { updateCamera(t); return; } // throttle ke cap (camera tetap hidup)
+    }
+    lastFrame = now;
+
+    // §2.3/§2.5: sistem bintang & planet—deterministik, mengorbit barycenter.
+    const tick = simTick();
+    for (let i = 1; i < suns.length; i++) {
+      const p = keplerPosition(suns[i].orbit, tick);
+      suns[i].sun.position.copy(p);
+      suns[i].glow.position.copy(p);
+      suns[i].light.position.copy(p);
+    }
+    for (const pl of planets) {
+      const p = keplerPosition(pl.orbit, tick);
+      pl.mesh.position.copy(p);
+      pl.atmo.position.copy(p);
+      if (pl.ring) pl.ring.position.copy(p);
+      for (const mo of pl.moons) {
+        const mp = keplerPosition(mo.orbit, tick);
+        mo.mesh.position.set(p.x + mp.x, p.y + mp.y, p.z + mp.z);
+        // §2.3 fase lunar dari geometri (arah relatif ke matahari)
+        const mdir = mo.mesh.position.clone().sub(p).normalize();
+        const sdir = suns[0].sun.position.clone().sub(p).normalize();
+        (mo.mesh.material as THREE.MeshStandardMaterial).emissiveIntensity = 0.4 + 0.6 * Math.max(0, mdir.dot(sdir));
+      }
+    }
+
+    // §2.6 Termal: emissive planet ∝ 1/(1+r²) relatif matahari.
+    for (const pl of planets) {
+      const d = pl.mesh.position.distanceTo(suns[0].sun.position);
+      const r = Math.max(1, d / 5000);
+      const thermal = Math.min(1.5, pl.emissiveBase + 1.2 / (r * r));
+      (pl.mesh.material as THREE.MeshStandardMaterial).emissiveIntensity = thermal;
+    }
+    // Meteor shower (§2.4) — spawning bursty & bergerak (peak saat "hujan").
+    const burst = Math.sin(t * 0.0007) > 0.985 || Math.cos(t * 0.0009) > 0.995 ? 4 : 1;
+    for (let i = 0; i < burst; i++) spawnMeteor();
+    for (const m of meteors.slice()) {
+      m.life += 1 / 60;
+      m.ttl -= 1 / 60;
+      updateMeteorPos(m.line, m.start, m.v, m.life);
+      if (m.ttl <= 0) {
+        scene.remove(m.line);
+        m.line.geometry.dispose();
+        meteors.splice(meteors.indexOf(m), 1);
+      }
+    }
+    // Aurora — denyut halus (§2.4)
+    auroraSpr.material.opacity = 0.1 + 0.06 * Math.sin(t * 0.0002);
+    auroraSprB.material.opacity = 0.07 + 0.05 * Math.cos(t * 0.00025);
+
+    // Interpolasi vessel (presentation ✓, autoritas server tetap D-008).
+    const alpha = Math.min(1, (now - lastSnapshotAt) / 100);
+    for (const [id, grp] of vessels) {
+      const a = prev.get(id); const b = cur.get(id);
+      if (a && b) grp.position.lerpVectors(a, b, alpha);
+    }
+
+    updateCamera(t);
+    composer.render();
+  };
+
+  // Snapshot timing (biar interp akurat)
+  renderer.setPixelRatio(Math.min(DPR, 2));
+  const stopLoop = (): void => cancelAnimationFrame(rafId);
+
+  const onResize = (): void => {
     const w = target?.clientWidth ?? width;
     const h = target?.clientHeight ?? height;
     camera.aspect = w / h;
     camera.updateProjectionMatrix();
     renderer.setSize(w, h);
+    composer.setSize(w, h);
   };
   if (typeof window !== "undefined") window.addEventListener("resize", onResize);
 
-  const dispose = () => {
+  const dispose = (): void => {
     if (typeof window !== "undefined") window.removeEventListener("resize", onResize);
+    stopLoop();
+    running = false;
     renderer.dispose();
+    composer.dispose();
     for (const m of vessels.values()) disposeGroup(m);
     for (const m of stations.values()) disposeGroup(m);
     vessels.clear(); stations.clear();
-    disposeIfaces({ scene, starGeom, starMat, hotGeom, hotMats, beltGeom, beltMat, sunGeom, sunMat });
+    for (const pl of planets) {
+      scene.remove(pl.mesh); scene.remove(pl.atmo); if (pl.ring) scene.remove(pl.ring);
+      for (const mo of pl.moons) scene.remove(mo.mesh);
+    }
+    for (const b of backdrops) scene.remove(b.mesh);
+    for (const m of meteors) scene.remove(m.line);
     if (target && renderer.domElement.parentElement === target) target.removeChild(renderer.domElement);
   };
 
-  renderer.render(scene, camera);
-  return { renderRegion, updateVessel, dispose };
+  // Start rAF
+  running = true;
+  if (settings) applyQuality(settings);
+  else settingsRef = { preset: "ULTRA", fpsCap: 0, resolutionScale: 1, pixelRatio: 2, antialias: true, bloom: "high", shadowQuality: "high", nebulaDensity: 12, starBodies: 3, planetCount: 9, planetDetail: 48, beltDensity: 8000, vesselDetail: 3, toneMapping: "ACES" } as GameSettings;
+  lastFrame = performance.now();
+  lastSnapshotAt = lastFrame;
+  rafId = requestAnimationFrame(frame);
+
+  return { renderRegion, updateVessel, setCameraMode, applyQuality, setLookYawPitch, dispose };
 }
 
 // ---------------------------------------------------------------------------
-// ARK-LIBRARIESCHIP — struktur vessel-world (blueprint §15/§18.5).
-// Konstruksi murni procedural dengan material PBR dari tokens; no external asset.
+// ARK-LIBRARIESCHIP (§18.5) — struktur vessel-world procedural.
 // ---------------------------------------------------------------------------
 function buildArkLibrary(): { group: THREE.Group } {
   const g = new THREE.Group();
@@ -352,23 +764,19 @@ function buildArkLibrary(): { group: THREE.Group } {
   const amber = new THREE.MeshStandardMaterial({ color: threeColor(colors.tactical), emissive: threeColor(colors.tactical), emissiveIntensity: 1.4 });
   const tech = new THREE.MeshStandardMaterial({ color: threeColor(colors.tech), emissive: threeColor(colors.tech), emissiveIntensity: 1.2 });
 
-  // Main keel — long-nacelle (bow → stern)
   const keel = new THREE.Mesh(new THREE.CylinderGeometry(320, 380, 4200, 48), steel);
   keel.rotation.z = Math.PI / 2;
   g.add(keel);
 
-  // Bow prow — tapered pylon
   const prow = new THREE.Mesh(new THREE.ConeGeometry(200, 1100, 40), steelHigh);
   prow.rotation.z = -Math.PI / 2;
   prow.position.x = 2400;
   g.add(prow);
 
-  // Stern bulb — reactor/thrust housing
   const stern = new THREE.Mesh(new THREE.SphereGeometry(360, 40, 40), steel);
   stern.position.x = -2300;
   g.add(stern);
 
-  // Central spire — the Library heart (sentral slot / katedral-bibliotek)
   const spire = new THREE.Mesh(new THREE.CylinderGeometry(90, 220, 1100, 36), steelHigh);
   spire.position.y = 700;
   g.add(spire);
@@ -376,13 +784,11 @@ function buildArkLibrary(): { group: THREE.Group } {
   spireCap.position.y = 1380;
   g.add(spireCap);
 
-  // Jumlah ring-distrik: 4 katedral rings (menampung distrik/history)
   for (let i = 0; i < 4; i++) {
     const ring = new THREE.Mesh(new THREE.TorusGeometry(640 + i * 40, 26, 16, 72), i === 1 ? amber : steelHigh);
     ring.rotation.x = 1.2 + i * 0.08;
     ring.position.x = -400 + i * 500;
     g.add(ring);
-    // ring glow (distrik aktif — history)
     const ringGlow = new THREE.Sprite(new THREE.SpriteMaterial({
       map: makeGlowTexture(), color: threeColor(i === 2 ? colors.glowStation : colors.glowEngine),
       transparent: true, opacity: 0.35, blending: THREE.AdditiveBlending, depthWrite: false,
@@ -391,33 +797,12 @@ function buildArkLibrary(): { group: THREE.Group } {
     ringGlow.scale.set(300, 300, 1);
     g.add(ringGlow);
   }
-
-  // Basilica struts — cross spars (distrik menempel ke keel)
   for (let i = 0; i < 6; i++) {
     const spar = new THREE.Mesh(new THREE.BoxGeometry(140, 30, 1200), steelHigh);
     spar.position.x = -1000 + i * 400;
     spar.rotation.y = Math.PI / 2;
     g.add(spar);
   }
-
-  // Landing/observation balconies — fraksi docking beacons (timur/west)
-  const balL = new THREE.Mesh(new THREE.CylinderGeometry(70, 70, 40, 24), tech);
-  balL.position.set(-700, 0, 760);
-  g.add(balL);
-  const balR = new THREE.Mesh(new THREE.CylinderGeometry(70, 70, 40, 24), tech);
-  balR.position.set(-700, 0, -760);
-  g.add(balR);
-
-  // Dorsal coms pylons
-  for (const x of [-1200, 0, 1200]) {
-    const pylon = new THREE.Mesh(new THREE.ConeGeometry(40, 260, 8), steelHigh);
-    pylon.position.set(x, 360, 0);
-    g.add(pylon);
-    const tip = new THREE.Mesh(new THREE.SphereGeometry(30, 12, 12), amber);
-    tip.position.set(x, 490, 0);
-    g.add(tip);
-  }
-
   return { group: g };
 }
 
@@ -448,22 +833,4 @@ function disposeGroup(g: THREE.Group): void {
       else m.dispose();
     }
   });
-}
-
-function disposeIfaces(o: Record<string, unknown>): void {
-  for (const k of Object.keys(o)) {
-    const v = (o as Record<string, unknown>)[k];
-    if (v instanceof THREE.BufferGeometry) (v as THREE.BufferGeometry).dispose();
-    else if (v instanceof THREE.Material) (v as THREE.Material).dispose();
-    else if (v instanceof THREE.Scene) {
-      v.traverse((child) => {
-        const m = child as THREE.Mesh;
-        if (m.geometry) m.geometry.dispose();
-        if (m.material) {
-          if (Array.isArray(m.material)) m.material.forEach((mm) => mm.dispose());
-          else (m.material as THREE.Material).dispose();
-        }
-      });
-    }
-  }
 }

--- a/apps/game/src/renderer/settings.ts
+++ b/apps/game/src/renderer/settings.ts
@@ -1,0 +1,224 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+// Engine (apps/web, packages/engine, etc.) remains Apache-2.0 (LICENSE-ENGINE).
+//
+// src/renderer/settings.ts — graphig settings engine (blueprint 01 §22 LOD,
+// §28 command-interface). Desktop MMORPG tiers: LOW/MEDIUM/HIGH/ULTRA/CINEMATIC.
+// FPS cap 30-240/∞; render resolution scale; bloom; nebula/star/planet density.
+// Persist ke localStorage per region session (D-008: visual hanya client-side,
+// authoritative tetap server).
+
+export type QualityPreset = "LOW" | "MEDIUM" | "HIGH" | "ULTRA" | "CINEMATIC";
+export type FpsCap = 30 | 60 | 90 | 120 | 240 | 0; // 0 = uncapped
+export type BloomQuality = "off" | "low" | "high";
+
+export interface GameSettings {
+  preset: QualityPreset;
+  fpsCap: FpsCap;
+  resolutionScale: number; // 0.5..2.0
+  pixelRatio: number; // 1 | 2 | 3 (kap per-DPR)
+  antialias: boolean;
+  bloom: BloomQuality;
+  shadowQuality: "off" | "low" | "medium" | "high";
+  nebulaDensity: number; // 0..12
+  starBodies: number; // 0..3 (binary/trinary)
+  planetCount: number; // 6..12
+  planetDetail: number; // 16..96 (segments)
+  beltDensity: number; // 0..10000 asteroids
+  vesselDetail: number; // 1..3 (LOD §22)
+  toneMapping: "ACES" | "AGX" | "REINHARD";
+
+  // Audio (audio.ts konsumen)
+  masterVolume: number; // 0..1
+  sfxVolume: number;
+  musicVolume: number;
+  muted: boolean;
+
+  // Controls (§6)
+  keyForward: string;
+  keyReverse: string;
+  keyStrafeLeft: string;
+  keyStrafeRight: string;
+  keyUp: string;
+  keyDown: string;
+  keyBoost: string;
+  keyBrake: string;
+  keyLook: string; // "mouse" | "pointer-lock"
+  invertLookY: boolean;
+  lookSensitivity: number; // 0.1..2.0
+}
+
+const DEFAULT_KEY = {
+  forward: "KeyW",
+  reverse: "KeyS",
+  strafeLeft: "KeyA",
+  strafeRight: "KeyD",
+  up: "KeyQ",
+  down: "KeyE",
+  boost: "ShiftLeft",
+  brake: "Space",
+  look: "mouse",
+} as const;
+
+export function defaultSettings(): GameSettings {
+  return {
+    preset: "ULTRA",
+    fpsCap: 120,
+    resolutionScale: 1,
+    pixelRatio: 2,
+    antialias: true,
+    bloom: "high",
+    shadowQuality: "high",
+    nebulaDensity: 12,
+    starBodies: 3,
+    planetCount: 12,
+    planetDetail: 48,
+    beltDensity: 8000,
+    vesselDetail: 3,
+    toneMapping: "ACES",
+
+    masterVolume: 0.85,
+    sfxVolume: 0.7,
+    musicVolume: 0.5,
+    muted: false,
+
+    keyForward: DEFAULT_KEY.forward,
+    keyReverse: DEFAULT_KEY.reverse,
+    keyStrafeLeft: DEFAULT_KEY.strafeLeft,
+    keyStrafeRight: DEFAULT_KEY.strafeRight,
+    keyUp: DEFAULT_KEY.up,
+    keyDown: DEFAULT_KEY.down,
+    keyBoost: DEFAULT_KEY.boost,
+    keyBrake: DEFAULT_KEY.brake,
+    keyLook: DEFAULT_KEY.look,
+    invertLookY: false,
+    lookSensitivity: 0.6,
+  };
+}
+
+const PRESETS: Record<QualityPreset, () => Partial<GameSettings>> = {
+  // Mobile-ish fallback tidak disediakan: ARCLUX desktop MMORPG (§28).
+  // LOW = netbook/iGPU sekelas, bukan cellphone.
+  LOW: () => ({
+    fpsCap: 60,
+    resolutionScale: 0.6,
+    pixelRatio: 1,
+    antialias: false,
+    bloom: "off",
+    shadowQuality: "off",
+    nebulaDensity: 3,
+    starBodies: 1,
+    planetCount: 6,
+    planetDetail: 16,
+    beltDensity: 2000,
+    vesselDetail: 1,
+    toneMapping: "REINHARD",
+  }),
+  MEDIUM: () => ({
+    fpsCap: 60,
+    resolutionScale: 0.75,
+    pixelRatio: 1,
+    antialias: true,
+    bloom: "low",
+    shadowQuality: "low",
+    nebulaDensity: 6,
+    starBodies: 2,
+    planetCount: 8,
+    planetDetail: 24,
+    beltDensity: 4000,
+    vesselDetail: 2,
+    toneMapping: "ACES",
+  }),
+  HIGH: () => ({
+    fpsCap: 120,
+    resolutionScale: 1,
+    pixelRatio: 2,
+    antialias: true,
+    bloom: "high",
+    shadowQuality: "medium",
+    nebulaDensity: 9,
+    starBodies: 3,
+    planetCount: 10,
+    planetDetail: 32,
+    beltDensity: 6000,
+    vesselDetail: 3,
+    toneMapping: "ACES",
+  }),
+  ULTRA: () => ({
+    ...defaultSettings(),
+  }),
+  CINEMATIC: () => ({
+    fpsCap: 240,
+    resolutionScale: 1.5,
+    pixelRatio: 3,
+    antialias: true,
+    bloom: "high",
+    shadowQuality: "high",
+    nebulaDensity: 12,
+    starBodies: 3,
+    planetCount: 12,
+    planetDetail: 64,
+    beltDensity: 10000,
+    vesselDetail: 3,
+    toneMapping: "AGX",
+  }),
+};
+
+const STORAGE_KEY = "arclux.game.settings.v1";
+
+export function loadSettings(): GameSettings {
+  const base = defaultSettings();
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    if (!raw) return base;
+    const parsed = JSON.parse(raw) as Partial<GameSettings>;
+    return { ...base, ...parsed };
+  } catch {
+    return base;
+  }
+}
+
+export function saveSettings(s: GameSettings): void {
+  try {
+    if (typeof localStorage !== "undefined") localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+  } catch {}
+}
+
+export function applyPreset(preset: QualityPreset): GameSettings {
+  const fresh = defaultSettings();
+  const p = PRESETS[preset];
+  if (!p) return fresh;
+  const merged = { ...fresh, ...p() };
+  // Preset tidak menyentuh audio & controls (kategori terpisah).
+  const cur = loadSettings();
+  merged.masterVolume = cur.masterVolume;
+  merged.sfxVolume = cur.sfxVolume;
+  merged.musicVolume = cur.musicVolume;
+  merged.muted = cur.muted;
+  merged.keyForward = cur.keyForward;
+  merged.keyReverse = cur.keyReverse;
+  merged.keyStrafeLeft = cur.keyStrafeLeft;
+  merged.keyStrafeRight = cur.keyStrafeRight;
+  merged.keyUp = cur.keyUp;
+  merged.keyDown = cur.keyDown;
+  merged.keyBoost = cur.keyBoost;
+  merged.keyBrake = cur.keyBrake;
+  merged.keyLook = cur.keyLook;
+  merged.invertLookY = cur.invertLookY;
+  merged.lookSensitivity = cur.lookSensitivity;
+  merged.preset = preset;
+  return merged;
+}
+
+export function updateSettings(patch: Partial<GameSettings>): GameSettings {
+  const next = { ...loadSettings(), ...patch };
+  saveSettings(next);
+  return next;
+}
+
+export function effPixelRatio(s: GameSettings, dpr: number): number {
+  const cap = s.pixelRatio;
+  return Math.min(Math.max(cap, 1), Math.min(dpr, 3));
+}

--- a/apps/game/src/ui/tokens.ts
+++ b/apps/game/src/ui/tokens.ts
@@ -68,6 +68,22 @@ export const colors = {
   stationHub: "#335a7a",
   stationRing: "#2b4a66",
 
+  // Sistem bintang kaya (blueprint 01 §2.1/§2.2/§2.6) — bagian dari Scene3D.
+  // Termal ∝ 1/r² (§2.6): emissive planet naik saat dekat matahari.
+  planetGasGiant: "#caa06a",     // gas giant — sabuk awan amber
+  planetGasGiantBelt: "#e8c896", // lapisan awan terang
+  ringInner: "#8a7a6a",          // cincin padat (ring system)
+  ringOuter: "#5a4f45",          // cincin luar redup
+  planetIce: "#a8d8e8",          // es — reflektif dingin
+  planetOcean: "#2a4a8a",        // oceanik — air biru
+  planetDesert: "#c9a05a",       // desert — pasir
+  planetLava: "#5a1a0a",         // lava — kena termal
+  lavaGlow: "#ff5a1a",
+  backdropPlanet: "#4a4a5a",     // BACKDROP §2.2 — planet super-jauh, depth
+  auroraA: "#5affb0",            // aurora (ATMOSPHERIC §2.4)
+  auroraB: "#52c8ff",
+  meteorTrail: "#fff2dd",        // meteor shower §2.4
+
   // Glow (scene — additive)
   glowEngine: "#4cc9ff",
   glowShield: "#3aa0ff",


### PR DESCRIPTION
## What
Client-side cosmic render layer per blueprint 01 §2. Full star system with deterministic Kepler orbits, binary/trinary stars, planet variety (gas giant/ring/ice/ocean/desert/volcanic), moons with lunar phase, asteroid belt, backdrop planets for depth, 2-layer nebula, aurora, meteor showers.

Bloom post-processing (EffectComposer + UnrealBloomPass + OutputPass from three.js). rAF render loop with FPS cap from settings + snapshot interpolation (D-008: presentation only, server still authoritative).

**settings.ts** — GPU tier presets LOW/MED/HIGH/ULTRA/CINEMATIC, FPS 30-240/∞, nebula/belt/star/planet density, localStorage persist.

**audio.ts** — WebAudio: engine hum ∝ vessel speed, UI sfx, ambient pad, master/sfx/music volume, mute.

**menu.ts** — ESC menu + sidebar (GRAPHICS / AUDIO / CONTROLS tabs). DOM API + textContent only (ThreatCrush XSS-safe). Controls rebind + sensitivity + invert-Y.

**input.ts** — §6 controls rewrite: W/S forward/reverse, A/D strafe, Q/E vertical, Shift boost, **Space brake** (was Space=up — fixed), pointer-lock mouse look, rebinds from settings.

thermal emissive ∝ 1/r² (§2.6) · Camera modes §21 (follow/tactical/cinematic/free) · LOD §22 via settings segments.

---

Related: #624