### PR TITLE
feat(game): 09 Fase 8 iris 5 — CharacterEntity + DockingState switch

### DIFF
--- a/apps/game/src/renderer/renderer.ts
+++ b/apps/game/src/renderer/renderer.ts
@@ -19,7 +19,10 @@ import { initAudio, type AudioHandle } from "./audio";
 import { initMenu, type MenuHandle, type MenuCameraMode } from "./menu";
 import { initLanding } from "./landing";
 import { loadSettings } from "./settings";
+import { buildArkInterior } from "./interior";
 import type { RegionSnapshot, VesselEntity, WorldEntity } from "../../../../packages/gameserver/types";
+
+export type DockingState = "EXTERIOR" | "ENTERING" | "INTERIOR";
 
 export interface RendererHandle {
   scene: Scene3D;
@@ -28,6 +31,9 @@ export interface RendererHandle {
   input: InputHandle;
   audio: AudioHandle;
   menu: MenuHandle;
+  dockingState: DockingState;
+  enterInterior(): void;
+  exitInterior(): void;
   dispose(): void;
 }
 
@@ -59,6 +65,33 @@ export function bootstrapRenderer(opts?: { serverUrl?: string }): RendererHandle
     onCameraMode: (mode) => scene.setCameraMode(mode as Parameters<Scene3D["setCameraMode"]>[0]),
     onSfx: (kind) => audio.ui(kind === "click" ? "click" : "hover"),
   }, audio);
+
+  // Iris 5 — DockingState + lazy interior (corridor+promenade+plaza+96 habitat)
+  let dockingState: DockingState = "EXTERIOR";
+  let interiorGroup: import("three").Group | null = null;
+  let interiorBounds: import("three").Box3[] = [];
+  const enterInterior = (): void => {
+    if (dockingState !== "EXTERIOR") return;
+    dockingState = "ENTERING";
+    if (!interiorGroup) {
+      const built = buildArkInterior();
+      interiorGroup = built.group;
+      interiorBounds = built.walkBounds;
+      scene.addGroup(interiorGroup);
+      input.setWalkBounds(interiorBounds);
+    } else {
+      scene.addGroup(interiorGroup);
+    }
+    input.setInteriorMode("FPS_INTERIOR");
+    input.setInteriorPosition({ x: 0, y: 0, z: 0 });
+    dockingState = "INTERIOR";
+  };
+  const exitInterior = (): void => {
+    if (dockingState !== "INTERIOR") return;
+    dockingState = "EXTERIOR";
+    input.setInteriorMode("EXTERIOR");
+    if (interiorGroup) scene.removeGroup(interiorGroup);
+  };
   // Fase 5 — wire explosion/shield/debris sfx ke scene (server-authoritative, client hanya play)
   scene.setSfxHandler((kind) => {
     try {
@@ -132,6 +165,8 @@ export function bootstrapRenderer(opts?: { serverUrl?: string }): RendererHandle
   // Unlock audio + buka menu di ESC (interaction-driven, autoplay policy).
   const onDocClick = (): void => { audio.unlock(); };
   const onKeyDown = (e: KeyboardEvent): void => {
+    if (e.code === "KeyF" && dockingState === "EXTERIOR") { e.preventDefault(); enterInterior(); return; }
+    if (e.code === "Escape" && dockingState === "INTERIOR") { e.preventDefault(); exitInterior(); return; }
     if (e.code === "Escape" && !menu.isOpen) { e.preventDefault(); menu.open(); audio.ui("click"); }
   };
   document.addEventListener("click", onDocClick, { once: true });
@@ -152,9 +187,13 @@ export function bootstrapRenderer(opts?: { serverUrl?: string }): RendererHandle
   };
 
   // Expose for manual control in devtools
-  if (typeof window !== "undefined") (window as any).__arcluxRenderer = { scene, net, hud, input, audio, menu };
+  if (typeof window !== "undefined") (window as any).__arcluxRenderer = { scene, net, hud, input, audio, menu, get dockingState() { return dockingState; }, enterInterior, exitInterior };
 
-  return { scene, hud, net, input, audio, menu, dispose };
+  return {
+    scene, hud, net, input, audio, menu,
+    get dockingState(): DockingState { return dockingState; },
+    enterInterior, exitInterior, dispose,
+  };
 }
 
 if (typeof document !== "undefined") {

--- a/apps/game/src/renderer/scene3d/index.ts
+++ b/apps/game/src/renderer/scene3d/index.ts
@@ -44,6 +44,8 @@ export interface Scene3D {
   applyQuality(settings: GameSettings): void;
   setLookYawPitch(yaw: number, pitch: number): void;
   setSfxHandler(cb: (kind: "explosion" | "shield" | "debris") => void): void;
+  addGroup(g: THREE.Group): void;
+  removeGroup(g: THREE.Group): void;
   dispose(): void;
 }
 
@@ -192,6 +194,8 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
     applyQuality: (s: GameSettings) => applyQuality(ctx, s),
     setLookYawPitch: (yaw: number, pitch: number) => setLookYawPitch(ctx, yaw, pitch),
     setSfxHandler: (cb: (kind: "explosion" | "shield" | "debris") => void) => { ctx.sfxHandler = cb; },
+    addGroup: (g: THREE.Group) => ctx.scene.add(g),
+    removeGroup: (g: THREE.Group) => ctx.scene.remove(g),
     dispose,
   };
 }

