### PR TITLE
fix(mcp): semantic_diff summary by default (BUG-3)

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -478,6 +478,7 @@ const TOOLS = [
         branch:    { type: "string" },
         refA:      { type: "string" },
         refB:      { type: "string" },
+        detail:    { type: "string", enum: ["summary", "full"], description: "summary (default): file lists + impact counts, no per-file trees. full: complete impactByModule + symbol arrays (large)." },
       },
       required: ["refA", "refB"],
     },
@@ -802,7 +803,8 @@ async function handleTool(name: string, args: Record<string, unknown>) {
     }
     case "semantic_diff": {
       const r = await doAnalyze(args);
-      return json(computeSemanticDiff({ repository: r.repository, repoPath: r.meta.rootPath, refA: args.refA as string, refB: args.refB as string }));
+      const detail = args.detail === "full" ? "full" : "summary";
+      return json(computeSemanticDiff({ repository: r.repository, repoPath: r.meta.rootPath, refA: args.refA as string, refB: args.refB as string, detail }));
     }
 
     // ── Git ────────────────────────────────────────────────────────

--- a/packages/semantic-diff/SemanticDiff.ts
+++ b/packages/semantic-diff/SemanticDiff.ts
@@ -26,16 +26,34 @@ export interface SemanticDiffOptions {
   refB: string;
   /** Optional second Repository snapshot (indexed at refB) for symbol-level diffing. Skipped if omitted. */
   repositoryAfter?: Repository;
+  /**
+   * Output detail (BUG-3): "summary" (default) returns file lists +
+   * per-module impact COUNTS + symbol counts — no per-file affected trees,
+   * no full SymbolInfo arrays. "full" returns the legacy complete shape.
+   * The full shape bloated MCP responses past truncation (132KB on a
+   * 16-module split) and ate agent context; default summary, opt-in full.
+   */
+  detail?: "summary" | "full";
+}
+
+export interface SemanticDiffSummaryCounts {
+  affectedFiles: number;
 }
 
 export interface SemanticDiffResult {
+  /** Which detail mode produced this result. */
+  mode: "summary" | "full";
   changedFiles: string[];
   dependencyDiff: DependencyDiffResult;
   symbolDiff?: SymbolDiffResult;
+  /** Summary-only projections (absent in full mode). */
+  impactCounts?: Record<string, SemanticDiffSummaryCounts>;
+  symbolCounts?: { added: number; removed: number; moved: number };
   rendered: string;
 }
 
 export function computeSemanticDiff(options: SemanticDiffOptions): SemanticDiffResult {
+  const mode = options.detail ?? "summary";
   const changed = getChangedFiles(options.repoPath, options.refA, options.refB);
   const dependencyDiff = computeDependencyDiff(options.repository, options.repoPath, options.refA, options.refB);
 
@@ -45,10 +63,27 @@ export function computeSemanticDiff(options: SemanticDiffOptions): SemanticDiffR
 
   const rendered = renderSemanticDiff({ symbolDiff, dependencyDiff });
 
+  if (mode === "full") {
+    return { mode, changedFiles: changed.map((c) => c.path), dependencyDiff, symbolDiff, rendered };
+  }
+
+  // Summary: counts + moved list only. impactByModule trees and full
+  // SymbolInfo arrays stay server-side (they caused the 132KB bloat).
+  const impactCounts: Record<string, SemanticDiffSummaryCounts> = {};
+  for (const [mod, impact] of Object.entries(dependencyDiff.impactByModule)) {
+    impactCounts[mod] = { affectedFiles: impact.affectedFiles.length };
+  }
   return {
+    mode,
     changedFiles: changed.map((c) => c.path),
-    dependencyDiff,
-    symbolDiff,
+    dependencyDiff: { ...dependencyDiff, impactByModule: {} },
+    symbolDiff: symbolDiff
+      ? { added: [], removed: [], moved: symbolDiff.moved }
+      : undefined,
+    impactCounts,
+    symbolCounts: symbolDiff
+      ? { added: symbolDiff.added.length, removed: symbolDiff.removed.length, moved: symbolDiff.moved.length }
+      : undefined,
     rendered,
   };
 }

