### PR TITLE
feat(game): 09 Fase 8 iris 6 — camera FPS + HUD deck (Fase 8 complete)

### DIFF
--- a/apps/game/src/renderer/hud.ts
+++ b/apps/game/src/renderer/hud.ts
@@ -18,12 +18,15 @@ import { colors, typography, spacing, glow } from "../ui/tokens";
 export interface Hud {
   update(region: RegionState): void;
   setTick(tick: number): void;
+  /** Iris 6: interior deck HUD (F walks, deck name, pos). */
+  setInterior(deck: string, pos: { x: number; y: number; z: number }): void;
+  clearInterior(): void;
   dispose(): void;
 }
 
 export function initHud(container?: HTMLElement): Hud {
   const root = container ?? (typeof document !== "undefined" ? document.body : null);
-  if (!root) return { update: () => {}, setTick: () => {}, dispose: () => {} };
+  if (!root) return { update: () => {}, setTick: () => {}, setInterior: () => {}, clearInterior: () => {}, dispose: () => {} };
 
   const el = document.createElement("div");
   el.id = "arclux-hud";
@@ -52,6 +55,7 @@ export function initHud(container?: HTMLElement): Hud {
     <div data-hud="top" style="position:absolute;top:${spacing.inset};left:50%;transform:translateX(-50%);text-align:center">
       <div data-hud="region" style="font-family:${typography.display};${typography.displaySpacing && `letter-spacing:${typography.displaySpacing}`};font-size:${typography.sizes.display};font-weight:700;color:${colors.foreground};text-transform:uppercase">—</div>
       <div data-hud="sysmeta" style="font-size:${typography.sizes.micro};color:${colors.muted};margin-top:4px;text-transform:uppercase;font-weight:400">SYSTEM ONLINE</div>
+      <div data-hud="deck" style="font-size:${typography.sizes.micro};color:${colors.tactical};margin-top:6px;letter-spacing:1px;display:none"></div>
     </div>
 
     <div data-hud="left" style="position:absolute;left:${spacing.inset};top:50%;transform:translateY(-50%);width:${spacing.panelWidthLeft};${panelFade};${panelEdgeL}">
@@ -179,9 +183,20 @@ export function initHud(container?: HTMLElement): Hud {
     if (tickEl) tickEl.textContent = `TICK ${tick}`;
   };
 
+  const setInterior = (deck: string, pos: { x: number; y: number; z: number }): void => {
+    const deckEl = q('[data-hud="deck"]');
+    if (!deckEl) return;
+    deckEl.style.display = "block";
+    deckEl.textContent = `DECK ${deck.toUpperCase()} — ${Math.round(pos.x)}, ${Math.round(pos.y)}, ${Math.round(pos.z)}`;
+  };
+  const clearInterior = (): void => {
+    const deckEl = q('[data-hud="deck"]');
+    if (deckEl) { deckEl.style.display = "none"; deckEl.textContent = ""; }
+  };
+
   const dispose = () => { if (el.parentElement) el.parentElement.removeChild(el); };
 
-  return { update, setTick, dispose };
+  return { update, setTick, setInterior, clearInterior, dispose };
 }
 
 function factionColorFor(faction: string): string {

--- a/apps/game/src/renderer/input.ts
+++ b/apps/game/src/renderer/input.ts
@@ -31,6 +31,7 @@ export interface InputHandle {
   setWalkBounds(bounds: import("three").Box3[]): void;
   getInteriorPosition(): { x: number; y: number; z: number };
   setInteriorPosition(p: { x: number; y: number; z: number }): void;
+  getLook(): { yaw: number; pitch: number };
 }
 
 export function initInput(opts: {
@@ -272,6 +273,7 @@ export function initInput(opts: {
     setWalkBounds(bounds) { walkBounds = bounds; },
     getInteriorPosition() { return { ...interiorPos }; },
     setInteriorPosition(p) { interiorPos = { ...p }; interiorVel = { x: 0, y: 0, z: 0 }; onGround = true; },
+    getLook() { return { yaw: lookYaw, pitch: lookPitch }; },
   };
 }
 

--- a/apps/game/src/renderer/renderer.ts
+++ b/apps/game/src/renderer/renderer.ts
@@ -85,13 +85,38 @@ export function bootstrapRenderer(opts?: { serverUrl?: string }): RendererHandle
     input.setInteriorMode("FPS_INTERIOR");
     input.setInteriorPosition({ x: 0, y: 0, z: 0 });
     dockingState = "INTERIOR";
+    if (!interiorPoll) {
+      interiorPoll = setInterval(() => {
+        if (dockingState !== "INTERIOR") return;
+        const pos = input.getInteriorPosition();
+        const { yaw, pitch } = input.getLook();
+        hud.setInterior(deckForPos(pos), pos);
+        scene.setInteriorCamera(pos, yaw, pitch);
+      }, 1000 / 30);
+    }
   };
   const exitInterior = (): void => {
     if (dockingState !== "INTERIOR") return;
     dockingState = "EXTERIOR";
     input.setInteriorMode("EXTERIOR");
     if (interiorGroup) scene.removeGroup(interiorGroup);
+    hud.clearInterior();
+    if (interiorPoll) { clearInterval(interiorPoll); interiorPoll = null; }
   };
+
+  // Iris 6: HUD deck + camera FPS follow interiorPos
+  const deckForPos = (p: { x: number; y: number; z: number }): string => {
+    if (Math.abs(p.x) < 400 && Math.abs(p.z) < 400) return "plaza";
+    if (Math.abs(p.x) < 2100 && Math.abs(p.z) < 40) return "corridor";
+    for (let r = 0; r < 4; r++) {
+      const radius = 640 + r * 46;
+      const cx = -400 + r * 500;
+      const d = Math.hypot(p.x - cx, p.z);
+      if (Math.abs(d - radius) < 40) return "promenade";
+    }
+    return "habitat";
+  };
+  let interiorPoll: ReturnType<typeof setInterval> | null = null;
   // Fase 5 — wire explosion/shield/debris sfx ke scene (server-authoritative, client hanya play)
   scene.setSfxHandler((kind) => {
     try {
@@ -176,6 +201,7 @@ export function bootstrapRenderer(opts?: { serverUrl?: string }): RendererHandle
 
   const dispose = () => {
     try { ambientHandle?.stop(); } catch {}
+    if (interiorPoll) { clearInterval(interiorPoll); interiorPoll = null; }
     hideLanding();
     stop();
     input.detach();

--- a/apps/game/src/renderer/scene3d/index.ts
+++ b/apps/game/src/renderer/scene3d/index.ts
@@ -46,6 +46,8 @@ export interface Scene3D {
   setSfxHandler(cb: (kind: "explosion" | "shield" | "debris") => void): void;
   addGroup(g: THREE.Group): void;
   removeGroup(g: THREE.Group): void;
+  /** Iris 6: FPS interior camera follow local pos */
+  setInteriorCamera(pos: { x: number; y: number; z: number }, yaw: number, pitch: number): void;
   dispose(): void;
 }
 
@@ -187,6 +189,18 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
   ctx.lastSnapshotAt = ctx.lastFrame;
   ctx.rafId = requestAnimationFrame(frame);
 
+  const setInteriorCamera = (pos: { x: number; y: number; z: number }, yaw: number, pitch: number): void => {
+    const cam = ctx.camera;
+    if (!cam) return;
+    const eye = 1.7;
+    cam.position.set(pos.x, pos.y + eye, pos.z);
+    const d = 10;
+    const lx = pos.x + Math.sin(yaw) * Math.cos(pitch) * d;
+    const ly = pos.y + eye + Math.sin(pitch) * d;
+    const lz = pos.z + Math.cos(yaw) * Math.cos(pitch) * d;
+    cam.lookAt(lx, ly, lz);
+  };
+
   return {
     renderRegion,
     updateVessel: (v: VesselEntity) => updateVessel(ctx, v),
@@ -196,6 +210,7 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
     setSfxHandler: (cb: (kind: "explosion" | "shield" | "debris") => void) => { ctx.sfxHandler = cb; },
     addGroup: (g: THREE.Group) => ctx.scene.add(g),
     removeGroup: (g: THREE.Group) => ctx.scene.remove(g),
+    setInteriorCamera,
     dispose,
   };
 }


### PR DESCRIPTION
Iris 6/6 — nutup Fase 8. HUD: setInterior/clearInterior + deck element (DECK PLAZA/CORRIDOR/PROMENADE/HABITAT + pos), walkBounds-aware deckForPos. Scene: Scene3D.setInteriorCamera(pos,yaw,pitch) + eye 1.7m. Renderer: DockingState poll 30Hz → hud.setInterior + scene.setInteriorCamera, F enter / Esc exit, input.getLook(). Di atas iris 1-5 (96 habitat + plaza + corridor/promenade + lighting + FPS Box3 + CharacterEntity). Verify: tsc clean, build-game.mjs OK. Acceptance Fase 8 6/6.