--- a/packages/gameserver/types.ts
+++ b/packages/gameserver/types.ts
@@ -23,7 +23,7 @@ export interface Vec3 {
 
 export type FactionId = string;
 
-export type EntityKind = "vessel" | "station";
+export type EntityKind = "vessel" | "station" | "character";
 
 /** Base identity shared by every in-world entity. */
 export interface GameEntity {
@@ -59,7 +59,15 @@ export interface StationEntity extends GameEntity {
   communityId?: string;
 }
 
-export type WorldEntity = VesselEntity | StationEntity;
+/** A pilot avatar inside Ark/stadium interior (Fase 8 iris 5, walkable). */
+export interface CharacterEntity extends GameEntity {
+  kind: "character";
+  /** Vessel induk yang dimiliki pilot ini. */
+  vesselId: string;
+  deck: "hangar" | "promenade" | "plaza" | "habitat" | "corridor";
+}
+
+export type WorldEntity = VesselEntity | StationEntity | CharacterEntity;
 
 /** Live state of a single region (a shard's world). */
 export interface RegionState {

--- a/packages/gameserver/world.ts
+++ b/packages/gameserver/world.ts
@@ -10,7 +10,7 @@
 // simulation engine). The region owns its entities; external code never
 // mutates the map directly.
 
-import type { GameEntity, RegionSnapshot, StationEntity, VesselEntity, WorldEntity } from "./types";
+import type { CharacterEntity, GameEntity, RegionSnapshot, StationEntity, VesselEntity, WorldEntity } from "./types";
 
 export interface SpawnVesselOptions {
   id: string;
@@ -26,6 +26,14 @@ export interface SpawnStationOptions {
   communityId?: string;
   position?: { x: number; y: number; z: number };
   safeZoneRadius?: number;
+}
+
+export interface SpawnCharacterOptions {
+  id: string;
+  owner?: string;
+  vesselId: string;
+  deck?: CharacterEntity["deck"];
+  position?: { x: number; y: number; z: number };
 }
 
 /**
@@ -129,6 +137,29 @@ export class WorldRegion {
     };
     this.entities.set(entity.id, entity);
     return entity;
+  }
+
+  spawnCharacter(opts: SpawnCharacterOptions): CharacterEntity {
+    if (this.entities.has(opts.id)) {
+      throw new Error(`Entity already exists in region: ${opts.id}`);
+    }
+    const entity: CharacterEntity = {
+      id: opts.id,
+      kind: "character",
+      owner: opts.owner,
+      vesselId: opts.vesselId,
+      deck: opts.deck ?? "plaza",
+      position: opts.position ?? { x: 0, y: 0, z: 0 },
+      velocity: { x: 0, y: 0, z: 0 },
+      heading: { yaw: 0, pitch: 0 },
+    };
+    this.entities.set(entity.id, entity);
+    return entity;
+  }
+
+  getCharacter(id: string): CharacterEntity | undefined {
+    const e = this.entities.get(id);
+    return e?.kind === "character" ? e : undefined;
   }
 
   remove(id: string): boolean {


### PR DESCRIPTION
Iris 5/6 Fase 8. Server: CharacterEntity kind "character" (vesselId, deck), WorldEntity union expanded, WorldRegion.spawnCharacter/getCharacter + RegionState/Snapshot include characters (persistence otomatis). Client: DockingState EXTERIOR/ENTERING/INTERIOR, lazy buildArkInterior + walkBounds, scene.addGroup/removeGroup (scene3d facade), F toggle enter / Esc exit, input FPS mode switch. Verify: tsc clean, build-game.mjs OK.