--- a/tests/semantic-diff-modes.test.ts
+++ b/tests/semantic-diff-modes.test.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for semantic-diff detail modes (BUG-3): default summary must stay
+// small (file lists + counts, no per-file impact trees, no SymbolInfo
+// arrays); full mode keeps the legacy complete shape. Verified against a
+// real throwaway git repo (two refs) so changedFiles is genuine.
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildIndex } from "../packages/indexer/buildIndex";
+import { computeSemanticDiff } from "../packages/semantic-diff/SemanticDiff";
+import { parserRegistry } from "../packages/parser/core/ParserRegistry";
+import { parseJs } from "../packages/parser/javascript/parseJs";
+import { parseTs } from "../packages/parser/typescript/parseTs";
+import type { RepositoryMeta } from "../packages/shared/types";
+
+parserRegistry.register(parseJs);
+parserRegistry.register(parseTs);
+
+const tempDirs: string[] = [];
+function track(dir: string): string {
+  tempDirs.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function git(dir: string, ...args: string[]): void {
+  execFileSync("git", ["-c", "user.email=t@t.co", "-c", "user.name=t", ...args], { cwd: dir });
+}
+
+const META: Omit<RepositoryMeta, "analyzedAt"> = {
+  id: "semdiff-test",
+  org: "local",
+  name: "semdiff-test",
+  defaultBranch: "local",
+  rootPath: "",
+  detectedFrameworks: [],
+  packageManager: "unknown",
+};
+
+async function twoRefRepo(): Promise<{ dir: string; refA: string; refB: string }> {
+  const dir = track(mkdtempSync(join(tmpdir(), "arclux-semdiff-")));
+  writeFileSync(join(dir, "b.ts"), "export function helper() { return 1; }\n");
+  writeFileSync(join(dir, "a.ts"), 'import { helper } from "./b";\nexport function run() { return helper(); }\n');
+  writeFileSync(join(dir, "c.ts"), 'import { run } from "./a";\nexport function main() { return run(); }\n');
+  git(dir, "init", "-q");
+  git(dir, "add", ".");
+  git(dir, "commit", "-qm", "one");
+  const refA = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+  writeFileSync(join(dir, "b.ts"), "export function helper() { return 2; }\nexport function extra() { return 3; }\n");
+  git(dir, "add", ".");
+  git(dir, "commit", "-qm", "two");
+  const refB = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+  return { dir, refA, refB };
+}
+
+describe("semantic_diff detail modes (BUG-3)", () => {
+  it("default is summary: changedFiles + counts, no impact trees", async () => {
+    const { dir, refA, refB } = await twoRefRepo();
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+    const out = computeSemanticDiff({ repository, repoPath: dir, refA, refB });
+    expect(out.mode).toBe("summary");
+    expect(out.changedFiles).toContain("b.ts");
+    expect(out.dependencyDiff.impactByModule).toEqual({});
+    expect(Object.keys(out.impactCounts ?? {}).length).toBeGreaterThan(0);
+    for (const counts of Object.values(out.impactCounts ?? {})) {
+      expect(counts.affectedFiles).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("summary JSON is smaller than full JSON on the same diff", async () => {
+    const { dir, refA, refB } = await twoRefRepo();
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+    const summary = computeSemanticDiff({ repository, repoPath: dir, refA, refB });
+    const full = computeSemanticDiff({ repository, repoPath: dir, refA, refB, detail: "full" });
+    expect(full.mode).toBe("full");
+    expect(Object.keys(full.dependencyDiff.impactByModule).length).toBeGreaterThan(0);
+    expect(JSON.stringify(summary).length).toBeLessThan(JSON.stringify(full).length);
+  });
+
+  it("full mode preserves the legacy complete shape", async () => {
+    const { dir, refA, refB } = await twoRefRepo();
+    const repository = await buildIndex({ rootPath: dir, meta: { ...META, rootPath: dir } });
+    const full = computeSemanticDiff({ repository, repoPath: dir, refA, refB, detail: "full" });
+    expect(full.impactCounts).toBeUndefined();
+    expect(full.symbolCounts).toBeUndefined();
+    expect(typeof full.rendered).toBe("string");
+  });
+});


### PR DESCRIPTION
Full impactByModule + SymbolInfo arrays bikin respons 132KB ke-truncate dan makan konteks agen. Fix: detail summary (default) = changedFiles + affectedModules + impactCounts + symbolCounts/moved; full = legacy shape opt-in via detail:'full'. MCP schema + passthrough. Test: 3 baru lolos (summary kecil vs full, shape legacy utuh).