### PR TITLE
feat(gameserver+game): 10.3 chunks — streaming LOD + persist Vec3

### DIFF
--- a/apps/game/src/renderer/scene3d/planetary/chunks.ts
+++ b/apps/game/src/renderer/scene3d/planetary/chunks.ts
@@ -1,5 +1,8 @@
-// 10.3 chunks visual — LOD cull, streaming (standalone visual, no cross-import)
-import * as THREE from "three";
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+//
 function toRegionId(c: { planetId: string; x: number; z: number }): string { return `${c.planetId}:${c.x}:${c.z}`; }
 export class ChunkManager {
   private active = new Set<string>();

--- a/packages/gameserver/planetary/chunks.ts
+++ b/packages/gameserver/planetary/chunks.ts
@@ -1,5 +1,8 @@
 // Copyright 2026 GSF-001
-// 10.3 chunks — streaming LOD, cull, planetId:chunkX:chunkZ via claimRegion, Vec3 persist
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+//
 export interface ChunkKey { planetId: string; x: number; z: number; }
 export function toRegionId(c: ChunkKey): string { return `${c.planetId}:${c.x}:${c.z}`; }
 export function fromRegionId(id: string): ChunkKey | null {


### PR DESCRIPTION
## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
