### PR TITLE
docs(progres): sync 0.3.0 batch — non-MMO work since 08-26

### DIFF
--- a/progres/status-core.md
+++ b/progres/status-core.md
@@ -833,6 +833,22 @@ New packages/incremental with Cell/Database/Query classes for per-file cache inv
 
 ## 2026-08-26 — MCP server + npm publish milestone
 
-**Status:** In Progress
+**Status:** Done
 
-MCP server (32 tools) and npm publish package are both built and ready. MCP server: 32 registry-driven tools, all auto-evolving. npm package: arclux@0.2.0, single 10.2MB bundle via esbuild, ships dist/ + wasms/ tree-sitter grammars. One command: npx arclux analyze . or npx arclux mcp. Blocked on npm login — machine needs npm adduser or NPM_TOKEN.
+MCP server (32 tools) and npm publish package are both built and ready. MCP server: 32 registry-driven tools, all auto-evolving. npm package: arclux@0.2.0, single 10.2MB bundle via esbuild, ships dist/ + wasms/ tree-sitter grammars. One command: npx arclux analyze . or npx arclux mcp. Published as `arclux` on npm (v0.2.0).
+
+## 2026-09-05 — 0.3.0 engine honesty batch: two-pass resolver, freshness, local cache, CLI RESULT
+
+**Status:** Done — PRs #654, #655, #660, #661 — all merged to `ARCLUX.main` (v0.3.0)
+
+This batch ports the ManSio honesty line (PR #20 freshness) and closes 3 silent-failure classes in the engine:
+
+- **Two-pass call resolver** (`packages/graph/resolveCalls.ts`, port of ManSio PR #20): ladder verified import `1.0` → unique-global `0.85` → external → explicit unresolved. Fixes G1 (last-write-wins → explicit `ambiguous`), G2 (default-import via `RawImport.defaultLocalName` + verified `hasDefaultExport`), G4 (nothing drops silently — `ModuleInfo.unresolvedCalls`), G5 partial (verifies target actually exports the name). New types: `ResolvedCall.confidence`/`resolver`, `UnresolvedCall` (`ambiguous`/`external`/`unknown`), `RawImport.defaultLocalName`. `buildIndex` pre-resolves every import (internal vs external) once, builds repo-wide `exportMap`/`hasDefaultExport`/`globalNameMap`, calls `resolveModuleCalls` per module. Exports verified via `tests/graph-resolver.test.ts` (14) + updated `tests/graph-callgraph.test.ts` (5 expectations now assert confidence — target unchanged). Full suite 8 failing identical to main (pre-existing). Deviation documented: no `DEPENDENCY` nodes — call graph stays file-node-only (external recorded, not materialized).
+
+- **Head freshness** (`packages/git/headFreshness.ts`, port of ManSio #21/#22 line): `HeadState` (`isRepo`/`commit`/`dirty`), `getHeadState` (never throws, non-git → `INCONCLUSIVE`), `evaluateFreshness` (7-case contract: `FRESH` only `build==HEAD && clean`, else `STALE`/`INCONCLUSIVE` fail-closed), `reportFreshness` (human wording). `RepositoryMeta.buildHead` stamped in `pipeline.ts` (both local + clone paths, now `{isRepo,commit,dirty}` — earlier `{commit,dirty}` shaped bug caught live and fixed). `tests/git-freshness.test.ts` 15 cases incl. end-to-end `analyzeRepository → FRESH`.
+
+- **Local fingerprint cache** (`packages/engine/pipeline.ts`): `analyzeLocalPath` now fingerprint-first (`local:<resolvedPath>` key, same `computeRepositoryFingerprint` as remote). Hit = identical content, honest re-anchor of `buildHead`+`analyzedAt` to now (closes commit-without-change sharp edge); edit anywhere = miss by construction. In-memory only — long-running processes (daemon/MCP/serve) benefit, single-shot CLI fresh processes miss (documented, no false promise). `cacheHit` flag on `AnalyzeRepositoryResult`. `tests/pipeline-cache.test.ts` 3 cases (hit/miss/re-anchor+FRESH).
+
+- **CLI RESULT + freshness lamp** (`apps/cli/analyze.ts`, `doctor.ts`): `analyze` prints `RESULT org/name — modules, edges, dependencies` + `Security` + `Analyzed at` + `Freshness: FRESH/STALE/INCONCLUSIVE — detail` (short lines, demo-safe). `doctor` shows freshness lamp (analysis just built → `FRESH` on clean, `STALE` = built on dirty tree with explained wording, not alarm). Both verified live: `FRESH` on clean tinyrepo, `STALE` on dirty tree. `tests/git-freshness` extended.
+
+**Honest scope:** in-memory cache only; disk cache of live `Repository` (Map inside) would need serialization — separate project. Per-file incremental (`packages/incremental`) remains coarse (full rebuild) — decision #6 still holds, but this cache already kills the 21-minute repeat cost for `daemon`/`watch` loops.

--- a/progres/status-detectors.md
+++ b/progres/status-detectors.md
@@ -170,6 +170,19 @@ Two additions, verified end-to-end on ~/flask (25 orphan findings):
 Real-repo result on ~/flask: 25 orphans → 7 ambiguous / 11 dead / 7 unwired; 5 with integration suggestions; best suggestion `views.py → src/flask/app.py` (high 0.69 via 11 siblings). 12 new tests in tests/orphan-integration.test.ts → suite 641→653, typecheck clean.
 ARCLUX.main
 
+## 2026-09-05 — Orphan precision (BUG-2): barrel, re-export, noise, dedupe
+
+**Status:** Done — PR #658 — `packages/detectors/detectOrphanFiles.ts` + `tests/orphan-integration.test.ts` (4 new, 16 total)
+
+Fixes the “523 findings” noise case where `server.ts` (gameserver) was called unwired while its consumers lived outside the analyzed scope:
+
+- **Pure-barrel exclude** — modules where every export is `re-export` (`export *` wall, e.g. `gameserver/index.ts`) are public API surfaces, excluded like entry points. Decided from `RawExport.kind` alone, no file I/O.
+- **Re-export honesty** — `reExportedBy` map (moduleId → barrel ids in scope). Module re-exported by an in-scope barrel but with zero direct importers → `ambiguous` with evidence (“re-exported by N barrel(s) … consumers may live outside it”), never `unwired`.
+- **Noise skip** — `isNoisePath` (`*.config.*`, `*.d.ts`, `vendor-ui/`, `_inbox/`) — reporting `next.config.ts` etc. buried real signal.
+- **Dedupe** — dedupe by `filePath` (one file, one verdict) — fixes 9× `impactStore.ts` case where upstream merge surfaced same module twice.
+
+All decisions are pure-Repository (no file I/O, no package.json read) — detector stays mappable via MCP.
+
 ## 08-20 — 13 parser baru (12 → 25 bahasa, 38 extension)
 - Batch #529: bash, c, dart, elixir, kotlin, lua, objc, ocaml, scala, solidity,
   swift, vue, zig — semua lewat `makeTreeSitterParser()` factory config-driven

--- a/progres/status-infra.md
+++ b/progres/status-infra.md
@@ -593,6 +593,20 @@ Adding a new rule: 1 import + 1 entry in ALL_RULES → auto-wired to run_rules.
 
 Single-file CLI bundle (apps/cli/dist/arclux.mjs, ~10MB) via esbuild. Package name 'arclux' confirmed free on npm. ships dist/ + wasms/ (tree-sitter grammars). bin: arclux. engines: node>=20. prepublishOnly runs build-cli.mjs. Verified: pnpm install works, arclux --version outputs 0.2.0.
 
+## 2026-09-05 — MCP self-triggering + honesty infra (BUG-1/3)
+
+**Status:** Done — PRs #656, #657, #659 — all merged to `ARCLUX.main` (v0.3.0)
+
+This batch makes MCP discoverable and fixes two infra bugs that killed agent context:
+
+- **MCP self-triggering** (`packages/mcp/src/index.ts`, PR #659): `SERVER_INSTRUCTIONS` (workflow 4 langkah shown at connect time: `FIRST` analyze before opening files → `NEVER` guess relationships → `BEFORE` edit run `impact` → `AFTER` verify via `detect`/`doctor`) + 16 trigger-first tool descriptions (`FIRST`/`INSTEAD OF`/`BEFORE`/`NEVER guess`). `SERVER_INSTRUCTIONS` + `TOOLS` exported and test-locked (`tests/mcp-triggers.test.ts` 4 cases: tool without trigger → suite fails). Complements existing `SKILL.md` for Claude Code/Cursor. Note: instructions are strong invites, not enforcement — model can still ignore, but now has a reason at every tool.
+
+- **BUG-1 `folder_graph` circular JSON** (`packages/graph/buildFolderGraph.ts`, PR #656): `HierarchyNode` carries `parent` pointers → `JSON.stringify` threw “Converting circular structure … parent closes the circle” on every repo (4/4 repro). Fix: `FolderGraphJSON` (`tree`+`folders`+`stats` depth/nodeCount/fileCount/folderCount) via `folderGraphToJSON()`, MCP now returns it; raw `HierarchyNode` stays internal. `buildFolderGraph` signature unchanged — web’s `.tree` path untouched. `tests/graph-folder.test.ts` 3 cases incl. repro crash.
+
+- **BUG-3 `semantic_diff` bloat** (`packages/semantic-diff/SemanticDiff.ts`, PR #657): full `impactByModule` + `SymbolInfo` arrays bloated MCP response to 132 KB (truncated, ate agent context). Fix: `detail` `summary` (default, file lists + counts + `moved` only) vs `full` (legacy complete, opt-in `detail:"full"`). MCP schema passthrough. `tests/semantic-diff-modes.test.ts` 3 cases (summary smaller than full, legacy shape preserved).
+
+Also in this window: `docs/blueprint/09-client-polish.md` split follow-ups and `apps/game` scene3d modularization (see below) — infra fixes landed first so MCP remains usable for those.
+
 ## 2026-08-26 — Branch cleanup: 150+ stale local branches deleted
 
 **Status:** Done


### PR DESCRIPTION
Bikin PROGRES yang ketinggalan jauh jadi sinkron sama rilis 0.3.0 (selain MMO yang udah di MMO-IMPLEMENTATION):\n- status-core: two-pass resolver, freshness, local cache, CLI RESULT (PR #654/#655/#660/#661)\n- status-detectors: orphan precision BUG-2\n- status-infra: MCP self-triggering + BUG-1 folder_graph + BUG-3 semantic_diff\nMMO tetep di docs/blueprint/progres/ — nggak dicampur biar nggak bingung pas balik Fase 8.