### PR TITLE
feat(graph): two-pass call resolver — port ManSio PR #20

### DIFF
--- a/packages/graph/buildCallGraph.ts
+++ b/packages/graph/buildCallGraph.ts
@@ -19,13 +19,13 @@ import type { DependencyGraph, GraphNode, GraphEdge } from "../shared/types";
  * call site.
  *
  * The raw material is ModuleInfo.calls (ResolvedCall[]), populated by
- * buildIndex.ts pass 3: each bare-identifier call site in the source is
- * matched against the module's named imports to find the module that
- * exports the callee. Two known limitations inherited from that pass (see
- * extractJs.ts's extractCallsJs doc comment for the full rationale):
- *   1. Calls of default-imported functions are never resolved — RawImport
- *      stores no local name for default imports, so there is no name to
- *      match the callee against.
+ * buildIndex.ts pass 3 via the two-pass resolver (packages/graph/
+ * resolveCalls.ts — import-verified, unique-global, explicit-unresolved;
+ * never silent-picks, never silent-drops). Two known limitations inherited
+ * from extraction (see extractJs.ts's extractCallsJs doc comment):
+ *   1. Calls of default-imported functions resolve via
+ *      RawImport.defaultLocalName, verified against the target's default
+ *      export — the old total blind spot is closed.
  *   2. `obj.foo()` / `this.foo()` are never captured at all — the parser
  *      layer is AST-only (no type checker), and those callees are property
  *      accesses, not identifiers.

--- a/packages/graph/resolveCalls.ts
+++ b/packages/graph/resolveCalls.ts
@@ -1,0 +1,169 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { builtinModules } from "node:module";
+import type {
+  RawCall,
+  ResolvedCall,
+  UnresolvedCall,
+} from "../shared/types";
+
+/**
+ * Two-pass call resolver — TypeScript port of ManSio/mscodebase-intelligence
+ * PR #20 (`GraphSymbolResolver`, `src/core/search/graph_resolver.py`).
+ *
+ * Concept ports cleanly; the stdlib question is answered the TS way (see
+ * isExternalOrStdlib): Node HAS the equivalent of Python's
+ * `sys.stdlib_module_names` — `node:module`.builtinModules — plus
+ * module resolution (internal vs `node_modules`) instead of a stdlib set.
+ *
+ * Ladder (first match wins, mirrors ManSio 3.1 → 3.4):
+ *   3.1 import — callee bound by an explicit import of the caller AND the
+ *       target verified to export it (fixes G5: old code never verified).
+ *       Ambiguous bindings (2+ verified modules) are REFUSED, never
+ *       last-write-wins (fixes G1) → unresolved "ambiguous" + candidates.
+ *       Default-import calls resolve via defaultLocalName when the target
+ *       has a default export (fixes G2).
+ *   3.2 unique-global — callee exported by exactly one repo module, no
+ *       import needed. Confidence 0.85. Ambiguous globals fall through
+ *       (mirrors ManSio: only len==1 resolves).
+ *   3.3 external — callee bound to an external import whose package is
+ *       recognized (node builtin or seen bare specifier). Recorded as
+ *       unresolved "external" + packageName. NO graph node is created
+ *       (deviation from ManSio's DEPENDENCY nodes, documented below).
+ *   3.4 fallback — explicit unresolved "unknown". Nothing is ever dropped
+ *       silently (fixes G4).
+ *
+ * Deviation note: ManSio creates `{proj}.dependency.{name}` DEPENDENCY
+ * nodes for externals. ARCLUX call graphs are file-node-only and consumed
+ * by buildCallGraph.ts, MCP file_info, and the web graph — all of which
+ * assume nodes are repo modules. External calls are therefore recorded
+ * (evidence preserved) but not materialized as nodes. Phase 2 may add
+ * "external-package" nodes (GraphNodeType already exists) after auditing
+ * those consumers.
+ */
+
+/** One internal import binding of the calling module (resolvePath internal). */
+export interface ImportBinding {
+  moduleId: string;
+  namedImports: string[];
+  defaultLocalName?: string;
+}
+
+/** One external import binding (resolvePath external — bare specifier). */
+export interface ExternalBinding {
+  packageName: string;
+  namedImports: string[];
+  defaultLocalName?: string;
+}
+
+export interface ResolverInput {
+  rawCalls: RawCall[];
+  /** Internal imports of the caller (resolvePath type internal). */
+  internalImports: ImportBinding[];
+  /** External imports of the caller (resolvePath type external). */
+  externalImports: ExternalBinding[];
+  /** moduleId -> exported names (named + re-export names as listed). */
+  exportMap: Map<string, Set<string>>;
+  /** moduleId -> has a default export. */
+  hasDefaultExport: Map<string, boolean>;
+  /** exported name -> moduleIds exporting it (named only, whole repo). */
+  globalNameMap: Map<string, string[]>;
+  /**
+   * Bare package names seen anywhere in the repo (self-consistent external
+   * registry: a bare specifier imported anywhere counts as known — the
+   * loose TS equivalent of ManSio's find_spec fallback).
+   */
+  knownDependencies: Set<string>;
+}
+
+export interface ResolverOutput {
+  resolved: ResolvedCall[];
+  unresolved: UnresolvedCall[];
+}
+
+const NODE_BUILTINS = new Set<string>(
+  builtinModules.flatMap((m) => (m.startsWith("node:") ? [m, m.slice(5)] : [m, `node:${m}`])),
+);
+
+/**
+ * TS answer to ManSio's is_external_or_stdlib: node builtins (the
+ * interpreter-maintained set — no manual drift list) plus the repo's own
+ * bare-specifier registry. Scoped packages compare on `@scope/name`.
+ */
+export function isExternalOrStdlib(packageName: string, knownDependencies: Set<string>): boolean {
+  if (!packageName) return false;
+  const top = packageName.startsWith("@")
+    ? packageName.split("/").slice(0, 2).join("/")
+    : packageName.split("/")[0];
+  const bare = top.startsWith("node:") ? top.slice(5) : top;
+  if (NODE_BUILTINS.has(top) || NODE_BUILTINS.has(bare)) return true;
+  if (knownDependencies.has(top) || knownDependencies.has(bare)) return true;
+  return false;
+}
+
+function exportsName(
+  exportMap: Map<string, Set<string>>,
+  hasDefaultExport: Map<string, boolean>,
+  moduleId: string,
+  calleeName: string,
+  viaDefault: boolean,
+): boolean {
+  if (viaDefault) return hasDefaultExport.get(moduleId) === true;
+  return exportMap.get(moduleId)?.has(calleeName) === true;
+}
+
+export function resolveModuleCalls(input: ResolverInput): ResolverOutput {
+  const resolved: ResolvedCall[] = [];
+  const unresolved: UnresolvedCall[] = [];
+
+  for (const rawCall of input.rawCalls) {
+    const callee = rawCall.calleeName;
+
+    // 3.1 import — collect ALL verified candidates before deciding.
+    const candidates: string[] = [];
+    for (const binding of input.internalImports) {
+      const viaDefault =
+        binding.defaultLocalName !== undefined && binding.defaultLocalName === callee;
+      const viaNamed = binding.namedImports.includes(callee);
+      if (!viaDefault && !viaNamed) continue;
+      if (exportsName(input.exportMap, input.hasDefaultExport, binding.moduleId, callee, viaDefault)) {
+        if (!candidates.includes(binding.moduleId)) candidates.push(binding.moduleId);
+      }
+    }
+    if (candidates.length === 1) {
+      resolved.push({ moduleId: candidates[0], calleeName: callee, line: rawCall.line, confidence: 1.0, resolver: "import" });
+      continue;
+    }
+    if (candidates.length > 1) {
+      unresolved.push({ calleeName: callee, line: rawCall.line, reason: "ambiguous", candidates });
+      continue;
+    }
+
+    // 3.2 unique-global — exactly one repo module exports this name.
+    const globals = input.globalNameMap.get(callee) ?? [];
+    if (globals.length === 1) {
+      resolved.push({ moduleId: globals[0], calleeName: callee, line: rawCall.line, confidence: 0.85, resolver: "unique-global" });
+      continue;
+    }
+
+    // 3.3 external — callee bound to an external import.
+    const externalHit = input.externalImports.find(
+      (b) => b.namedImports.includes(callee) || b.defaultLocalName === callee,
+    );
+    if (externalHit && isExternalOrStdlib(externalHit.packageName, input.knownDependencies)) {
+      unresolved.push({ calleeName: callee, line: rawCall.line, reason: "external", packageName: externalHit.packageName });
+      continue;
+    }
+
+    // 3.4 fallback — explicit unknown. Never silent.
+    unresolved.push({ calleeName: callee, line: rawCall.line, reason: "unknown" });
+  }
+
+  return { resolved, unresolved };
+}

--- a/packages/indexer/buildIndex.ts
+++ b/packages/indexer/buildIndex.ts
@@ -9,6 +9,7 @@
 import { scanFiles } from "../parser/core/scanFiles";
 import { parserRegistry } from "../parser/core/ParserRegistry";
 import { resolvePath } from "../graph/resolvePath";
+import { resolveModuleCalls } from "../graph/resolveCalls";
 import { loadAliasConfig } from "../graph/resolveAliases";
 import { resolveSameScopeDependencies, type ScopedFile } from "./resolveSameScopeDependencies";
 import { Repository } from "../repository/Repository";
@@ -19,7 +20,7 @@ import {
   setDiskCachedParsedFile,
 } from "../cache/diskCache";
 import { ArcluxError } from "../shared/errors";
-import type { RepositoryMeta, ModuleInfo, ParsedFile, ResolvedImport, ResolvedCall } from "../shared/types";
+import type { RepositoryMeta, ModuleInfo, ParsedFile, RawImport, ResolvedImport, ResolvedCall } from "../shared/types";
 
 export interface BuildIndexOptions {
   rootPath: string;
@@ -120,53 +121,91 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
   const implicitDepsByPath = resolveSameScopeDependencies(scopedFiles);
 
   // Pass 3: build ModuleInfo with resolved import ids (but importedBy not filled yet)
+  // Call resolution runs through the two-pass resolver
+  // (packages/graph/resolveCalls.ts — port of ManSio PR #20):
+  // 3.1 verified import (incl. default-local) → 3.2 unique global →
+  // 3.3 recognized external → 3.4 explicit unresolved. Ambiguous bindings
+  // are refused, never last-write-wins; nothing drops silently.
   const modulesByPath = new Map<string, ModuleInfo>();
-  for (const [relativePath, parsed] of parsedByPath) {
-    const resolvedImportIds: string[] = [];
-    const resolvedImports: ResolvedImport[] = [];
-    // callee name -> moduleId for every named import of this module. Used
-    // below to resolve bare call sites (extractCallsJs output) to the
-    // module that exports the callee. Last write wins if the same name is
-    // imported from two modules — that source is a duplicate-identifier
-    // error anyway, so there is no correct answer to prefer.
-    const namedImportToModule = new Map<string, string>();
 
+  // Pre-pass: resolve every raw import once (internal vs external) so the
+  // resolver below sees both sides; externals used to vanish here.
+  interface BoundImport {
+    internal?: { moduleId: string; namedImports: string[]; defaultLocalName?: string };
+    external?: { packageName: string; namedImports: string[]; defaultLocalName?: string };
+    raw: RawImport;
+  }
+  const boundByPath = new Map<string, BoundImport[]>();
+  const knownDependencies = new Set<string>();
+  for (const [relativePath, parsed] of parsedByPath) {
+    const bound: BoundImport[] = [];
     for (const rawImport of parsed.imports) {
       const resolution = resolvePath(relativePath, rawImport.source, knownFiles, aliasConfig);
       if (resolution.type === "internal") {
-        resolvedImportIds.push(resolution.moduleId);
-        resolvedImports.push({
-          moduleId: resolution.moduleId,
-          kind: rawImport.kind,
-          namedImports: rawImport.namedImports,
-          hasDefaultImport: rawImport.hasDefaultImport,
-          hasNamespaceImport: rawImport.hasNamespaceImport,
-          line: rawImport.line,
+        bound.push({
+          internal: { moduleId: resolution.moduleId, namedImports: rawImport.namedImports, defaultLocalName: rawImport.defaultLocalName },
+          raw: rawImport,
         });
-        for (const name of rawImport.namedImports) {
-          namedImportToModule.set(name, resolution.moduleId);
-        }
+      } else {
+        knownDependencies.add(resolution.packageName);
+        bound.push({
+          external: { packageName: resolution.packageName, namedImports: rawImport.namedImports, defaultLocalName: rawImport.defaultLocalName },
+          raw: rawImport,
+        });
       }
-      // external packages intentionally not added as modules — they're graph nodes, not repo modules
+    }
+    boundByPath.set(relativePath, bound);
+  }
+
+  // Repo-wide export maps for rungs 3.1 (verify) and 3.2 (unique global).
+  const exportMap = new Map<string, Set<string>>();
+  const hasDefaultExport = new Map<string, boolean>();
+  const globalNameMap = new Map<string, string[]>();
+  for (const [relativePath, parsed] of parsedByPath) {
+    const names = new Set<string>();
+    let hasDefault = false;
+    for (const exp of parsed.exports) {
+      if (exp.kind === "default") hasDefault = true;
+      else {
+        names.add(exp.name);
+        const list = globalNameMap.get(exp.name) ?? [];
+        if (!list.includes(relativePath)) list.push(relativePath);
+        globalNameMap.set(exp.name, list);
+      }
+    }
+    exportMap.set(relativePath, names);
+    hasDefaultExport.set(relativePath, hasDefault);
+  }
+
+  for (const [relativePath, parsed] of parsedByPath) {
+    const resolvedImportIds: string[] = [];
+    const resolvedImports: ResolvedImport[] = [];
+    const bound = boundByPath.get(relativePath) ?? [];
+
+    for (const b of bound) {
+      if (!b.internal) continue; // external packages intentionally not added as modules — they're graph nodes, not repo modules
+      resolvedImportIds.push(b.internal.moduleId);
+      resolvedImports.push({
+        moduleId: b.internal.moduleId,
+        kind: b.raw.kind,
+        namedImports: b.raw.namedImports,
+        hasDefaultImport: b.raw.hasDefaultImport,
+        hasNamespaceImport: b.raw.hasNamespaceImport,
+        line: b.raw.line,
+      });
     }
 
-    // Resolve bare call sites to the module exporting the callee. A call
-    // whose callee is not among the module's named imports (a local
-    // function, a default-imported function, or a global) is dropped here
-    // on purpose — see extractJs.ts's extractCallsJs doc comment for the
-    // two by-design limitations (default-import calls and
-    // obj.foo()/this.foo() calls are never resolved).
-    const resolvedCalls: ResolvedCall[] = [];
-    for (const rawCall of parsed.calls ?? []) {
-      const targetModuleId = namedImportToModule.get(rawCall.calleeName);
-      if (targetModuleId) {
-        resolvedCalls.push({
-          moduleId: targetModuleId,
-          calleeName: rawCall.calleeName,
-          line: rawCall.line,
-        });
-      }
-    }
+    // Two-pass call resolution (replaces the old namedImportToModule
+    // last-write-wins map + silent drop).
+    const { resolved: resolvedCalls, unresolved: unresolvedCalls } = resolveModuleCalls({
+      rawCalls: parsed.calls ?? [],
+      internalImports: bound.flatMap((b) => (b.internal ? [b.internal] : [])),
+      externalImports: bound.flatMap((b) => (b.external ? [b.external] : [])),
+      exportMap,
+      hasDefaultExport,
+      globalNameMap,
+      knownDependencies,
+    });
 
     const resolvedReExports: Record<string, string> = {};
     for (const exp of parsed.exports) {
@@ -186,6 +225,7 @@ export async function buildIndex(options: BuildIndexOptions): Promise<Repository
       imports: resolvedImportIds,
       resolvedImports,
       calls: resolvedCalls,
+      unresolvedCalls,
       importedBy: [], // filled in pass 4
       calledBy: [], // filled in pass 4
       implicitDependencies: implicitDepsByPath.get(relativePath) ?? [],

--- a/packages/parser/javascript/extractJs.ts
+++ b/packages/parser/javascript/extractJs.ts
@@ -30,11 +30,15 @@ export function extractImportsJs(sourceFile: ts.SourceFile): RawImport[] {
     if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
       const namedImports: string[] = [];
       let hasDefaultImport = false;
+      let defaultLocalName: string | undefined;
       let hasNamespaceImport = false;
       const kind: ImportKind = "static";
 
       if (node.importClause) {
-        if (node.importClause.name) hasDefaultImport = true;
+        if (node.importClause.name) {
+          hasDefaultImport = true;
+          defaultLocalName = node.importClause.name.text;
+        }
         const bindings = node.importClause.namedBindings;
         if (bindings && ts.isNamedImports(bindings)) {
           for (const el of bindings.elements) {
@@ -50,6 +54,7 @@ export function extractImportsJs(sourceFile: ts.SourceFile): RawImport[] {
         kind,
         namedImports,
         hasDefaultImport,
+        defaultLocalName,
         hasNamespaceImport,
         line: getLine(sourceFile, node.getStart()),
       });
@@ -317,15 +322,15 @@ export function extractExportsJs(sourceFile: ts.SourceFile): RawExport[] {
  *
  * This is an AST-only pass — no type information is available — so a bare
  * call like `helper()` cannot be attributed to a module here. Attribution
- * happens later in buildIndex.ts pass 3, which matches the callee name
- * against the module's named imports. Two known limitations, both by
- * design (issue #50):
- *   1. Calls of default-imported functions (`import helper from "./h"`
- *      then `helper()`) can never be resolved — RawImport does not capture
- *      a local name for default imports, only hasDefaultImport: true.
- *   2. `obj.foo()` / `this.foo()` can never be resolved — even with type
- *      info this would need a full type-checker pass (method resolution),
- *      which the parser layer deliberately does not run.
+ * happens later in buildIndex.ts pass 3 via the two-pass resolver
+ * (packages/graph/resolveCalls.ts). One known limitation, by design
+ * (issue #50):
+ *   - `obj.foo()` / `this.foo()` can never be resolved — even with type
+ *     info this would need a full type-checker pass (method resolution),
+ *     which the parser layer deliberately does not run.
+ * (The old limitation #1 — default-import calls never resolving — is
+ * closed: RawImport.defaultLocalName feeds the resolver, verified against
+ * the target's default export.)
  */
 export function extractCallsJs(sourceFile: ts.SourceFile): RawCall[] {
   const calls: RawCall[] = [];

--- a/packages/parser/typescript/parseTs.ts
+++ b/packages/parser/typescript/parseTs.ts
@@ -22,11 +22,15 @@ function extractImports(sourceFile: ts.SourceFile): RawImport[] {
     if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
       const namedImports: string[] = [];
       let hasDefaultImport = false;
+      let defaultLocalName: string | undefined;
       let hasNamespaceImport = false;
       let kind: ImportKind = node.importClause?.isTypeOnly ? "type-only" : "static";
 
       if (node.importClause) {
-        if (node.importClause.name) hasDefaultImport = true;
+        if (node.importClause.name) {
+          hasDefaultImport = true;
+          defaultLocalName = node.importClause.name.text;
+        }
         const bindings = node.importClause.namedBindings;
         if (bindings && ts.isNamedImports(bindings)) {
           for (const el of bindings.elements) {
@@ -42,6 +46,7 @@ function extractImports(sourceFile: ts.SourceFile): RawImport[] {
         kind,
         namedImports,
         hasDefaultImport,
+        defaultLocalName,
         hasNamespaceImport,
         line: getLine(sourceFile, node.getStart()),
       });
@@ -182,8 +187,9 @@ function extractExports(sourceFile: ts.SourceFile): RawExport[] {
  * Known limitations (documented, not bugs — AST-only, no type info):
  * - `obj.foo()` / `this.foo()` are PropertyAccessExpressions, not
  *   captured — resolving them needs type information.
- * - Default-imported callees are never resolved downstream because
- *   RawImport has no local name for default imports.
+ * - Default-imported callees resolve via RawImport.defaultLocalName in the
+ *   two-pass resolver (resolveCalls.ts), verified against the target's
+ *   default export — the old "never resolved" gap (G2) is closed.
  * - `require(...)` is excluded — it's an import, not a call edge.
  */
 function extractCalls(sourceFile: ts.SourceFile): RawCall[] {

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -73,6 +73,13 @@ export interface RawImport {
   /** Named imports, e.g. ["useState", "useEffect"]. Empty for default/namespace-only. */
   namedImports: string[];
   hasDefaultImport: boolean;
+  /**
+   * Local name of the default import, e.g. "h" in `import h from "./h"`.
+   * Needed by the two-pass call resolver (resolveCalls.ts) so calls of
+   * default-imported functions resolve instead of dropping silently (G2).
+   * Absent when there is no default import.
+   */
+  defaultLocalName?: string;
   hasNamespaceImport: boolean;
   /** Line number in source file (1-indexed) */
   line: number;
@@ -198,16 +205,50 @@ export interface ResolvedImport {
 /**
  * A RawCall whose callee name matched a named import of the calling module,
  * resolved to the module that exports it. Built by buildIndex.ts pass 3
- * (named import name -> target moduleId). A RawCall whose callee is not
- * among the module's named imports is dropped there (unresolvable — e.g.
- * a local function or a default-imported function) and never reaches the
- * call graph.
+ * via packages/graph/resolveCalls.ts (two-pass resolver, ported from
+ * ManSio/mscodebase-intelligence PR #20 — see resolveCalls.ts for the
+ * strategy ladder). A RawCall that cannot be resolved is NOT dropped
+ * silently anymore: it lands in ModuleInfo.unresolvedCalls with a reason.
  */
 export interface ResolvedCall {
   /** Module id of the module that exports the callee */
   moduleId: string;
   calleeName: string;
   line: number;
+  /**
+   * Resolution confidence (ManSio ladder): 1.0 = matched via an explicit
+   * import of the caller; 0.85 = unique global (exported by exactly one
+   * repo module, no import). Optional so fixtures/tests built before the
+   * two-pass resolver keep compiling — resolver output always sets it.
+   */
+  confidence?: 1.0 | 0.85;
+  /** Which ladder rung resolved this call. Absent on pre-resolver fixtures. */
+  resolver?: "import" | "unique-global";
+}
+
+/**
+ * A call site the two-pass resolver explicitly could NOT resolve — the
+ * anti-silent-drop record (ManSio rule 3.4). Every RawCall ends up either
+ * in `calls` or here; nothing vanishes.
+ */
+export interface UnresolvedCall {
+  calleeName: string;
+  line: number;
+  /**
+   * - "ambiguous": exported/imported by 2+ modules — resolver refuses to
+   *   pick (no last-write-wins). `candidates` lists the module ids.
+   * - "external": callee comes from an external package (node builtin or
+   *   package.json dep). `packageName` set. No graph node is created for
+   *   it (call graph stays file-node-only) — the record is the evidence.
+   * - "unknown": no import, no unique global, not external (local def,
+   *   global, typo, or unsupported syntax like default-import without a
+   *   verifiable default export).
+   */
+  reason: "ambiguous" | "external" | "unknown";
+  /** Candidate module ids (reason "ambiguous" only). */
+  candidates?: string[];
+  /** Package name (reason "external" only). */
+  packageName?: string;
 }
 
 export interface ModuleInfo {
@@ -237,6 +278,14 @@ export interface ModuleInfo {
    * `obj.foo()`/`this.foo()` calls are never resolved.
    */
   calls: ResolvedCall[];
+  /**
+   * Call sites the two-pass resolver explicitly left unresolved (with
+   * reasons) — the anti-silent-drop counterpart to `calls`. Optional (not
+   * REQUIRED like `calls`) so the ~15 test fixtures constructing ModuleInfo
+   * manually keep compiling; buildIndex.ts always populates it. Consumers
+   * treat absent as [].
+   */
+  unresolvedCalls?: UnresolvedCall[];
   /** Module ids that call this module's exported functions — back-filled by buildIndex.ts pass 4, mirrors `importedBy` */
   calledBy: string[];
   /**

--- a/tests/graph-callgraph.test.ts
+++ b/tests/graph-callgraph.test.ts
@@ -278,7 +278,7 @@ describe("buildIndex call resolution", () => {
 
     const a = repository.getModule("a.js");
     const b = repository.getModule("b.js");
-    expect(a?.calls).toEqual([{ moduleId: "b.js", calleeName: "helper", line: 2 }]);
+    expect(a?.calls).toEqual([{ moduleId: "b.js", calleeName: "helper", line: 2, confidence: 1.0, resolver: "import" }]);
     expect(b?.calledBy).toEqual(["a.js"]);
   });
 
@@ -293,7 +293,7 @@ describe("buildIndex call resolution", () => {
 
     const a = repository.getModule("a.ts");
     const b = repository.getModule("b.ts");
-    expect(a?.calls).toEqual([{ moduleId: "b.ts", calleeName: "helper", line: 2 }]);
+    expect(a?.calls).toEqual([{ moduleId: "b.ts", calleeName: "helper", line: 2, confidence: 1.0, resolver: "import" }]);
     expect(b?.calledBy).toEqual(["a.ts"]);
 
     const graph = buildCallGraph(repository);
@@ -313,7 +313,7 @@ describe("buildIndex call resolution", () => {
     const a = repository.getModule("a.tsx");
     // Only the bare helper() on line 5 resolves — the JSX element, the
     // type-only import, and obj.helper() are all non-call sites.
-    expect(a?.calls).toEqual([{ moduleId: "b.ts", calleeName: "helper", line: 5 }]);
+    expect(a?.calls).toEqual([{ moduleId: "b.ts", calleeName: "helper", line: 5, confidence: 1.0, resolver: "import" }]);
   });
 
   it("drops a bare call whose callee is not among the module's named imports", async () => {
@@ -326,7 +326,11 @@ describe("buildIndex call resolution", () => {
     const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
 
     const a = repository.getModule("a.js");
-    expect(a?.calls).toEqual([{ moduleId: "b.js", calleeName: "helper", line: 3 }]);
+    expect(a?.calls).toEqual([{ moduleId: "b.js", calleeName: "helper", line: 3, confidence: 1.0, resolver: "import" }]);
+
+    // missing() at line 2 stays out of the graph, but is RECORDED explicitly
+    // (two-pass resolver never drops silently) — unresolved "unknown".
+    expect(a?.unresolvedCalls).toEqual([{ calleeName: "missing", line: 2, reason: "unknown" }]);
 
     // missing() at line 2 was dropped, so the call graph has one edge
     const graph = buildCallGraph(repository);
@@ -346,7 +350,7 @@ describe("buildIndex call resolution", () => {
     const a = repository.getModule("a.js");
     // require("fs") at line 2 is an import, obj.helper() at line 3 is a
     // property access — only the bare helper() at line 4 resolves.
-    expect(a?.calls).toEqual([{ moduleId: "b.js", calleeName: "helper", line: 4 }]);
+    expect(a?.calls).toEqual([{ moduleId: "b.js", calleeName: "helper", line: 4, confidence: 1.0, resolver: "import" }]);
 
     const graph = buildCallGraph(repository);
     expect(graph.edges).toHaveLength(1);

--- a/tests/graph-resolver.test.ts
+++ b/tests/graph-resolver.test.ts
@@ -1,0 +1,233 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for the two-pass call resolver (packages/graph/resolveCalls.ts) —
+// TypeScript port of ManSio/mscodebase-intelligence PR #20 behavior
+// (tests/test_graph_resolver.py). Ladder: verified import (1.0) ->
+// unique global (0.85) -> recognized external -> explicit unresolved.
+// Core invariant: every RawCall lands in resolved OR unresolved —
+// nothing drops silently.
+
+import { describe, it, expect } from "vitest";
+import {
+  isExternalOrStdlib,
+  resolveModuleCalls,
+  type ResolverInput,
+} from "../packages/graph/resolveCalls";
+
+/** exportMap builder: [["mod.ts", ["a", "b"]]] -> Map<mod, Set<names>> */
+function exp(entries: Array<[string, string[]]>): Map<string, Set<string>> {
+  return new Map(entries.map(([k, v]): [string, Set<string>] => [k, new Set(v)]));
+}
+
+/** globalNameMap builder: [["name", ["a.ts", "b.ts"]]] */
+function glo(entries: Array<[string, string[]]>): Map<string, string[]> {
+  return new Map(entries);
+}
+
+function input(over: Partial<ResolverInput> = {}): ResolverInput {
+  return {
+    rawCalls: [],
+    internalImports: [],
+    externalImports: [],
+    exportMap: new Map(),
+    hasDefaultExport: new Map(),
+    globalNameMap: new Map(),
+    knownDependencies: new Set(),
+    ...over,
+  };
+}
+
+describe("two-pass resolver ladder", () => {
+  it("3.1 import: named import verified against target exports -> 1.0/import", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "targetFunc", line: 42 }],
+        internalImports: [{ moduleId: "target.ts", namedImports: ["targetFunc"] }],
+        exportMap: exp([["target.ts", ["targetFunc"]]]),
+        globalNameMap: glo([["targetFunc", ["target.ts"]]]),
+      }),
+    );
+    expect(out.resolved).toEqual([
+      { moduleId: "target.ts", calleeName: "targetFunc", line: 42, confidence: 1.0, resolver: "import" },
+    ]);
+    expect(out.unresolved).toEqual([]);
+  });
+
+  it("3.2 unique global: no import, single repo exporter -> 0.85/unique-global", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "UniqueService", line: 7 }],
+        exportMap: exp([["unique.ts", ["UniqueService"]]]),
+        globalNameMap: glo([["UniqueService", ["unique.ts"]]]),
+      }),
+    );
+    expect(out.resolved).toEqual([
+      { moduleId: "unique.ts", calleeName: "UniqueService", line: 7, confidence: 0.85, resolver: "unique-global" },
+    ]);
+    expect(out.unresolved).toEqual([]);
+  });
+
+  it("G1: ambiguous import (2 verified modules) -> explicit ambiguous, never last-write-wins", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "helper", line: 3 }],
+        internalImports: [
+          { moduleId: "a.ts", namedImports: ["helper"] },
+          { moduleId: "b.ts", namedImports: ["helper"] },
+        ],
+        exportMap: exp([
+          ["a.ts", ["helper"]],
+          ["b.ts", ["helper"]],
+        ]),
+        globalNameMap: glo([["helper", ["a.ts", "b.ts"]]]),
+      }),
+    );
+    expect(out.resolved).toEqual([]);
+    expect(out.unresolved).toEqual([
+      { calleeName: "helper", line: 3, reason: "ambiguous", candidates: ["a.ts", "b.ts"] },
+    ]);
+  });
+
+  it("ambiguous global without import falls through to unknown (mirrors ManSio: only len==1 resolves)", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "helper", line: 3 }],
+        exportMap: exp([
+          ["a.ts", ["helper"]],
+          ["b.ts", ["helper"]],
+        ]),
+        globalNameMap: glo([["helper", ["a.ts", "b.ts"]]]),
+      }),
+    );
+    expect(out.resolved).toEqual([]);
+    expect(out.unresolved).toEqual([{ calleeName: "helper", line: 3, reason: "unknown" }]);
+  });
+
+  it("3.3 external builtin: import { join } from 'path' -> unresolved external", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "join", line: 5 }],
+        externalImports: [{ packageName: "path", namedImports: ["join"] }],
+        knownDependencies: new Set(),
+      }),
+    );
+    expect(out.resolved).toEqual([]);
+    expect(out.unresolved).toEqual([
+      { calleeName: "join", line: 5, reason: "external", packageName: "path" },
+    ]);
+  });
+
+  it("3.3 external dep: lodash in knownDependencies -> unresolved external + packageName", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "debounce", line: 9 }],
+        externalImports: [{ packageName: "lodash", namedImports: ["debounce"] }],
+        knownDependencies: new Set(["lodash"]),
+      }),
+    );
+    expect(out.unresolved).toEqual([
+      { calleeName: "debounce", line: 9, reason: "external", packageName: "lodash" },
+    ]);
+  });
+
+  it("3.4 fallback: local/typo with no match -> explicit unknown (never silent)", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "localHelper", line: 11 }],
+        exportMap: exp([["other.ts", ["somethingElse"]]]),
+        globalNameMap: glo([["somethingElse", ["other.ts"]]]),
+      }),
+    );
+    expect(out.resolved).toEqual([]);
+    expect(out.unresolved).toEqual([{ calleeName: "localHelper", line: 11, reason: "unknown" }]);
+  });
+
+  it("G2: default import via defaultLocalName + verified default export -> 1.0/import", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "h", line: 4 }],
+        internalImports: [{ moduleId: "h.ts", namedImports: [], defaultLocalName: "h" }],
+        exportMap: exp([["h.ts", []]]),
+        hasDefaultExport: new Map([["h.ts", true]]),
+      }),
+    );
+    expect(out.resolved).toEqual([
+      { moduleId: "h.ts", calleeName: "h", line: 4, confidence: 1.0, resolver: "import" },
+    ]);
+    expect(out.unresolved).toEqual([]);
+  });
+
+  it("default import without a default export in target -> unknown (no blind resolve)", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "h", line: 4 }],
+        internalImports: [{ moduleId: "h.ts", namedImports: [], defaultLocalName: "h" }],
+        exportMap: exp([["h.ts", ["other"]]]),
+        hasDefaultExport: new Map([["h.ts", false]]),
+        globalNameMap: glo([["other", ["h.ts"]]]),
+      }),
+    );
+    expect(out.resolved).toEqual([]);
+    expect(out.unresolved).toEqual([{ calleeName: "h", line: 4, reason: "unknown" }]);
+  });
+
+  it("G5: named import the target does not export -> falls through, never blind-resolves", () => {
+    const out = resolveModuleCalls(
+      input({
+        rawCalls: [{ calleeName: "typoFn", line: 6 }],
+        internalImports: [{ moduleId: "real.ts", namedImports: ["typoFn"] }],
+        exportMap: exp([["real.ts", ["realFn"]]]),
+        globalNameMap: glo([["realFn", ["real.ts"]]]),
+      }),
+    );
+    expect(out.resolved).toEqual([]);
+    expect(out.unresolved).toEqual([{ calleeName: "typoFn", line: 6, reason: "unknown" }]);
+  });
+
+  it("no-silent-drop invariant: resolved + unresolved covers every raw call", () => {
+    const rawCalls = [
+      { calleeName: "a", line: 1 },
+      { calleeName: "b", line: 2 },
+      { calleeName: "c", line: 3 },
+      { calleeName: "d", line: 4 },
+    ];
+    const out = resolveModuleCalls(
+      input({
+        rawCalls,
+        internalImports: [{ moduleId: "a.ts", namedImports: ["a"] }],
+        externalImports: [{ packageName: "fs", namedImports: ["c"] }],
+        exportMap: exp([["a.ts", ["a"]]]),
+        globalNameMap: glo([["a", ["a.ts"]]]),
+        knownDependencies: new Set(),
+      }),
+    );
+    expect(out.resolved.length + out.unresolved.length).toBe(rawCalls.length);
+    expect(out.resolved[0].calleeName).toBe("a");
+    expect(out.unresolved.map((u) => u.calleeName).sort()).toEqual(["b", "c", "d"]);
+  });
+});
+
+describe("isExternalOrStdlib (TS answer to sys.stdlib_module_names)", () => {
+  const deps = new Set(["lodash", "@scope/pkg"]);
+  it("node builtins recognized, bare and node:-prefixed", () => {
+    expect(isExternalOrStdlib("fs", deps)).toBe(true);
+    expect(isExternalOrStdlib("node:path", deps)).toBe(true);
+    expect(isExternalOrStdlib("os", deps)).toBe(true);
+  });
+  it("known deps recognized, scoped packages compare on @scope/name", () => {
+    expect(isExternalOrStdlib("lodash", deps)).toBe(true);
+    expect(isExternalOrStdlib("lodash/debounce", deps)).toBe(true);
+    expect(isExternalOrStdlib("@scope/pkg", deps)).toBe(true);
+    expect(isExternalOrStdlib("@scope/pkg/sub", deps)).toBe(true);
+  });
+  it("unknown bare specifiers rejected; empty rejected", () => {
+    expect(isExternalOrStdlib("my-hypothetical-module", deps)).toBe(false);
+    expect(isExternalOrStdlib("", deps)).toBe(false);
+  });
+});


### PR DESCRIPTION
Port TypeScript dari ManSio/mscodebase-intelligence#20 (GraphSymbolResolver) ke ARCLUX. Ladder: verified import 1.0 (termasuk default-local + verifikasi ekspor target) -> unique-global 0.85 -> external tercatat -> explicit unresolved. Menutup G1 (last-write-wins jadi explicit ambiguous), G2 (default-import resolve), G4 (nothing drops silently — tiap RawCall berakhir di calls ATAU unresolvedCalls), G5 parsial (verifikasi ekspor). Deviasi didokumen: tanpa DEPENDENCY node (callgraph tetap file-node-only). Test: 14 baru lolos, 5 ekspektasi callgraph diupdate (target sama + metadata). Full suite: 8 gagal identik di main bersih (pre-existing). Co-credit: ManSio.