### PR TITLE
feat(git): head freshness stamp + evaluate — port ManSio #21/#22 line

### DIFF
--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -53,6 +53,7 @@ import { parseCsproj } from "../parser/csharp/parseCsproj";
 import { parseGradle_, parsePom } from "../parser/java/parseGradlePom";
 import { parseRequirements } from "../parser/python/parseRequirements";
 import { detectFrameworks, detectPackageManager } from "./detectRepositoryMeta";
+import { getHeadState } from "../git/headFreshness";
 import { ArcluxError, isArcluxError } from "../shared/errors";
 import type { DependencyGraph, RepositoryMeta, ScanSummary } from "../shared/types";
 import type { Repository } from "../repository/Repository";
@@ -210,6 +211,10 @@ export async function analyzeRepository(
  */
 async function analyzeLocalPath(localPath: string): Promise<AnalyzeRepositoryResult> {
   const resolvedPath = path.resolve(localPath);
+  // Freshness stamp (ManSio #22 line): git head at build time, so readers
+  // holding this result can evaluateFreshness() before trusting it.
+  // Never throws (non-git -> null stamp -> INCONCLUSIVE downstream).
+  const head = await getHeadState(resolvedPath);
 
   const meta: RepositoryMeta = {
     id: "local",
@@ -220,6 +225,7 @@ async function analyzeLocalPath(localPath: string): Promise<AnalyzeRepositoryRes
     detectedFrameworks: detectFrameworks(resolvedPath),
     packageManager: detectPackageManager(resolvedPath),
     analyzedAt: new Date().toISOString(),
+    buildHead: head.isRepo ? { commit: head.commit, dirty: head.dirty } : null,
   };
 
   let repository: Repository;
@@ -275,6 +281,8 @@ async function analyzeRemoteRepository(
     const cloneResult = await cloneRepository({ repoUrl, branch });
     localPath = cloneResult.localPath;
 
+    const head = await getHeadState(localPath);
+
     const meta: RepositoryMeta = {
       id: randomUUID(),
       org,
@@ -284,6 +292,7 @@ async function analyzeRemoteRepository(
       detectedFrameworks: detectFrameworks(localPath),
       packageManager: detectPackageManager(localPath),
       analyzedAt: new Date().toISOString(),
+      buildHead: head.isRepo ? { commit: head.commit, dirty: head.dirty } : null,
     };
 
     // Cheap up-front scan (hashing only, not parsing) to compute a

--- a/packages/git/headFreshness.ts
+++ b/packages/git/headFreshness.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+import { simpleGit } from "simple-git";
+
+/**
+ * Head freshness — TypeScript port of ManSio/mscodebase-intelligence's
+ * freshness contract (test_symbol_freshness.py, issues #21/#22 fix line).
+ *
+ * Problem it solves: an analysis result outlives the tree it was built
+ * from (daemon cache, db AnalysisStore, an agent holding an old snapshot).
+ * Consuming it as current is a stale-anchor bug — ManSio #22's class
+ * (VERIFIED stamped on a deleted symbol because its FILE still existed).
+ *
+ * Contract (mirrors ManSio's 7 freshness cases exactly):
+ * - build head == current HEAD **and** tree clean → FRESH.
+ * - HEAD moved, tree dirty, build head unknown (legacy), or not a git
+ *   repo at all → never FRESH: STALE when we can tell it moved,
+ *   INCONCLUSIVE when we cannot tell (fail-closed: unverifiable analysis
+ *   is never presented as fresh).
+ *
+ * Wiring: engine pipeline stamps RepositoryMeta.buildHead at analysis
+ * time (getHeadState); any reader holding a stamped result calls
+ * evaluateFreshness against a fresh getHeadState before trusting it.
+ * Records without a stamp (legacy) are INCONCLUSIVE, never FRESH.
+ */
+
+/** Git state captured at analysis-build time (or read time). */
+export interface HeadState {
+  /** False for non-git directories — commit/dirty are meaningless there. */
+  isRepo: boolean;
+  /** Full HEAD sha, or null when unknown (non-repo, fresh clone without commits). */
+  commit: string | null;
+  /** Uncommitted changes present (staged or unstaged, incl. untracked). */
+  dirty: boolean;
+}
+
+export type Freshness = "FRESH" | "STALE" | "INCONCLUSIVE";
+
+/**
+ * Capture the current head state of rootPath. Never throws: non-git
+ * directories and git failures yield { isRepo: false, ... } so callers
+ * degrade to INCONCLUSIVE instead of crashing analysis.
+ */
+export async function getHeadState(rootPath: string): Promise<HeadState> {
+  try {
+    const git = simpleGit(rootPath);
+    if (!(await git.checkIsRepo())) {
+      return { isRepo: false, commit: null, dirty: false };
+    }
+    let commit: string | null = null;
+    try {
+      const raw = await git.revparse(["HEAD"]);
+      commit = raw.trim() || null;
+    } catch {
+      commit = null; // repo without commits yet — known state, not an error
+    }
+    let dirty = false;
+    try {
+      const status = await git.status();
+      dirty = !status.isClean();
+    } catch {
+      dirty = false;
+    }
+    return { isRepo: true, commit, dirty };
+  } catch {
+    return { isRepo: false, commit: null, dirty: false };
+  }
+}
+
+/**
+ * buildHead: the stamp recorded when the analysis was built (null/absent
+ * = legacy record, pre-stamp). current: a fresh getHeadState of the same
+ * rootPath, taken at read time.
+ */
+export function evaluateFreshness(
+  buildHead: HeadState | null | undefined,
+  current: HeadState,
+): Freshness {
+  // Legacy record or non-git tree: we cannot tell → fail closed.
+  if (!buildHead || !buildHead.isRepo || !current.isRepo) return "INCONCLUSIVE";
+  if (!buildHead.commit || !current.commit) return "INCONCLUSIVE";
+  // Dirty at either end means the tree is not exactly what was analyzed.
+  if (buildHead.dirty || current.dirty) return "STALE";
+  return buildHead.commit === current.commit ? "FRESH" : "STALE";
+}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -184,6 +184,14 @@ export interface RepositoryMeta {
   detectedFrameworks: string[]; // e.g. ["nextjs", "react"]
   packageManager: "npm" | "pnpm" | "yarn" | "poetry" | "uv" | "pipenv" | "pdm" | "pip" | "unknown";
   analyzedAt: string; // ISO timestamp
+  /**
+   * Git head captured when this analysis was built (packages/git/
+   * headFreshness.ts — port of ManSio's freshness contract). Readers
+   * holding a stamped result call evaluateFreshness() against a fresh
+   * getHeadState() before trusting it. Absent = legacy record, never
+   * FRESH (fail-closed). Optional so fixtures keep compiling.
+   */
+  buildHead?: { commit: string | null; dirty: boolean } | null;
 }
 
 /**

--- a/tests/git-freshness.test.ts
+++ b/tests/git-freshness.test.ts
@@ -1,0 +1,123 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for head freshness (packages/git/headFreshness.ts) — port of
+// ManSio/mscodebase-intelligence's freshness contract
+// (tests/test_symbol_freshness.py, issues #21/#22 fix line). Uses real
+// throwaway git repos: FRESH only when build head == HEAD and clean;
+// everything else is STALE or fail-closed INCONCLUSIVE.
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { evaluateFreshness, getHeadState } from "../packages/git/headFreshness";
+
+const dirs: string[] = [];
+function track(dir: string): string {
+  dirs.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+function git(dir: string, ...args: string[]): string {
+  return execFileSync("git", ["-c", "user.email=t@t.co", "-c", "user.name=t", ...args], {
+    cwd: dir,
+    encoding: "utf8",
+  });
+}
+
+function makeRepo(): string {
+  const dir = track(mkdtempSync(join(tmpdir(), "arclux-fresh-")));
+  git(dir, "init", "-q");
+  writeFileSync(join(dir, "a.txt"), "one\n");
+  git(dir, "add", ".");
+  git(dir, "commit", "-qm", "one");
+  return dir;
+}
+
+describe("getHeadState", () => {
+  it("captures commit sha on a clean repo", async () => {
+    const dir = makeRepo();
+    const st = await getHeadState(dir);
+    expect(st.isRepo).toBe(true);
+    expect(st.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(st.dirty).toBe(false);
+  });
+
+  it("reports dirty on modification and on untracked files", async () => {
+    const dir = makeRepo();
+    writeFileSync(join(dir, "a.txt"), "two\n");
+    expect((await getHeadState(dir)).dirty).toBe(true);
+    git(dir, "checkout", "--", "a.txt");
+    mkdirSync(join(dir, "sub"));
+    writeFileSync(join(dir, "sub", "new.txt"), "x\n");
+    expect((await getHeadState(dir)).dirty).toBe(true);
+  });
+
+  it("non-git directory degrades gracefully (never throws)", async () => {
+    const dir = track(mkdtempSync(join(tmpdir(), "arclux-nogit-")));
+    const st = await getHeadState(dir);
+    expect(st).toEqual({ isRepo: false, commit: null, dirty: false });
+  });
+});
+
+describe("evaluateFreshness (ManSio 7-case contract)", () => {
+  it("build head == HEAD and clean -> FRESH", async () => {
+    const dir = makeRepo();
+    const built = await getHeadState(dir);
+    expect(evaluateFreshness(built, await getHeadState(dir))).toBe("FRESH");
+  });
+
+  it("HEAD moved after build -> STALE", async () => {
+    const dir = makeRepo();
+    const built = await getHeadState(dir);
+    writeFileSync(join(dir, "b.txt"), "two\n");
+    git(dir, "add", ".");
+    git(dir, "commit", "-qm", "two");
+    expect(evaluateFreshness(built, await getHeadState(dir))).toBe("STALE");
+  });
+
+  it("dirty tree at read time (same HEAD) -> STALE", async () => {
+    const dir = makeRepo();
+    const built = await getHeadState(dir);
+    writeFileSync(join(dir, "a.txt"), "dirty\n");
+    expect(evaluateFreshness(built, await getHeadState(dir))).toBe("STALE");
+  });
+
+  it("dirty tree at build time -> STALE even if HEAD matches", async () => {
+    const dir = makeRepo();
+    writeFileSync(join(dir, "a.txt"), "dirty\n");
+    const built = await getHeadState(dir);
+    expect(built.dirty).toBe(true);
+    git(dir, "checkout", "--", "a.txt");
+    expect(evaluateFreshness(built, await getHeadState(dir))).toBe("STALE");
+  });
+
+  it("legacy record (null build head) -> INCONCLUSIVE, never FRESH", async () => {
+    const dir = makeRepo();
+    expect(evaluateFreshness(null, await getHeadState(dir))).toBe("INCONCLUSIVE");
+    expect(evaluateFreshness(undefined, await getHeadState(dir))).toBe("INCONCLUSIVE");
+  });
+
+  it("non-git tree -> INCONCLUSIVE (fail-closed)", async () => {
+    const dir = track(mkdtempSync(join(tmpdir(), "arclux-nogit-")));
+    const st = await getHeadState(dir);
+    expect(evaluateFreshness({ isRepo: true, commit: "abc", dirty: false }, st)).toBe("INCONCLUSIVE");
+    expect(evaluateFreshness(null, st)).toBe("INCONCLUSIVE");
+  });
+
+  it("missing commit sha on either side -> INCONCLUSIVE", async () => {
+    const dir = makeRepo();
+    const built = await getHeadState(dir);
+    expect(evaluateFreshness({ isRepo: true, commit: null, dirty: false }, built)).toBe("INCONCLUSIVE");
+  });
+});


### PR DESCRIPTION
Port TS kontrak freshness ManSio (test_symbol_freshness, fix line issue #21/#22). packages/git/headFreshness.ts: getHeadState (never throws, non-git graceful) + evaluateFreshness (FRESH hanya build==HEAD && clean; STALE saat pindah/dirty; INCONCLUSIVE fail-closed buat legacy/non-git). Pipeline stamp RepositoryMeta.buildHead di dua situs meta (local + clone). Audit #21: ARCLUX tidak punya bare-symbol single-pick (semua .find exact-match id/path; search balikin ranked list; ambiguitas di-resolver hanya via explicit candidates G1) — tidak ada write path yang perlu refusal. Test: 10 baru lolos. Full suite: 8 gagal identik main bersih (pre-existing). Co-credit: ManSio.