### PR TITLE
fix(cli): 0.3.1 robust version + doctor dynamic (clean PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to ARCLUX are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/); versioning follows
 [SemVer](https://semver.org/) (pre-1.0: minor bump = significant features).
 
+## [0.3.1] — 2026-09-06
+
+### Fixed
+- **CLI --version on npm install** — `resolveVersion()` now walks up from `import.meta.url` (handles `dist/arclux.mjs → ../package.json` npm layout). Verified: `npm pack → npm install → arclux --version → 0.3.1`. Fixes `0.0.0` fallback.
+- **doctor --help stale count** — `10/18` → dynamic `DETECTORS.length` (20, includes `orphanIntegration`). Single source of truth, never stale.
+- **Build break** — removed duplicate resolver fragment that left `const program` inside `try` (esbuild `Expected "finally" but found "const"`).
+
 ## [0.3.0] — 2026-09-05
 
 Stable README + self-triggering MCP + engine honesty fixes. The “boring but brutal” release.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ message: "If you use this software, please cite it using the metadata below."
 authors:
   - name: "ARCLUX Contributors"
 title: "ARCLUX – codebase intelligence platform"
-version: "0.3.0"
-date-released: "2026-09-05"
+version: "0.3.1"
+date-released: "2026-09-06"
 url: "https://github.com/GSF-001/ARCLUX"
 repository-code: "https://github.com/GSF-001/ARCLUX"
 license: Apache-2.0

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arclux",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Codebase intelligence platform \u2014 27-language parser, dependency & call graphs, 20 architecture detectors, impact tracing, security pipeline, and the ARCLUX scripting DSL.",
   "license": "Apache-2.0",
   "type": "module",

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "arclux-vscode",
   "displayName": "ARCLUX",
   "description": "Live dependency graph, impact analysis, and diagnostics -- connects to a running ARCLUX daemon (arclux daemon --detach)",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "engines": {
     "vscode": "^1.85.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arclux",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@9.15.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arclux/mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for ARCLUX — exposes codebase intelligence tools via Model Context Protocol",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Clean PR — previous 680 already merged, this is the 0.3.1 follow-up that was pushed to merged branch by mistake. Same fix: walk-up version resolver (handles ../package.json npm layout) + doctor 20 dynamic. Verified npm pack → 0.3.1.