### PR TITLE
feat(engine): local fingerprint cache (honest hits)

### DIFF
--- a/packages/engine/pipeline.ts
+++ b/packages/engine/pipeline.ts
@@ -145,6 +145,14 @@ export interface AnalyzeRepositoryResult {
   /** Combined dependency list from every manifest file present in the repo (package.json, go.mod, etc). See ManifestRegistry.ts. */
   dependencies: import("../parser/core/ManifestParserInterface").ManifestDependency[];
   securityAnalysis?: SecurityAnalysis;
+  /**
+   * True when repository+graph came from the fingerprint cache (content
+   * identical to a previous analysis in this process) instead of a fresh
+   * buildIndex. Optional so older fixtures keep compiling; pipeline always
+   * sets it. On a hit the meta stamp + clock are re-anchored (see
+   * analyzeLocalPath), so a hit is honest, not just fast.
+   */
+  cacheHit?: boolean;
 }
 
 /** Parses "org/name" out of a git URL, for https, ssh, and shorthand forms */
@@ -200,14 +208,23 @@ export async function analyzeRepository(
 }
 
 /**
- * Local-path flow: no git clone, no cleanup, no cache.
+ * Local-path flow: no git clone, no cleanup — but WITH the fingerprint
+ * cache (same machinery as the remote flow, keyed `local:<resolvedPath>`).
  *
- * No caching on purpose: the fingerprint/cache system (repositoryCache.ts,
- * graphCache.ts) is keyed by repoUrl+branch, which doesn't map cleanly to
- * a bare local directory a developer is actively editing. Caching stale
- * results mid-edit would be worse than the cost of re-indexing. Revisit
- * if `arclux` commands feel slow on large local repos — that's a real
- * possible follow-up, not ruled out, just not built here.
+ * Why this is safe where naive caching would not be: the key is a CONTENT
+ * fingerprint (every file's hash — an edit anywhere changes it), not a
+ * timestamp or a git HEAD. Mid-edit staleness is impossible by
+ * construction: edited tree → different fingerprint → miss → rebuild.
+ * The known sharp edge is commit-without-change (same content, new HEAD):
+ * handled by re-anchoring the stamp on a hit (see below), so freshness
+ * stays truthful.
+ *
+ * Scope honesty: the caches are IN-MEMORY (repositoryCache.ts /
+ * graphCache.ts, by design — see their headers). Long-running processes
+ * (daemon, MCP server, watch batches) hit; single-shot CLI runs are fresh
+ * processes and always miss. Cross-process disk caching of full
+ * Repositories is a separate project (Repository holds a live Map —
+ * naive JSON would silently empty it, see AnalyzeRepositoryResult docs).
  */
 async function analyzeLocalPath(localPath: string): Promise<AnalyzeRepositoryResult> {
   const resolvedPath = path.resolve(localPath);
@@ -228,24 +245,55 @@ async function analyzeLocalPath(localPath: string): Promise<AnalyzeRepositoryRes
     buildHead: head.isRepo ? { isRepo: true, commit: head.commit, dirty: head.dirty } : null,
   };
 
-  let repository: Repository;
-  try {
-    repository = await buildIndex({ rootPath: resolvedPath, meta });
-  } catch (err) {
-    throw isArcluxError(err)
-      ? err
-      : new ArcluxError({ code: "INDEX_FAILED", message: "Indexing failed", cause: err });
-  }
+  // Fingerprint-first: one hashing scan up front (cheap — same pass the
+  // remote flow already pays). On a hit we skip buildIndex +
+  // buildDependencyGraph entirely; on a miss buildIndex scans again
+  // internally (one extra hashing pass, accepted — hashing is dwarfed by
+  // parsing + graph building, which the hit path avoids).
+  const scannedFiles = scanFiles(resolvedPath);
+  const fingerprint = computeRepositoryFingerprint(scannedFiles);
+  const cacheKey = `local:${resolvedPath}`;
 
+  const cachedRepository = getCachedRepository(cacheKey, "local", fingerprint);
+  const cachedGraph = getCachedGraph(cacheKey, "local", fingerprint);
+
+  let repository: Repository;
   let graph: DependencyGraph;
-  try {
-    graph = buildDependencyGraph(repository);
-  } catch (err) {
-    throw new ArcluxError({
-      code: "GRAPH_BUILD_FAILED",
-      message: "Graph construction failed",
-      cause: err,
-    });
+  let cacheHit = false;
+
+  if (cachedRepository && cachedGraph) {
+    // HIT: content identical, so the result is identical — but the ANCHOR
+    // may have moved (commit-without-change). Re-anchor stamp + clock to
+    // now so freshness stays truthful instead of pointing at the past.
+    const now = await getHeadState(resolvedPath);
+    cachedRepository.meta.buildHead = now.isRepo
+      ? { isRepo: true, commit: now.commit, dirty: now.dirty }
+      : null;
+    cachedRepository.meta.analyzedAt = new Date().toISOString();
+    repository = cachedRepository;
+    graph = cachedGraph;
+    cacheHit = true;
+  } else {
+    try {
+      repository = await buildIndex({ rootPath: resolvedPath, meta });
+    } catch (err) {
+      throw isArcluxError(err)
+        ? err
+        : new ArcluxError({ code: "INDEX_FAILED", message: "Indexing failed", cause: err });
+    }
+
+    try {
+      graph = buildDependencyGraph(repository);
+    } catch (err) {
+      throw new ArcluxError({
+        code: "GRAPH_BUILD_FAILED",
+        message: "Graph construction failed",
+        cause: err,
+      });
+    }
+
+    setCachedRepository(cacheKey, "local", fingerprint, repository);
+    setCachedGraph(cacheKey, "local", fingerprint, graph);
   }
 
   return {
@@ -261,6 +309,7 @@ async function analyzeLocalPath(localPath: string): Promise<AnalyzeRepositoryRes
     repository,
     dependencies: manifestRegistry.detectDependencies(resolvedPath),
     securityAnalysis: analyzeRepositorySecurity(repository, resolvedPath),
+    cacheHit,
   };
 }
 
