### PR TITLE
feat(cli): RESULT block + freshness lamp (analyze/doctor)

### DIFF
--- a/apps/cli/analyze.ts
+++ b/apps/cli/analyze.ts
@@ -9,6 +9,7 @@
 import type { Command } from "commander";
 import * as p from "@clack/prompts";
 import { analyzeRepository } from "../../packages/engine/pipeline";
+import { getHeadState, reportFreshness } from "../../packages/git/headFreshness";
 import { detectCircularDependency } from "../../packages/detectors/detectCircularDependency";
 import { detectUnusedExports } from "../../packages/detectors/detectUnusedExports";
 import { detectOrphanFiles } from "../../packages/detectors/detectOrphanFiles";
@@ -53,7 +54,8 @@ export function registerAnalyzeCommand(program: Command): void {
       spinner.start(`Analyzing ${targetPath}`);
       const startedAt = Date.now();
       try {
-        const { repository, meta, graph, scanSummary } = await analyzeRepository({ localPath: targetPath });
+        const { repository, meta, graph, scanSummary, dependencies, securityAnalysis } =
+          await analyzeRepository({ localPath: targetPath });
         const elapsedMs = Date.now() - startedAt;
         spinner.stop("Analysis complete");
 
@@ -74,6 +76,21 @@ export function registerAnalyzeCommand(program: Command): void {
           `Detectors: ${summary.total} issue${summary.total === 1 ? "" : "s"} \u2014 circular ${summary.circular}, unused ${summary.unusedExports}, orphan ${summary.orphanFiles}, layer ${summary.layerViolations}`
         );
         p.log.info(`Elapsed: ${(elapsedMs / 1000).toFixed(2)}s`);
+
+        // RESULT block: the value, not just "done". Same one-line discipline
+        // as above — short lines only.
+        p.log.success(
+          `RESULT ${meta.org}/${meta.name} \u2014 ${repository.moduleCount} modules, ${graph.edges.length} edges, ${dependencies.length} dependencies`
+        );
+        p.log.info(`Security: ${securityAnalysis?.findings.length ?? 0} findings`);
+        p.log.info(`Analyzed at: ${meta.analyzedAt}`);
+        const fresh = reportFreshness(
+          meta.buildHead ?? null,
+          await getHeadState(meta.rootPath)
+        );
+        if (fresh.verdict === "FRESH") p.log.success(`Freshness: FRESH \u2014 ${fresh.detail}`);
+        else if (fresh.verdict === "STALE") p.log.warn(`Freshness: STALE \u2014 ${fresh.detail}`);
+        else p.log.info(`Freshness: INCONCLUSIVE \u2014 ${fresh.detail}`);
       } catch (err) {
         spinner.stop("Analysis failed");
         p.log.error(err instanceof Error ? err.message : String(err));

--- a/apps/cli/doctor.ts
+++ b/apps/cli/doctor.ts
@@ -26,6 +26,7 @@
 import type { Command } from "commander";
 import * as p from "@clack/prompts";
 import { analyzeRepository } from "../../packages/engine/pipeline";
+import { getHeadState, reportFreshness } from "../../packages/git/headFreshness";
 import { detectCircularDependency } from "../../packages/detectors/detectCircularDependency";
 import { detectUnusedExports } from "../../packages/detectors/detectUnusedExports";
 import { detectOrphanFiles } from "../../packages/detectors/detectOrphanFiles";
@@ -56,8 +57,17 @@ export function registerDoctorCommand(program: Command): void {
       spinner.start(`Running detectors on ${targetPath}`);
 
       try {
-        const { repository } = await analyzeRepository({ localPath: targetPath });
+        const { repository, meta } = await analyzeRepository({ localPath: targetPath });
         spinner.stop("Detectors finished");
+
+        // Freshness lamp: the analysis was just built, so this reports its
+        // anchor (HEAD/clean) — STALE here means "built on a dirty tree",
+        // explained, not alarming. Held/cached results are checked by
+        // readers via evaluateFreshness, not here.
+        const fresh = reportFreshness(meta.buildHead ?? null, await getHeadState(meta.rootPath));
+        if (fresh.verdict === "FRESH") p.log.success(`Analysis fresh \u2014 ${fresh.detail}`);
+        else if (fresh.verdict === "STALE") p.log.warn(`Analysis anchor: STALE \u2014 ${fresh.detail}`);
+        else p.log.info(`Analysis anchor: INCONCLUSIVE \u2014 ${fresh.detail}`);
 
         const cycles = detectCircularDependency(repository);
         const unusedExports = detectUnusedExports(repository);

--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -225,7 +225,7 @@ async function analyzeLocalPath(localPath: string): Promise<AnalyzeRepositoryRes
     detectedFrameworks: detectFrameworks(resolvedPath),
     packageManager: detectPackageManager(resolvedPath),
     analyzedAt: new Date().toISOString(),
-    buildHead: head.isRepo ? { commit: head.commit, dirty: head.dirty } : null,
+    buildHead: head.isRepo ? { isRepo: true, commit: head.commit, dirty: head.dirty } : null,
   };
 
   let repository: Repository;
@@ -292,7 +292,7 @@ async function analyzeRemoteRepository(
       detectedFrameworks: detectFrameworks(localPath),
       packageManager: detectPackageManager(localPath),
       analyzedAt: new Date().toISOString(),
-      buildHead: head.isRepo ? { commit: head.commit, dirty: head.dirty } : null,
+      buildHead: head.isRepo ? { isRepo: true, commit: head.commit, dirty: head.dirty } : null,
     };
 
     // Cheap up-front scan (hashing only, not parsing) to compute a

--- a/packages/git/headFreshness.ts
+++ b/packages/git/headFreshness.ts
@@ -89,3 +89,43 @@ export function evaluateFreshness(
   if (buildHead.dirty || current.dirty) return "STALE";
   return buildHead.commit === current.commit ? "FRESH" : "STALE";
 }
+
+/**
+ * Human-facing report over evaluateFreshness: same verdict, plus the
+ * detail a CLI needs so STALE never scares without explaining. In
+ * particular a just-built analysis of a dirty tree reports STALE with
+ * the working-tree explanation (fail-closed: dirty was never anchored
+ * to a commit), not a bare alarm.
+ */
+export interface FreshnessReport {
+  verdict: Freshness;
+  /** Short (7-char) build commit, or null when unknown. */
+  shortCommit: string | null;
+  detail: string;
+}
+
+export function reportFreshness(
+  buildHead: HeadState | null | undefined,
+  current: HeadState,
+): FreshnessReport {
+  const verdict = evaluateFreshness(buildHead, current);
+  const shortCommit = buildHead?.commit?.slice(0, 7) ?? null;
+  if (verdict === "FRESH") {
+    return { verdict, shortCommit, detail: `HEAD ${shortCommit} (clean)` };
+  }
+  if (!buildHead || !buildHead.isRepo || !current.isRepo || !buildHead.commit || !current.commit) {
+    return { verdict, shortCommit, detail: "no git anchor — legacy result or non-git tree; treat as snapshot, re-run to anchor" };
+  }
+  if (buildHead.commit !== current.commit) {
+    return {
+      verdict,
+      shortCommit,
+      detail: `tree moved since analysis (built at ${shortCommit}, now at ${current.commit.slice(0, 7)}) — re-run analysis`,
+    };
+  }
+  return {
+    verdict,
+    shortCommit,
+    detail: "uncommitted changes present — results track the working tree, re-run after commit for an anchored result",
+  };
+}

--- a/packages/shared/types.ts
+++ b/packages/shared/types.ts
@@ -186,12 +186,14 @@ export interface RepositoryMeta {
   analyzedAt: string; // ISO timestamp
   /**
    * Git head captured when this analysis was built (packages/git/
-   * headFreshness.ts — port of ManSio's freshness contract). Readers
-   * holding a stamped result call evaluateFreshness() against a fresh
-   * getHeadState() before trusting it. Absent = legacy record, never
-   * FRESH (fail-closed). Optional so fixtures keep compiling.
+   * headFreshness.ts — port of ManSio's freshness contract). Same shape
+   * as HeadState (isRepo/commit/dirty) so evaluateFreshness() takes it
+   * directly. Readers holding a stamped result call evaluateFreshness()
+   * against a fresh getHeadState() before trusting it. Absent/null =
+   * legacy record, never FRESH (fail-closed). Optional so fixtures keep
+   * compiling.
    */
-  buildHead?: { commit: string | null; dirty: boolean } | null;
+  buildHead?: { isRepo: boolean; commit: string | null; dirty: boolean } | null;
 }
 
 /**

--- a/tests/git-freshness.test.ts
+++ b/tests/git-freshness.test.ts
@@ -17,7 +17,8 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { evaluateFreshness, getHeadState } from "../packages/git/headFreshness";
+import { evaluateFreshness, getHeadState, reportFreshness } from "../packages/git/headFreshness";
+import { analyzeRepository } from "../packages/engine/pipeline";
 
 const dirs: string[] = [];
 function track(dir: string): string {
@@ -120,4 +121,59 @@ describe("evaluateFreshness (ManSio 7-case contract)", () => {
     const built = await getHeadState(dir);
     expect(evaluateFreshness({ isRepo: true, commit: null, dirty: false }, built)).toBe("INCONCLUSIVE");
   });
+});
+
+describe("reportFreshness (human wording over the verdict)", () => {
+  it("FRESH carries the short commit", async () => {
+    const dir = makeRepo();
+    const built = await getHeadState(dir);
+    const rep = reportFreshness(built, await getHeadState(dir));
+    expect(rep.verdict).toBe("FRESH");
+    expect(rep.shortCommit).toMatch(/^[0-9a-f]{7}$/);
+    expect(rep.detail).toContain("clean");
+  });
+
+  it("moved tree explains both commits", async () => {
+    const dir = makeRepo();
+    const built = await getHeadState(dir);
+    writeFileSync(join(dir, "b.txt"), "two\n");
+    git(dir, "add", ".");
+    git(dir, "commit", "-qm", "two");
+    const rep = reportFreshness(built, await getHeadState(dir));
+    expect(rep.verdict).toBe("STALE");
+    expect(rep.detail).toContain("re-run analysis");
+    expect(rep.detail).toContain(rep.shortCommit as string);
+  });
+
+  it("dirty tree explains working-tree tracking instead of alarming", async () => {
+    const dir = makeRepo();
+    const built = await getHeadState(dir);
+    writeFileSync(join(dir, "a.txt"), "dirty\n");
+    const rep = reportFreshness(built, await getHeadState(dir));
+    expect(rep.verdict).toBe("STALE");
+    expect(rep.detail).toContain("working tree");
+  });
+
+  it("legacy/non-git explains the missing anchor", async () => {
+    const dir = makeRepo();
+    const rep = reportFreshness(null, await getHeadState(dir));
+    expect(rep.verdict).toBe("INCONCLUSIVE");
+    expect(rep.shortCommit).toBeNull();
+    expect(rep.detail).toContain("no git anchor");
+  });
+});
+
+describe("pipeline stamp shape (regression: stamp must satisfy the evaluator)", () => {
+  it("analyzeRepository stamps a buildHead that evaluates FRESH end-to-end", async () => {
+    const dir = makeRepo();
+    writeFileSync(join(dir, "b.ts"), "export function b() { return 1; }\n");
+    git(dir, "add", ".");
+    git(dir, "commit", "-qm", "two");
+    const result = await analyzeRepository({ localPath: dir });
+    // The stamp must carry isRepo — a {commit,dirty}-only stamp silently
+    // degrades every read to INCONCLUSIVE (caught live via CLI smoke test).
+    expect(result.meta.buildHead?.isRepo).toBe(true);
+    const rep = reportFreshness(result.meta.buildHead ?? null, await getHeadState(dir));
+    expect(rep.verdict).toBe("FRESH");
+  }, 120000);
 });


### PR DESCRIPTION
Dua program: (1) RESULT block di analyze (modules/edges/deps/security/analyzed-at + freshness) + lampu freshness di doctor — speedometer buat stamp #655. (2) FIX misunderstanding ketemu live: stamp {commit,dirty} tanpa isRepo bikin semua read INCONCLUSIVE; stamp sekarang full HeadState + regression test end-to-end (analyze->FRESH). Live verified: FRESH di repo bersih, STALE di dirty tree. Test: 15 lolos. Full: 8 gagal identik main bersih (pre-existing).