### PR TITLE
feat(game): Fase 1 env map reflection — PMREMGenerator scene.environm…

### DIFF
--- a/apps/game/src/renderer/scene3d.ts
+++ b/apps/game/src/renderer/scene3d.ts
@@ -133,6 +133,15 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
   const outputPass = new OutputPass(); // menangani tone mapping di akhir
   composer.addPass(outputPass);
 
+  // =================== ENV MAP (Fase 1 — PMREMGenerator) ====================
+  // Kapal memantulkan cahaya suns/planets/nebula via PBR envMap.
+  // Regen tiap 10 frame (PMREM mahal, jangan tiap frame). scene.environment
+  // auto-apply ke semua MeshStandardMaterial tanpa set envMap manual.
+  const pmrem = new THREE.PMREMGenerator(renderer);
+  pmrem.compileEquirectangularShader();
+  let pmremTarget: THREE.WebGLRenderTarget | null = null;
+  let envFrame = 0;
+
   const rand = mulberry32(nebulaSeed);
 
   // =================== STARFIELD (FAR §22, instanced) =======================
@@ -653,6 +662,13 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
     }
     lastFrame = now;
 
+    // Fase 1 — env map regen tiap 10 frame (presentasi, bukan otoritas).
+    if (++envFrame % 10 === 0) {
+      if (pmremTarget) pmremTarget.dispose();
+      pmremTarget = pmrem.fromScene(scene, 0.04);
+      scene.environment = pmremTarget.texture;
+    }
+
     // §2.3/§2.5: sistem bintang & planet—deterministik, mengorbit barycenter.
     const tick = simTick();
     for (let i = 1; i < suns.length; i++) {
@@ -729,6 +745,9 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
     if (typeof window !== "undefined") window.removeEventListener("resize", onResize);
     stopLoop();
     running = false;
+    if (pmremTarget) { pmremTarget.dispose(); pmremTarget = null; }
+    pmrem.dispose();
+    scene.environment = null;
     renderer.dispose();
     composer.dispose();
     for (const m of vessels.values()) disposeGroup(m);

--- a/docs/blueprint/09-client-polish.md
+++ b/docs/blueprint/09-client-polish.md
@@ -49,7 +49,7 @@ Konteks dari pemilik (GSF-001):
 
 # FASE 1 — ENVIRONMENT MAP REFLECTION (PMREMGenerator)
 
-## Status: ⬜ Belum mulai
+## Status: ✅ Selesai (commit implementasi Fase 1 — scene3d.ts pmrem)
 
 ## Tujuan
 Ships jadi memantulkan cahaya dari celestial bodies (suns, planets, nebula)
@@ -77,9 +77,9 @@ if (frameCount % 10 === 0) {
 ```
 
 ## Acceptance
-- [ ] Ship hull memantulkan warna sun/planet saat berputar
-- [ ] Metalness 0.7 + envMap tetap performa (regenerate tiap 10 frame)
-- [ ] Gak ngerusak bloom composer
+- [x] Ship hull memantulkan warna sun/planet saat berputar (`scene.environment` PMREM)
+- [x] Metalness 0.7 + envMap tetap performa (regenerate tiap 10 frame, dispose target lama)
+- [x] Gak ngerusak bloom composer (`EffectComposer` tetap)
 
 ---
 
@@ -984,10 +984,10 @@ function buildStadiumFromConfig(cfg: StadiumConfig): THREE.Group {
 
 # EXECUTION CHECKLIST (per fase — centang saat selesai)
 
-## Fase 1 — Env map
-- [ ] pmrem generator dibuat
-- [ ] scene.environment di-set tiap 10 frame
-- [ ] Verify build + tsc
+## Fase 1 — Env map ✅
+- [x] pmrem generator dibuat (`PMREMGenerator` + `compileEquirectangularShader`)
+- [x] scene.environment di-set tiap 10 frame (`pmrem.fromScene(scene,0.04)` + dispose target lama)
+- [x] Verify build + tsc (`build-game.mjs` ✓, `tsc -p apps/game` ✓, ThreatCrush 0)
 
 ## Fase 2 — Ship model
 - [ ] buildVessel() detail baru


### PR DESCRIPTION
…ent tiap 10 frame (scene3d.ts) + centang blueprint 09

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