@@ -306,13 +355,22 @@ async function analyzeRemoteRepository(
 
     let repository: Repository;
     let graph: DependencyGraph;
+    let cacheHit = false;
 
     const cachedRepository = getCachedRepository(repoUrl, meta.defaultBranch, fingerprint);
     const cachedGraph = getCachedGraph(repoUrl, meta.defaultBranch, fingerprint);
 
     if (cachedRepository && cachedGraph) {
+      // Same re-anchor honesty as the local flow: content identical, so
+      // re-anchor stamp + clock to now (a fresh clone is clean at HEAD).
+      const now = await getHeadState(localPath);
+      cachedRepository.meta.buildHead = now.isRepo
+        ? { isRepo: true, commit: now.commit, dirty: now.dirty }
+        : null;
+      cachedRepository.meta.analyzedAt = new Date().toISOString();
       repository = cachedRepository;
       graph = cachedGraph;
+      cacheHit = true;
     } else {
       try {
         repository = await buildIndex({ rootPath: localPath, meta });
@@ -349,6 +407,7 @@ async function analyzeRemoteRepository(
       repository,
       dependencies: manifestRegistry.detectDependencies(localPath),
       securityAnalysis: analyzeRepositorySecurity(repository, localPath),
+      cacheHit,
     };
   } finally {
     // Always clean up the temp clone, even if analysis threw partway through.

--- a/tests/pipeline-cache.test.ts
+++ b/tests/pipeline-cache.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Mikatoshi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Tests for the local-path fingerprint cache (analyzeLocalPath): content
+// fingerprint decides hit/miss (never timestamps), a hit returns the SAME
+// repository object with re-anchored stamp+clock, and any edit misses.
+// The honesty invariant: cacheHit + fresh stamp travel together.
+
+import { describe, it, expect, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { analyzeRepository } from "../packages/engine/pipeline";
+import { evaluateFreshness, getHeadState } from "../packages/git/headFreshness";
+
+const dirs: string[] = [];
+function track(dir: string): string {
+  dirs.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+});
+
+function git(dir: string, ...args: string[]): void {
+  execFileSync("git", ["-c", "user.email=t@t.co", "-c", "user.name=t", ...args], { cwd: dir });
+}
+
+function makeRepo(): string {
+  const dir = track(mkdtempSync(join(tmpdir(), "arclux-cache-")));
+  writeFileSync(join(dir, "a.ts"), "export function a() { return 1; }\n");
+  writeFileSync(join(dir, "b.ts"), 'import { a } from "./a";\nexport function b() { return a(); }\n');
+  git(dir, "init", "-q");
+  git(dir, "add", ".");
+  git(dir, "commit", "-qm", "one");
+  return dir;
+}
+
+describe("local fingerprint cache", () => {
+  it("miss then hit: second identical analysis returns the cached repository", async () => {
+    const dir = makeRepo();
+    const first = await analyzeRepository({ localPath: dir });
+    expect(first.cacheHit).toBe(false);
+    const second = await analyzeRepository({ localPath: dir });
+    expect(second.cacheHit).toBe(true);
+    expect(second.repository).toBe(first.repository);
+    expect(second.moduleCount).toBe(first.moduleCount);
+  }, 120000);
+
+  it("any content edit misses and rebuilds", async () => {
+    const dir = makeRepo();
+    const first = await analyzeRepository({ localPath: dir });
+    writeFileSync(join(dir, "a.ts"), "export function a() { return 2; }\n");
+    const second = await analyzeRepository({ localPath: dir });
+    expect(second.cacheHit).toBe(false);
+    expect(second.repository).not.toBe(first.repository);
+  }, 120000);
+
+  it("commit-without-change hits AND re-anchors the stamp (honest hit)", async () => {
+    const dir = makeRepo();
+    const first = await analyzeRepository({ localPath: dir });
+    const oldCommit = first.meta.buildHead?.commit;
+    // Empty commit: same content, new HEAD — the sharp edge.
+    git(dir, "commit", "-qm", "empty", "--allow-empty");
+    const second = await analyzeRepository({ localPath: dir });
+    expect(second.cacheHit).toBe(true);
+    expect(second.repository).toBe(first.repository);
+    // Re-anchored, not pointing at the past:
+    expect(second.meta.buildHead?.commit).not.toBe(oldCommit);
+    expect(second.meta.buildHead?.commit).toBe((await getHeadState(dir)).commit);
+    expect(evaluateFreshness(second.meta.buildHead ?? null, await getHeadState(dir))).toBe("FRESH");
+  }, 120000);
+});


### PR DESCRIPTION
analyzeLocalPath sekarang pakai fingerprint cache yang sama kayak remote (key local:<path>): konten identik -> skip buildIndex+graph; EDIT apa pun -> miss by construction (impossible stale mid-edit). Sharp edge commit-tanpa-ubah ditutup via re-anchor stamp+clock pas hit (hasil identik DAN jangkar kini). Jujur scope: in-memory saja (daemon/MCP/serve yang untung; CLI single-shot fresh process tetap miss — disk cache proyek terpisah, bukan janji). cacheHit flag di result buat konsumen programmatic. Test: 3 baru (hit/miss/edit/re-anchor+FRESH). Suite 3 gelombang: 8 gagal identik main bersih (pre-existing).