### PR TITLE
fix(doctor): orphan precision — barrel/re-export/noise/dedupe (BUG-2)

### DIFF
--- a/packages/detectors/detectOrphanFiles.ts
+++ b/packages/detectors/detectOrphanFiles.ts
@@ -46,6 +46,26 @@ export interface OrphanFileFinding {
  * detectEntryPoints.ts (known entry-point conventions), mirroring what
  * detectUnusedExports.ts does.
  *
+ * BUG-2 precision fixes (scope-relative honesty):
+ * - Pure-barrel modules (every export is a re-export, e.g. gameserver/
+ *   index.ts's `export *` wall) are public API surfaces, excluded like
+ *   entries. No file I/O needed — decided from RawExport kinds alone.
+ * - Config/vendor/tooling paths (*.config.*, *.d.ts, vendor-ui/, _inbox/)
+ *   are skipped: reporting them as orphans buries real signal (523-noise
+ *   case). Deliberately narrow — user code named *.config.ts that IS
+ *   imported still shows up nowhere else, but an unimported
+ *   `weird.config.ts` with real code is a corner case we accept missing
+ *   in exchange for killing hundreds of false positives.
+ * - Findings dedupe by filePath (upstream merges can surface the same
+ *   module twice — e.g. the 9x impactStore.ts case — and one file gets
+ *   one verdict).
+ * - Re-export counts as weak usage: a module re-exported by an in-scope
+ *   barrel but directly imported by nothing is "ambiguous" (public via
+ *   barrel, consumers possibly out of scope), never "unwired". This is
+ *   the cross-package honesty fix: server.ts re-exported by
+ *   gameserver/index.ts must not be called unwired just because its
+ *   importers (serve.ts, game) live outside the analyzed scope.
+ *
  * Each orphan is classified by looking at REAL structural signals in the
  * repository (see classifyOrphan): are siblings in the same folder
  * imported anywhere? Is there a barrel index.ts that skips this file?
@@ -56,12 +76,36 @@ export function detectOrphanFiles(repository: Repository): OrphanFileFinding[] {
   for (const id of getEntryModuleIds(repository.getAllModules())) entryModuleIds.add(id);
   for (const finding of detectEntryPoints(repository)) entryModuleIds.add(finding.filePath);
 
+  const allModules = repository.getAllModules();
+
+  // Pure barrels: public surface, not orphans.
+  for (const m of allModules) {
+    if (m.exports.length > 0 && m.exports.every((e) => e.kind === "re-export")) {
+      entryModuleIds.add(m.id);
+    }
+  }
+
+  // Re-export usage: moduleId -> barrel ids re-exporting it (in scope).
+  const reExportedBy = new Map<string, string[]>();
+  for (const m of allModules) {
+    for (const targetId of Object.values(m.resolvedReExports)) {
+      const list = reExportedBy.get(targetId) ?? [];
+      if (!list.includes(m.id)) list.push(m.id);
+      reExportedBy.set(targetId, list);
+    }
+  }
+
   const orphans = repository
     .findModulesWithNoImporters()
-    .filter((module) => !entryModuleIds.has(module.id) && !isTestFilePath(module.id));
+    .filter((module) => !entryModuleIds.has(module.id) && !isTestFilePath(module.id))
+    .filter((module) => !isNoisePath(module.file.relativePath));
 
-  return orphans.map((module) => {
-    const { classification, evidence } = classifyOrphan(module, repository);
+  const seen = new Set<string>();
+  const findings: OrphanFileFinding[] = [];
+  for (const module of orphans) {
+    if (seen.has(module.id)) continue; // dedupe: one file, one verdict
+    seen.add(module.id);
+    const { classification, evidence } = classifyOrphan(module, repository, reExportedBy.get(module.id) ?? []);
     const filePath = module.file.relativePath;
     const message =
       classification === "unwired"
@@ -69,8 +113,9 @@ export function detectOrphanFiles(repository: Repository): OrphanFileFinding[] {
         : classification === "dead"
           ? `"${filePath}" is never imported and shows dead-code signals — likely safe to delete.`
           : `"${filePath}" is never imported (ambiguous — no strong integration or deletion signal).`;
-    return { filePath, message, classification, evidence };
-  });
+    findings.push({ filePath, message, classification, evidence });
+  }
+  return findings;
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -80,6 +125,19 @@ export function detectOrphanFiles(repository: Repository): OrphanFileFinding[] {
 const BACKUP_NAME = /\.(?:bak|old|orig|tmp|copy|backup)$/i;
 const SCRATCH_NAME = /(?:scratch|archive|-old|-copy|_draft|_tmp|-wip)/i;
 const STORY_NAME = /\.(?:stories|story)\./i;
+
+/**
+ * Tooling/config paths that are never meaningful orphans — reporting them
+ * buries real signal (BUG-2: next.config.ts, eslint.config.mjs, *.d.ts,
+ * vendor-ui/, _inbox/ dominated a 523-finding run). Deliberately narrow:
+ * only build/config latticed paths and vendored UI, never user code by
+ * naming pattern alone.
+ */
+const NOISE_PATH = /(?:^|\/)(?:[^/]*\.config\.[^/]+|[^/]*\.d\.ts|vendor-ui\/|_inbox\/)/;
+
+export function isNoisePath(relativePath: string): boolean {
+  return NOISE_PATH.test(relativePath);
+}
 
 /** Shared structural suffixes (e.g. userService.ts / paymentService.ts). */
 const KNOWN_SUFFIXES = [
@@ -156,7 +214,8 @@ export function siblingModules(module: ModuleInfo, repository: Repository): Modu
  */
 export function classifyOrphan(
   module: ModuleInfo,
-  repository: Repository
+  repository: Repository,
+  reExportedByBarrels: string[] = []
 ): { classification: OrphanClassification; evidence: string[] } {
   const evidence: string[] = [];
   const filePath = module.file.relativePath;
@@ -165,6 +224,18 @@ export function classifyOrphan(
     return {
       classification: "ambiguous",
       evidence: ["story file — loaded by story tooling, not by source imports (standalone by design)"],
+    };
+  }
+
+  // Re-exported by an in-scope barrel but directly imported by nothing:
+  // public via barrel, consumers possibly out of scope — ambiguous, never
+  // unwired (cross-package honesty, BUG-2A).
+  if (reExportedByBarrels.length > 0) {
+    return {
+      classification: "ambiguous",
+      evidence: [
+        `re-exported by ${reExportedByBarrels.length} in-scope barrel(s) (${reExportedByBarrels.slice(0, 3).join(", ")}) with no direct importers in this scope — consumers may live outside it`,
+      ],
     };
   }
 

--- a/tests/orphan-integration.test.ts
+++ b/tests/orphan-integration.test.ts
@@ -41,14 +41,14 @@ interface ResolvedImport {
 
 function makeModule(
   relativePath: string,
-  opts: { exports?: RawExport[]; imports?: string[]; resolvedImports?: ResolvedImport[]; importedBy?: string[] } = {}
+  opts: { exports?: RawExport[]; imports?: string[]; resolvedImports?: ResolvedImport[]; importedBy?: string[]; resolvedReExports?: Record<string, string> } = {}
 ): ModuleInfo {
   const imports = opts.imports ?? [];
   return {
     id: relativePath,
     file: makeFile(relativePath),
     exports: opts.exports ?? [],
-    resolvedReExports: {},
+    resolvedReExports: opts.resolvedReExports ?? {},
     importedBy: opts.importedBy ?? [],
     imports,
     resolvedImports: (opts.resolvedImports ?? imports.map((moduleId) => ({ moduleId, namedImports: [], hasDefaultImport: false, hasNamespaceImport: false, line: 1 }))).map((r) => ({ ...r, kind: "static" as const })),
@@ -56,6 +56,10 @@ function makeModule(
     calledBy: [],
     implicitDependencies: [],
   };
+}
+
+function reexp(name: string, line = 1): RawExport {
+  return { name, kind: "re-export", reExportSource: "./x", line };
 }
 
 function makeRepository(modules: ModuleInfo[]): Repository {
@@ -147,6 +151,66 @@ describe("detectOrphanFiles — classification", () => {
     const register = findings.get("src/features/auth/register.ts");
     expect(register.classification).toBe("unwired");
     expect(register.evidence.some((e: string) => e.includes("barrel"))).toBe(true);
+  });
+
+  it("excludes pure-barrel modules (all re-exports) like entries (BUG-2D)", () => {
+    const repo = makeRepository([
+      makeModule("pkg/index.ts", {
+        exports: [reexp("*")],
+        imports: ["pkg/server.ts"],
+        importedBy: [],
+      }),
+      makeModule("pkg/server.ts", { exports: [named("serve")], importedBy: [] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    expect(findings.has("pkg/index.ts")).toBe(false);
+  });
+
+  it("marks barrel-re-exported modules ambiguous, never unwired (BUG-2A cross-package honesty)", () => {
+    const repo = makeRepository([
+      makeModule("pkg/index.ts", {
+        exports: [reexp("*")],
+        imports: ["pkg/server.ts", "pkg/other.ts"],
+        importedBy: [],
+        resolvedReExports: { "*": "pkg/server.ts" },
+      }),
+      makeModule("pkg/server.ts", { exports: [named("serve")], importedBy: [] }),
+      makeModule("pkg/other.ts", { exports: [named("other")], importedBy: ["pkg/app.ts"] }),
+      makeModule("pkg/app.ts", { exports: [named("app")] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    const server = findings.get("pkg/server.ts");
+    expect(server.classification).toBe("ambiguous");
+    expect(server.evidence.some((e: string) => e.includes("re-exported"))).toBe(true);
+  });
+
+  it("skips tooling noise paths: configs, d.ts, vendor-ui, _inbox (BUG-2B)", () => {
+    const repo = makeRepository([
+      makeModule("next.config.ts", { exports: [] }),
+      makeModule("src/types.d.ts", { exports: [] }),
+      makeModule("src/vendor-ui/anim.tsx", { exports: [named("Anim")] }),
+      makeModule("src/_inbox/draft.tsx", { exports: [named("Draft")] }),
+      makeModule("src/real.ts", { exports: [named("real")], importedBy: [] }),
+    ]);
+    const findings = byPath(detectOrphanFiles(repo));
+    expect(findings.has("next.config.ts")).toBe(false);
+    expect(findings.has("src/types.d.ts")).toBe(false);
+    expect(findings.has("src/vendor-ui/anim.tsx")).toBe(false);
+    expect(findings.has("src/_inbox/draft.tsx")).toBe(false);
+    // Real user code still reported.
+    expect(findings.has("src/real.ts")).toBe(true);
+  });
+
+  it("dedupes: one file gets one verdict even if the module surfaces twice (BUG-2C)", () => {
+    const dup = makeModule("src/dup.ts", { exports: [named("dup")], importedBy: [] });
+    // Fake a repository surfacing the same module twice (as observed via
+    // upstream merges) — the guard lives in the detector, not the store.
+    const repo = {
+      getAllModules: () => [dup, dup],
+      findModulesWithNoImporters: () => [dup, dup],
+    } as unknown as Repository;
+    const findings = detectOrphanFiles(repo).filter((f) => f.filePath === "src/dup.ts");
+    expect(findings).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
4 fix presisi orphan: (1) pure-barrel (semua re-export) di-exclude kayak entry; (2) modul di-re-export barrel in-scope tapi tanpa importer langsung = ambiguous + evidence (bukan unwired) — kejujuran lintas-scope, kasus server.ts; (3) skip-list noise (*.config.*, *.d.ts, vendor-ui/, _inbox/); (4) dedupe per filePath (kasus 9x). Tanpa I/O baru (detector tetap murni Repository). Test: 4 baru + 121 detector-suite lolos. Full: 8 gagal identik main bersih (pre-existing).