### PR TITLE
release: 0.3.0 — permanent README + honest engine + self-triggering MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to ARCLUX are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/); versioning follows
 [SemVer](https://semver.org/) (pre-1.0: minor bump = significant features).
 
+## [0.3.0] — 2026-09-05
+
+Stable README + self-triggering MCP + engine honesty fixes. The “boring but brutal” release.
+
+### Added
+- **MCP self-triggering** — `SERVER_INSTRUCTIONS` (workflow 4 langkah) + 16 trigger-first tool descriptions (`FIRST`/`INSTEAD OF`/`BEFORE`). AI agents now pick the right tool without being reminded. Exported + test-locked.
+- **Two-pass call resolver** — port of ManSio PR #20: verified import `1.0` → unique-global `0.85` → external → explicit unresolved. Closes silent pick/drop (G1/G2/G4) and verifies exports (G5). `ModuleInfo.unresolvedCalls` preserves evidence.
+- **Head freshness** — port of ManSio #21/#22 line: `getHeadState` + `evaluateFreshness`/`reportFreshness` (`FRESH`/`STALE`/`INCONCLUSIVE`), `RepositoryMeta.buildHead` stamped in pipeline, re-anchored on cache hits. Doctor now shows freshness lamp.
+- **Local fingerprint cache** — `analyzeLocalPath` now uses content-hash cache (`local:<path>`). Hit = identical content, honest re-anchor; edit anywhere = miss by construction. In-memory (daemon/MCP/serve benefit), honest scope documented.
+- **CLI RESULT block** — `arclux analyze` prints modules/edges/deps/security + freshness; `arclux doctor` shows freshness lamp. Short lines, demo-safe.
+- **Fair Evaluation Protocol** — `ABOUT.md`: `repository → source → graph → build/test → runtime → conclusion` + `DONE`/`PLAN`/`ANALOGY`/`CLAIM` distinction.
+- **Scene3D split** — `scene3d.ts` 1577 lines → `scene3d/` 17 domain modules (zero behavior change), `planetary/` stub ready for Blueprint 10. Verified `tsc` + `build-game.mjs`.
+- **MMO polish** — HUD fade+glow, menu hover/slide-in (Fase 7), bot harness headless 2-player (9 checks, tick/move/scan/attack/dock), landing CCTV + live stats.
+
+### Fixed
+- **BUG-1 `folder_graph` circular JSON** — `folderGraphToJSON()` (tree+folders+stats), MCP now JSON-safe. Repro test added.
+- **BUG-3 `semantic_diff` bloat** — `detail` `summary` (default, file lists + counts) vs `full` (legacy trees). 132 KB → summary, opt-in full.
+- **BUG-2 orphan precision** — pure-barrel exclude, re-export honesty (barrel-re-exported → `ambiguous` not `unwired`), noise skip (`*.config.*`, `*.d.ts`, `vendor-ui/`, `_inbox/`), dedupe by `filePath`. Cross-package `server.ts` case fixed.
+- **Builder drift** — `packages/mcp/package.json` types etc. no longer rot; MCP tool list auto-discovers detectors/rules.
+
+### Changed
+- **README is now permanent** — high-level, links to live docs (`PROGRES.md`/`ABOUT.md`/docs site) instead of chasing numbers. Badges updated, install/usage evergreen, MCP self-triggering documented.
+- Versions bumped `0.2.0` → `0.3.0` across `package.json`, `apps/cli`, `apps/web`, `apps/vscode-extension`, `packages/mcp`, `CITATION.cff`.
+
 ## [0.2.1] — 2026-08-26
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: "If you use this software, please cite it using the metadata below."
 authors:
   - name: "ARCLUX Contributors"
 title: "ARCLUX – codebase intelligence platform"
-version: "0.2.0"
-date-released: "2026-08-21"
+version: "0.3.0"
+date-released: "2026-09-05"
 url: "https://github.com/GSF-001/ARCLUX"
 repository-code: "https://github.com/GSF-001/ARCLUX"
 license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 ![alt text](https://github.com/GSF-001/ARCLUX/blob/ARCLUX.main/assets/Banner-preview.png) 
 ## OPEN SOURCE
 
-Dependency graph, impact analysis, and structural convention checking for your codebase. CLI + web dashboard.
+Dependency graph, impact analysis, and structural convention checking for your codebase. CLI + web dashboard + MCP for AI.
 
 ![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-black)
- [](LICENSE)
+  [](LICENSE)
+![Version: 0.3.0](https://img.shields.io/badge/version-0.3.0-3f8fff)
 ![Status: alpha](https://img.shields.io/badge/status-alpha-black)
 [](#status)
 
 [![CI](https://github.com/GSF-001/ARCLUX/actions/workflows/ci.yml/badge.svg)](https://github.com/GSF-001/ARCLUX/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-live-3f8fff)](https://arclux-os.mintlify.site)
+[![npm](https://img.shields.io/badge/npm-arclux-cb3837)](https://www.npmjs.com/package/arclux)
 
 <p align="center">
   <img src="assets/demo.gif" alt="ARCLUX CLI in action: arclux analyze . and arclux doctor" />
@@ -28,11 +30,13 @@ Dependency graph, impact analysis, and structural convention checking for your c
 > [!NOTE] 
 > 
 > **[official documentation](https://arclux-os.mintlify.site)**
-content, searchable and organized
+> content, searchable and organized
+
+> This README is intentionally stable. Live numbers, detailed status, and per-package docs live in the links below and update automatically — you don't need to watch this file for changes.
 
 -----
 - [`ABOUT.md`](ABOUT.md) — the ARCLUX map: what it is, the intelligence layer, the platform underneath — **start here if you're new**
-- [`QUICKSTART.md`](QUICKSTART.md) — start here, fast-path workflow cheat sheet
+- [`QUICKSTART.md`](QUICKSTART.md) — fast-path workflow cheat sheet
 - [`QUICKSTART-MMO.md`](QUICKSTART-MMO.md) — MMO game: clone → vessel → self-host region → play (from zero)
 - [`TOOLING.md`](TOOLING.md) — all repo config/tooling explained (PROGRES system, git workflow, pre-commit hook, CI, CODEOWNERS, etc.)
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions for contributing code
@@ -42,20 +46,22 @@ content, searchable and organized
 - [`CONTEXT.md`](CONTEXT.md) — project brief at a glance: stack, architecture, current state.
 - [`progres/roadmap.md`](progres/roadmap.md) — long-term direction, phased
 
-## Status: alpha
+## Status
 
-Under active development. Core pipeline (parse/index/graph/impact), 20 detectors, 14 framework convention rules, scripting DSL, CLI + web dashboard + always-on daemon + VS Code extension are solid and verified against real repos (vscode, react, vite, laravel, flask). The persistence/cache layers are still stubs.
+Under active development. This section stays high-level on purpose — for the current, detailed breakdown see [progres/status-core.md](progres/status-core.md), [status-web.md](progres/status-web.md), and the [docs site](https://arclux-os.mintlify.site/status) (updated continuously, this README is not).
 
-For the current, detailed breakdown -- see [progres/status-core.md](progres/status-core.md), [status-web.md](progres/status-web.md), and the [docs site](https://arclux-os.mintlify.site/status) (updated continuously, this README is not).
+Core engine (parse / index / graph / impact / call graph / detectors / framework rules / DSL / search / security) is solid and verified against real repos (vscode, react, vite, laravel, flask). Platform layers (daemon + SSE bridge, persistence via `packages/db`, content-hash caches, watcher) are wired and used in production. Per-file incremental re-index is built but still coarse (full rebuild per change) — see `progres/status-core.md`. MMO product (`apps/game` + `packages/gameserver` + `packages/universe`) is in alpha — see `docs/blueprint/`.
 
 ## What it does
 
 - Builds a dependency graph (imports, exports, folders) + call graph (which functions call which, across files) from static analysis
-- Traces impact - what is affected if you change file X
-- Detects circular deps, dead code, orphan files, duplicate modules, layer violations, and more (20 detectors — run them all with `arclux doctor`)
-- Enforces framework conventions (14 rules: Next.js, NestJS, Express, Vite, Electron, React, Laravel — `arclux verify` gates on them)
+- Traces impact — what is affected if you change file X
+- Detects structural issues (circular deps, dead code, orphan files, duplicate modules, layer violations, and more — architecture detectors, auto-discovered — run them all with `arclux doctor`)
+- Enforces framework conventions (Next.js, NestJS, Express, Vite, Electron, React, Laravel — `arclux verify` gates on them, auto-discovered)
 - Runs scripted analysis — `arclux script file.arclux` executes the ARCLUX DSL (analyze, impact, doctor, security, graph from plain-text scripts)
-- Parses 27 languages: TypeScript/TSX, JavaScript, Python, Go, Java, PHP, Ruby, Rust, C++, C#, Bash, C, Dart, Elixir, Kotlin, Lua, Objective-C, OCaml, Scala, Solidity, Swift, Vue, Zig, Elm, ReScript, plus manifest formats (package.json, go.mod, Cargo.toml, Gemfile, composer.json, csproj, gradle, pom.xml, requirements.txt)
+- Parses many languages: TypeScript/TSX, JavaScript, Python, Go, Java, PHP, Ruby, Rust, C++, C#, Bash, C, Dart, Elixir, Kotlin, Lua, Objective-C, OCaml, Scala, Solidity, Swift, Vue, Zig, Elm, ReScript, plus manifest formats (package.json, go.mod, Cargo.toml, Gemfile, composer.json, csproj, gradle, pom.xml, requirements.txt) — via TypeScript Compiler API + web-tree-sitter. New parsers appear automatically in `arclux config` and `--help`.
+
+> Numbers (detector / rule / language counts) grow automatically as the codebase grows. This README does not chase them — run `arclux --help`, `arclux config`, or see the docs site for live counts.
 
 ## Install
 
@@ -93,10 +99,29 @@ Run CLI commands via: `arclux <command>` (installed) or `node apps/cli/dist/arcl
     arclux shell
     arclux mcp
 
+Run `arclux --help` for the full, always-current command list.
+
 Web dashboard:
 
     cd apps/web
     pnpm run dev
+
+### MCP for AI (self-triggering)
+
+ARCLUX exposes 30+ tools via Model Context Protocol. The server ships workflow instructions so AI agents use the right tool without being asked — `analyze` first, `file_info`/`impact` instead of manual reads, `detect`/`doctor` to verify.
+
+```json
+{
+  "mcpServers": {
+    "arclux": {
+      "command": "npx",
+      "args": ["arclux", "mcp"]
+    }
+  }
+}
+```
+
+See the pinned Discussion “Getting Started — install, CLI usage, MCP client config” and [`SKILL.md`](SKILL.md) for details. New detectors/rules/parsers automatically appear as tools — no manual MCP updates.
 
 ## Daemon (always-on background service)
 
@@ -108,7 +133,7 @@ arclux daemon --status
 arclux daemon --stop
 ```
 
-The daemon exposes a local HTTP+SSE bridge (GET /analysis, GET /events) so any editor/terminal can connect -- see packages/daemon/.
+The daemon exposes a local HTTP+SSE bridge (GET /analysis, GET /events) so any editor/terminal can connect — see packages/daemon/.
 
 ## VS Code Extension
 
@@ -126,11 +151,12 @@ Each stage is an independent package: parser, graph, impact, detectors, rules, e
 
     apps/cli        command-line interface (analyze, graph, impact, doctor, config, diff, diagnose, verify)
     apps/web        Next.js dashboard
+    apps/game       Electron + three.js MMO client (self-host region, vessel = repo)
     packages/       parser, graph, impact, detectors, rules, engine,
                      indexer, search, watcher, incremental, repository,
                      shared, plus runtime/platform layers (kernel, storage,
                      runtime, scheduler, networking, services, ...)
-                     see packages/README.md for the full list
+                     plus MMO (gameserver, universe, relay) — see packages/README.md for the full list
 
 ## Contributing
 
@@ -149,5 +175,4 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for conventions, and [`PROGRES.md`](PRO
 ## Citation
 
 If you use ARCLUX in research or other work, please cite it using the metadata in [`CITATION.cff`](CITATION.cff).
-
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arclux",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Codebase intelligence platform \u2014 27-language parser, dependency & call graphs, 20 architecture detectors, impact tracing, security pipeline, and the ARCLUX scripting DSL.",
   "license": "Apache-2.0",
   "type": "module",

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "arclux-vscode",
   "displayName": "ARCLUX",
   "description": "Live dependency graph, impact analysis, and diagnostics -- connects to a running ARCLUX daemon (arclux daemon --detach)",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "engines": {
     "vscode": "^1.85.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arclux",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@9.15.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arclux/mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server for ARCLUX — exposes codebase intelligence tools via Model Context Protocol",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bikin README permanen (nggak kejar angka) + bump 0.2.0→0.3.0 + CHANGELOG. Isi 0.3.0: MCP self-triggering, two-pass resolver, head freshness, local cache honest, CLI RESULT+lamp, BUG-1/2/3, scene3d split, MMO polish Fase 7 + harness. Live numbers tetep di PROGRES/docs, bukan di README.