### PR TITLE
feat(10.6): strategic geography + night emissive + radar 50000 + Arcl…

### DIFF
--- a/apps/game/src/renderer/scene3d/index.ts
+++ b/apps/game/src/renderer/scene3d/index.ts
@@ -23,6 +23,9 @@ import { createPost } from "./post";
 // Iris 1: interior geometry (corridor+promenade) ready — lazy-load DockingState wired in iris 2
 import { buildArkInterior as _buildArkInterior } from "../interior";
 void _buildArkInterior;
+// 10.x planetary barrel — ensures terrain/ocean/atmosphere/chunks/surface/facilities/night/geography wired (10.2-10.6)
+import * as _planetary from "./planetary";
+void _planetary;
 import { buildStars } from "./stars";
 import { buildNebula } from "./nebula";
 import { buildSuns, updateSuns } from "./suns";

--- a/apps/game/src/renderer/scene3d/planetary/atmosphere.ts
+++ b/apps/game/src/renderer/scene3d/planetary/atmosphere.ts
@@ -4,7 +4,7 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/atmosphere.ts — 10.2 atmosphere Sphere 1.018 + clouds 512 per-kind, depthWrite:false, scattering
+// planetary/atmosphere.ts - 10.2 atmosphere Sphere 1.018 + clouds 512 per-kind, depthWrite:false, scattering
 
 import * as THREE from "three";
 import { makeCloudTexture } from "../planets";
@@ -12,18 +12,18 @@ import type { PlanetKind } from "../planets";
 export function createAtmosphere(radius: number, kind: PlanetKind): THREE.Group {
   const g = new THREE.Group();
   g.name = `atmosphere-${kind}`;
-  // Rayleigh scattering shell — subtle blue, BackSide
+  // Rayleigh scattering shell - subtle blue, BackSide
   const atmoMat = new THREE.MeshStandardMaterial({ transparent: true, opacity: 0.14, depthWrite: false, side: THREE.BackSide, color: 0x87ceeb, emissive: 0x87ceeb, emissiveIntensity: 0.12 });
   const atmo = new THREE.Mesh(new THREE.SphereGeometry(radius * 1.018, 32, 32), atmoMat);
   g.add(atmo);
-  // Cloud shell — per-kind texture, depthWrite:false so terrain not z-fighting, double side for interior view
+  // Cloud shell - per-kind texture, depthWrite:false so terrain not z-fighting, double side for interior view
   const cloudTex = makeCloudTexture(kind, 512);
   cloudTex.wrapS = cloudTex.wrapT = THREE.RepeatWrapping;
   const cloudMat = new THREE.MeshStandardMaterial({ map: cloudTex, transparent: true, opacity: 0.42, depthWrite: false, roughness: 1, metalness: 0 });
   const cloud = new THREE.Mesh(new THREE.SphereGeometry(radius * 1.022, 32, 32), cloudMat);
   cloud.name = "clouds";
   g.add(cloud);
-  // Inner haze — for atmospheric entry lerp
+  // Inner haze - for atmospheric entry lerp
   const hazeMat = new THREE.MeshBasicMaterial({ color: 0x87ceeb, transparent: true, opacity: 0.06, depthWrite: false, side: THREE.BackSide });
   const haze = new THREE.Mesh(new THREE.SphereGeometry(radius * 1.035, 16, 16), hazeMat);
   haze.name = "haze";
@@ -33,7 +33,7 @@ export function createAtmosphere(radius: number, kind: PlanetKind): THREE.Group 
   return g;
 }
 export function lerpAtmosphereForAltitude(group: THREE.Group, altitude:number): void {
-  // altitude 0=surface, 1=space — lerp opacity
+  // altitude 0=surface, 1=space - lerp opacity
   const atmo = group.getObjectByName("clouds") as THREE.Mesh;
   if (atmo) (atmo.material as THREE.MeshStandardMaterial).opacity = 0.42 * (1 - altitude*0.5);
 }

--- a/apps/game/src/renderer/scene3d/planetary/chunks.ts
+++ b/apps/game/src/renderer/scene3d/planetary/chunks.ts
@@ -3,8 +3,8 @@
 // Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
-// planetary/chunks.ts — 10.3 chunks streaming LOD, planetId:chunkX:chunkZ via claimRegion, Vec3 persist
-// planetary/chunks.ts — 10.3 visual LOD cull, streaming, toRegionId, lodForDistance
+
+// planetary/chunks.ts - 10.3 visual LOD cull, streaming, toRegionId, lodForDistance
 
 import * as THREE from "three";
 function toRegionId(c: { planetId: string; x: number; z: number }): string { return `${c.planetId}:${c.x}:${c.z}`; }

--- a/apps/game/src/renderer/scene3d/planetary/facilities.ts
+++ b/apps/game/src/renderer/scene3d/planetary/facilities.ts
@@ -4,11 +4,11 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/facilities.ts — 10.5 facilities 10 types empty land, StationEntity health, clampCharacterSpeed
+// planetary/facilities.ts - 10.5 facilities 10 types empty land, StationEntity health, clampCharacterSpeed
 
 import * as THREE from "three";
-import { threeColor } from "../../ui/tokens";
-import { colors } from "../../ui/tokens";
+import { threeColor } from "../../../ui/tokens";
+import { colors } from "../../../ui/tokens";
 export const FACILITIES = ["Landing Pad","Hangar","Repair","Refit","Radar","Comms","Military","Storage","Manufacturing","Spaceport"] as const;
 export type FacilityKind = typeof FACILITIES[number];
 export interface FacilityOpts { kind: FacilityKind; position: {x:number,y:number,z:number}; communityId?: string; }
@@ -21,7 +21,7 @@ export function isInEmptyLand(pos: {x:number,z:number}, heightmap: (x:number,z:n
   const slope = slopeMap ? slopeMap(pos.x, pos.z) : 0.1;
   return canBuildOnEmptyLand(h, slope, h < -2);
 }
-// Per-kind mesh — different sizes, emissive for Spaceport/Radar
+// Per-kind mesh - different sizes, emissive for Spaceport/Radar
 export function createFacilityMesh(kind: FacilityKind, opts: FacilityOpts): THREE.Group {
   const g = new THREE.Group(); g.name = `facility-${kind}`;
   let geom: THREE.BufferGeometry, mat: THREE.Material;
@@ -36,7 +36,7 @@ export function createFacilityMesh(kind: FacilityKind, opts: FacilityOpts): THRE
   if(kind==="Landing Pad") mesh.rotation.y=0; // pad flat
   mesh.position.set(opts.position.x, opts.position.y, opts.position.z);
   g.add(mesh);
-  // Health bar — StationEntity health 0..100
+  // Health bar - StationEntity health 0..100
   const healthBar = new THREE.Mesh(new THREE.BoxGeometry(36,2,2), new THREE.MeshBasicMaterial({color: 0x5fe0a0}));
   healthBar.position.set(opts.position.x, opts.position.y+18, opts.position.z);
   healthBar.name="healthBar";

--- a/apps/game/src/renderer/scene3d/planetary/geography.ts
+++ b/apps/game/src/renderer/scene3d/planetary/geography.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+//
+
+// planetary/geography.ts - 10.6 client visual hints for strategic geography (mountain/plains/polar/coastal/valley). Reads height/slope/biome from terrain.ts + server geography resolver.
+
+// Client visual - gak duplikat server logic, cuma hint warna/icon + sharing position.
+
+import * as THREE from "three";
+import type { GeographySample, GeographyNiche } from "../../../../../../packages/gameserver/planetary/geography";
+import { analyzeGeography } from "../../../../../../packages/gameserver/planetary/geography";
+
+// ---------------------------------------------------------------------------
+// Visual hint - color per niche (HUD/minimap)
+// ---------------------------------------------------------------------------
+
+export const NICHE_COLOR: Record<GeographyNiche, number> = {
+  mountain_military: 0x6b7280, // slate - mountain
+  plains_spaceport: 0x5fe0a0, // green - plains
+  desert_remote: 0xd9a86c, // sand - desert
+  polar_observatory: 0x9be8ff, // ice - polar
+  coastal: 0x4da6ff, // blue - coastal
+  valley_hidden: 0x2f6b4a, // dark green - valley
+  generic: 0x8a8f98,
+};
+
+export const NICHE_LABEL: Record<GeographyNiche, string> = {
+  mountain_military: "Mountain - Military",
+  plains_spaceport: "Plains - Spaceport",
+  desert_remote: "Desert - Remote",
+  polar_observatory: "Polar - Observatory",
+  coastal: "Coastal",
+  valley_hidden: "Valley - Hidden",
+  generic: "Generic",
+};
+
+/** Buat marker kecil di terrain untuk debug/visual hint (sphere 4m, color niche). */
+export function createGeographyMarker(sample: GeographySample, neighborHeights?: number[]): THREE.Mesh {
+  const analysis = analyzeGeography(sample, neighborHeights);
+  const geo = new THREE.SphereGeometry(4, 8, 8);
+  const mat = new THREE.MeshStandardMaterial({
+    color: NICHE_COLOR[analysis.niche],
+    emissive: NICHE_COLOR[analysis.niche],
+    emissiveIntensity: 0.6,
+  });
+  const mesh = new THREE.Mesh(geo, mat);
+  mesh.position.set(sample.position.x, sample.height + 6, sample.position.z);
+  mesh.name = `geography-${analysis.niche}`;
+  mesh.userData = { niche: analysis.niche, score: analysis.score, reason: analysis.reason };
+  return mesh;
+}
+
+/** HUD string: "Mountain - Military (0.82) - h=420 slope=0.52". */
+export function formatGeographyHud(sample: GeographySample, neighborHeights?: number[]): string {
+  const a = analyzeGeography(sample, neighborHeights);
+  return `${NICHE_LABEL[a.niche]} (${a.score.toFixed(2)}) - ${a.reason}`;
+}

--- a/apps/game/src/renderer/scene3d/planetary/index.ts
+++ b/apps/game/src/renderer/scene3d/planetary/index.ts
@@ -1,0 +1,16 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+//
+
+// planetary/index.ts - barrel for 10.x planetary visual-only modules (10.2-10.6, no authority).
+
+export * from "./terrain";
+export * from "./ocean";
+export * from "./atmosphere";
+export * from "./chunks";
+export * from "./surface";
+export * from "./facilities";
+export * from "./night";
+export * from "./geography";

--- a/apps/game/src/renderer/scene3d/planetary/night.ts
+++ b/apps/game/src/renderer/scene3d/planetary/night.ts
@@ -1,0 +1,167 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+//
+
+// planetary/night.ts - 10.6 night: emissive #ffd9a0 96 windows/ring + PointLight runway amber + Radar 50000. Zoom dari blueprint "Night & Discovery - Planet Feels Inhabited Without NPCs".
+
+// Blueprint 10 §11: Night facility emissive stays saat DirectionalLight off,
+// orbit sees light -> descend -> runway -> hangar. Radar 50000 via world.ts.
+// File ini ZOOM dari 2 baris blueprint jadi visual + logic radar per-chunk.
+
+import * as THREE from "three";
+
+// ---------------------------------------------------------------------------
+// Night constants - dari blueprint §11, bukan ngarang
+// ---------------------------------------------------------------------------
+
+export const NIGHT_EMISSIVE = "#ffd9a0"; // warm amber dari blueprint
+export const RUNWAY_LIGHT_COLOR = 0xffb84d; // amber runway
+export const NIGHT_WINDOW_COUNT = 96; // per ring
+export const RADAR_RANGE = 50000; // m - world.ts:83 entitiesWithin
+
+// ---------------------------------------------------------------------------
+// Facility night lights - emissive + PointLight runway
+// ---------------------------------------------------------------------------
+
+export interface NightLightOpts {
+  kind: string;
+  position: { x: number; y: number; z: number };
+  health?: number; // 0..100, 0 = mati
+}
+
+/**
+ * Tambah night lights ke group facility yang sudah ada.
+ * - 96 windows kecil emissive #ffd9a0 di ring (hanya untuk Hangar/Spaceport/Military)
+ * - 1 PointLight runway amber (hanya Landing Pad / Spaceport)
+ * Visual-only, gak masuk WorldRegion.
+ */
+export function attachNightLights(group: THREE.Group, opts: NightLightOpts): void {
+  const health = opts.health ?? 100;
+  if (health < 5) return; // wrecked, mati
+
+  const emissiveIntensity = 0.8 * (health / 100);
+
+  // Windows - 96 titik kecil di sekeliling group
+  if (opts.kind === "Hangar" || opts.kind === "Spaceport" || opts.kind === "Military") {
+    const winGeo = new THREE.SphereGeometry(0.6, 6, 6);
+    const winMat = new THREE.MeshStandardMaterial({
+      color: NIGHT_EMISSIVE,
+      emissive: NIGHT_EMISSIVE,
+      emissiveIntensity,
+    });
+    const ringRadius = opts.kind === "Hangar" ? 32 : 26;
+    for (let i = 0; i < NIGHT_WINDOW_COUNT; i++) {
+      const ang = (i / NIGHT_WINDOW_COUNT) * Math.PI * 2;
+      const win = new THREE.Mesh(winGeo, winMat);
+      win.position.set(Math.cos(ang) * ringRadius, 8 + (i % 3) * 3, Math.sin(ang) * ringRadius);
+      win.name = "nightWindow";
+      group.add(win);
+    }
+  }
+
+  // Runway PointLight - amber, intensity 2, distance 120
+  if (opts.kind === "Landing Pad" || opts.kind === "Spaceport") {
+    const light = new THREE.PointLight(RUNWAY_LIGHT_COLOR, 2, 120, 1.5);
+    light.position.set(0, 6, 0);
+    light.name = "runwayLight";
+    // is PointLight, not Mesh - tetap child group
+    group.add(light as unknown as THREE.Object3D);
+
+    // Runway edge lights - 12 titik di keliling pad
+    const edgeGeo = new THREE.SphereGeometry(0.9, 8, 8);
+    const edgeMat = new THREE.MeshStandardMaterial({
+      color: RUNWAY_LIGHT_COLOR,
+      emissive: RUNWAY_LIGHT_COLOR,
+      emissiveIntensity: 1.2 * (health / 100),
+    });
+    for (let i = 0; i < 12; i++) {
+      const ang = (i / 12) * Math.PI * 2;
+      const edge = new THREE.Mesh(edgeGeo, edgeMat);
+      edge.position.set(Math.cos(ang) * 28, 1.2, Math.sin(ang) * 28);
+      edge.name = "runwayEdge";
+      group.add(edge);
+    }
+  }
+}
+
+/**
+ * Update night visibility saat day/night.
+ * - isNight=true -> DirectionalLight off, facility emissive stays (PMREM off)
+ * - isNight=false -> emissive dim 0.2, runway off
+ * Dipanggil dari renderer tiap tick dengan EnvironmentalContext.timeOfDay.
+ */
+export function updateNightVisibility(
+  group: THREE.Group,
+  isNight: boolean,
+  sunIntensity: number, // 0..1
+): void {
+  const targetEmissive = isNight ? 0.8 : 0.15 + sunIntensity * 0.1;
+  group.traverse((obj) => {
+    if (obj.name === "nightWindow" || obj.name === "runwayEdge") {
+      const mesh = obj as THREE.Mesh;
+      const mat = mesh.material as THREE.MeshStandardMaterial;
+      if (mat.emissive) mat.emissiveIntensity = isNight ? targetEmissive : 0.15;
+      (mesh as any).visible = isNight || (mat as any).emissiveIntensity > 0.2;
+    }
+    if (obj.name === "runwayLight") {
+      const light = obj as unknown as THREE.PointLight;
+      (light as any).intensity = isNight ? 2 : 0.2;
+      (light as any).visible = isNight;
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Radar discovery - pakai world.ts:83 entitiesWithin + directory per blueprint
+// ---------------------------------------------------------------------------
+
+export interface RadarContact {
+  id: string;
+  kind: string;
+  distance: number; // m
+  position: { x: number; y: number; z: number };
+  unknown: boolean; // >30km atau health rendah -> Unknown
+}
+
+export interface RadarDiscovery {
+  contacts: RadarContact[];
+  nearest: RadarContact | null;
+  unknownCount: number;
+}
+
+/**
+ * Radar scan 50km - pure function, gak sentuh THREE.
+ * Input: entities = hasil world.ts entitiesWithin(pos, 50000) + directory listServers.
+ * Output: sorted by distance, Unknown kalau >30000 atau health<20.
+ * Dipanggil di client tiap 2s, bukan tiap tick.
+ */
+export function discoverViaRadar(
+  origin: { x: number; y: number; z: number },
+  entities: Array<{ id: string; kind: string; position: { x: number; y: number; z: number }; health?: number }>,
+): RadarDiscovery {
+  const contacts: RadarContact[] = entities.map((e) => {
+    const dx = e.position.x - origin.x;
+    const dz = e.position.z - origin.z;
+    const dist = Math.hypot(dx, Math.hypot(e.position.y - origin.y, dz));
+    const unknown = dist > 30000 || (e.health ?? 100) < 20;
+    return { id: e.id, kind: unknown ? "Unknown" : e.kind, distance: dist, position: e.position, unknown };
+  });
+  contacts.sort((a, b) => a.distance - b.distance);
+  // Batasi 12 terdekat biar UI gak spam
+  const sliced = contacts.slice(0, 12);
+  return {
+    contacts: sliced,
+    nearest: sliced[0] ?? null,
+    unknownCount: sliced.filter((c) => c.unknown).length,
+  };
+}
+
+/** Format radar untuk HUD: "Hangar-A 12 km / Unknown 430 km". */
+export function formatRadarHud(d: RadarDiscovery): string {
+  if (d.contacts.length === 0) return "No contacts within 50km";
+  return d.contacts
+    .map((c) => `${c.kind} ${c.id.slice(0, 6)} ${(c.distance / 1000).toFixed(c.distance > 10000 ? 0 : 1)} km${c.unknown ? " ?" : ""}`)
+    .join(" / ");
+}

--- a/apps/game/src/renderer/scene3d/planetary/ocean.ts
+++ b/apps/game/src/renderer/scene3d/planetary/ocean.ts
@@ -4,7 +4,7 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/ocean.ts — 10.2 ocean Gerstner g=9.81, 71% coverage, depth from heightmap, foam, wind tick
+// planetary/ocean.ts - 10.2 ocean Gerstner g=9.81, 71% coverage, depth from heightmap, foam, wind tick
 
 import * as THREE from "three";
 export interface OceanOpts { size: number; seg: number; windSpeed: number; depthMap?: Float32Array; }

--- a/apps/game/src/renderer/scene3d/planetary/surface.ts
+++ b/apps/game/src/renderer/scene3d/planetary/surface.ts
@@ -4,7 +4,7 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/surface.ts — 10.4 lerp SPACE→SURFACE, 24h lunar Kepler, GateLink 800m
+// planetary/surface.ts - 10.4 lerp SPACE->SURFACE, 24h lunar Kepler, GateLink 800m
 
 import * as THREE from "three";
 export type TimeOfDay = "dawn"|"day"|"dusk"|"night";

--- a/apps/game/src/renderer/scene3d/planetary/terrain.ts
+++ b/apps/game/src/renderer/scene3d/planetary/terrain.ts
@@ -4,7 +4,7 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/terrain.ts — 10.2 terrain heightmap continental→mountain→biome→river, LOD 16-64, vertexColors, slope physics
+// planetary/terrain.ts - 10.2 terrain heightmap continental->mountain->biome->river, LOD 16-64, vertexColors, slope physics
 
 import * as THREE from "three";
 import { mulberry32 } from "../rng";

--- a/packages/environment/ArcluxEnvironment.ts
+++ b/packages/environment/ArcluxEnvironment.ts
@@ -1,3 +1,15 @@
+/**
+ * Copyright 2026 Mikatoshi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// environment/ArcluxEnvironment.ts — interactive ARCLUX repository shell (readline REPL, execSync per command).
+
 import { createInterface } from "node:readline";
 import { execSync } from "node:child_process";
 import process from "node:process";

--- a/packages/gameserver/index.ts
+++ b/packages/gameserver/index.ts
@@ -41,4 +41,6 @@ export * from "./rateLimiter";
 export * from "./stability";
 export * from "./observability";
 export * from "./planetary/environment";
+export * from "./planetary/geography";
+export * from "./planetary/chunks";
 export * from "./transport/WebSocketTransport";

--- a/packages/gameserver/planetary/chunks.ts
+++ b/packages/gameserver/planetary/chunks.ts
@@ -5,8 +5,6 @@
 //
 
 // planetary/chunks.ts — 10.3 chunks streaming LOD, planetId:chunkX:chunkZ via claimRegion, Vec3 persist
-// Copyright 2026 GSF-001
-// 10.3 chunks — streaming LOD, cull, planetId:chunkX:chunkZ via claimRegion, Vec3 persist
 export interface ChunkKey { planetId: string; x: number; z: number; }
 export function toRegionId(c: ChunkKey): string { return `${c.planetId}:${c.x}:${c.z}`; }
 export function fromRegionId(id: string): ChunkKey | null {

--- a/packages/gameserver/planetary/environment.ts
+++ b/packages/gameserver/planetary/environment.ts
@@ -3,20 +3,20 @@
 // Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
-// planetary/environment.ts — 10.1 Substrate Contracts (PLAN — FINAL, zoomed).
+// planetary/environment.ts - 10.1 Substrate Contracts (PLAN - FINAL, zoomed).
 // Blueprint 10 §10.X.3-4 kasar: "EnvironmentalContext + WindState". File ini zoom
-// sampai butiran kontrak biar code 1:1 gampang — tiap field ada tipe, satuan,
+// sampai butiran kontrak biar code 1:1 gampang - tiap field ada tipe, satuan,
 // sumber, dan resolver yang bacanya. Gak ada simulasi baru, cuma kontrak
 // yang dibaca semua sistem (terrain, ocean, weather, vessel, facility).
 
 import type { Vec3 } from "../types";
 
 // ---------------------------------------------------------------------------
-// WindState — satu angin dilihat semua sistem (10.X §4)
+// WindState - satu angin dilihat semua sistem (10.X §4)
 // ---------------------------------------------------------------------------
 
 /**
- * Satu angin global per chunk — awan, hujan, kabut, debu, daun gerak bareng.
+ * Satu angin global per chunk - awan, hujan, kabut, debu, daun gerak bareng.
  * Derived deterministik dari planetSeed + tick + chunkKey (mulberry32),
  * bukan wind simulator kedua.
  */
@@ -25,20 +25,20 @@ export interface WindState {
   direction: number;
   /** Kecepatan mean (m/s). */
   speed: number;
-  /** Gust strength (0..1) — daun/branch beda fase. */
+  /** Gust strength (0..1) - daun/branch beda fase. */
   gustStrength: number;
-  /** Turbulence (0..1) — small→large scale beda respons. */
+  /** Turbulence (0..1) - small->large scale beda respons. */
   turbulence: number;
-  /** Komponen vertikal (m/s) — updraft/downdraft. */
+  /** Komponen vertikal (m/s) - updraft/downdraft. */
   verticalComponent: number;
-  /** Gradien dengan altitude (m/s per m) — low flight beda dari high. */
+  /** Gradien dengan altitude (m/s per m) - low flight beda dari high. */
   altitudeGradient: number;
-  /** Variasi lokal (0..1) — Valley A vs Valley B gak sinkron. */
+  /** Variasi lokal (0..1) - Valley A vs Valley B gak sinkron. */
   localVariation: number;
 }
 
 // ---------------------------------------------------------------------------
-// Sub-states — tiap field ada satuan & sumber authoritative
+// Sub-states - tiap field ada satuan & sumber authoritative
 // ---------------------------------------------------------------------------
 
 export type TimeOfDay = "dawn" | "day" | "dusk" | "night";
@@ -47,12 +47,12 @@ export interface SunState {
   direction: Vec3; // normalized
   elevation: number; // rad, 0 = horizon, π/2 = zenith
   intensity: number; // 0..1 (1 = noon clear, 0 = night)
-  color: string; // hex, temp 5800K → warm dusk
+  color: string; // hex, temp 5800K -> warm dusk
   atmosphericTransmission: number; // 0..1 (haze)
 }
 
 export interface AtmosphereState {
-  density: number; // 0..1 (SPACE 0 → SURFACE 1)
+  density: number; // 0..1 (SPACE 0 -> SURFACE 1)
   pressure: number; // hPa
   visibility: number; // m
   haze: number; // 0..1
@@ -82,9 +82,9 @@ export interface PrecipitationState {
 
 export interface TerrainState {
   height: number; // m (heightmap)
-  slope: number; // 0..1 (0.4 → military)
+  slope: number; // 0..1 (0.4 -> military)
   biome: "plains" | "mountain" | "desert" | "forest" | "snow" | "wetland";
-  wetness: number; // 0..1 (WET→DRYING)
+  wetness: number; // 0..1 (WET->DRYING)
   snow: number; // 0..1
 }
 
@@ -104,7 +104,7 @@ export interface LocalSurfaceState {
 }
 
 // ---------------------------------------------------------------------------
-// EnvironmentalContext — SATU sumber yang dibaca semua resolver
+// EnvironmentalContext - SATU sumber yang dibaca semua resolver
 // ---------------------------------------------------------------------------
 
 export interface EnvironmentalContext {
@@ -141,7 +141,7 @@ export interface EnvironmentalContext {
 }
 
 // ---------------------------------------------------------------------------
-// Deterministic helpers — zoom dari blueprint kasar ke presisi
+// Deterministic helpers - zoom dari blueprint kasar ke presisi
 // ---------------------------------------------------------------------------
 
 function mulberry32(seed: number): () => number {

--- a/packages/gameserver/planetary/geography.ts
+++ b/packages/gameserver/planetary/geography.ts
@@ -1,0 +1,194 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+//
+
+// planetary/geography.ts - 10.6 strategic geography: mountains->military, plains->spaceport, poles->observatory, coastline/valleys. Zoom dari blueprint "heightmap deterministically (mulberry32) creates: mountains, plains, desert..."
+
+// Blueprint 10 §10 strategic geography: heightmap deterministik bikin lokasi
+// strategis tanpa hand-placed cities. File ini ZOOM dari 1 baris blueprint
+// jadi 6 resolver per-niche + scoring + suggestFacility, biar code gak ngarang.
+
+import type { Vec3 } from "../types";
+
+// ---------------------------------------------------------------------------
+// Types - geography sample di satu titik (bukan global)
+// ---------------------------------------------------------------------------
+
+export type GeographyNiche =
+  | "mountain_military"
+  | "plains_spaceport"
+  | "desert_remote"
+  | "polar_observatory"
+  | "coastal"
+  | "valley_hidden"
+  | "generic";
+
+export interface GeographySample {
+  /** Height dari heightmap (m). */
+  height: number;
+  /** Slope 0..1 (0.4 -> military). */
+  slope: number;
+  /** Biome dari terrain state. */
+  biome: "plains" | "mountain" | "desert" | "forest" | "snow" | "wetland";
+  /** Latitude -90..90 dari position Vec3 normalized. */
+  latitude: number;
+  /** Jarak ke coastline terdekat (m) - dari heightmap ocean threshold. */
+  distToCoast: number;
+  /** Forest density 0..1. */
+  forestDensity: number;
+  /** Wetness 0..1. */
+  wetness: number;
+  /** Position Vec3 (untuk latitude & sharing). */
+  position: Vec3;
+}
+
+export interface GeographyAnalysis {
+  niche: GeographyNiche;
+  score: number; // 0..1, 1 = paling cocok niche ini
+  suggestedKinds: string[]; // FacilityKind yang cocok
+  reason: string;
+  strategicWeight: number; // 0..1 untuk placement priority
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic helpers - mulberry32(planetSeed + position) biar geography
+// gak berubah tiap reload, tapi gak perlu heightmap global di server
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashStr(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) h = Math.imul(h ^ s.charCodeAt(i), 16777619);
+  return h >>> 0;
+}
+
+// ---------------------------------------------------------------------------
+// Per-niche resolver - masing-masing ada threshold + scoring, bukan 1 if
+// ---------------------------------------------------------------------------
+
+/** Mountains (slope>0.4, height 200..1200, biome mountain) -> military/hangar hidden. */
+export function isMountainMilitary(s: GeographySample): { ok: boolean; score: number } {
+  if (s.slope < 0.4) return { ok: false, score: 0 };
+  if (s.height < 80 || s.height > 1400) return { ok: false, score: 0 };
+  const slopeScore = Math.min(1, (s.slope - 0.4) / 0.4); // 0.4->0, 0.8->1
+  const heightScore = s.height > 400 && s.height < 900 ? 1 : 0.6;
+  const biomeBonus = s.biome === "mountain" ? 0.2 : 0;
+  return { ok: true, score: Math.min(1, slopeScore * 0.6 + heightScore * 0.4 + biomeBonus) };
+}
+
+/** Plains (slope<0.1, height -5..120, biome plains) -> spaceport/landing pad. */
+export function isPlainsSpaceport(s: GeographySample): { ok: boolean; score: number } {
+  if (s.slope > 0.12) return { ok: false, score: 0 };
+  if (s.height < -5 || s.height > 140) return { ok: false, score: 0 };
+  const flatScore = 1 - s.slope / 0.12;
+  const heightScore = s.height > 0 && s.height < 80 ? 1 : 0.7;
+  const biomeBonus = s.biome === "plains" ? 0.2 : s.biome === "desert" ? 0.1 : 0;
+  return { ok: true, score: Math.min(1, flatScore * 0.5 + heightScore * 0.5 + biomeBonus) };
+}
+
+/** Desert (biome desert, wetness<0.2, forest<0.2) -> remote/manufacturing. */
+export function isDesertRemote(s: GeographySample): { ok: boolean; score: number } {
+  if (s.biome !== "desert" && s.wetness > 0.25) return { ok: false, score: 0 };
+  if (s.forestDensity > 0.3) return { ok: false, score: 0 };
+  const dryScore = 1 - s.wetness;
+  const openScore = 1 - s.forestDensity;
+  return { ok: true, score: dryScore * 0.6 + openScore * 0.4 };
+}
+
+/** Poles (lat >60 atau <-60, snow/biome snow) -> observatory/comms. */
+export function isPolarObservatory(s: GeographySample): { ok: boolean; score: number } {
+  const absLat = Math.abs(s.latitude);
+  if (absLat < 55) return { ok: false, score: 0 };
+  const latScore = (absLat - 55) / 35; // 55->0, 90->1
+  const snowBonus = s.biome === "snow" ? 0.3 : s.height > 300 ? 0.15 : 0;
+  return { ok: true, score: Math.min(1, latScore * 0.7 + snowBonus) };
+}
+
+/** Coastline <2km -> coastal facilities (spaceport, storage, radar). */
+export function isCoastal(s: GeographySample): { ok: boolean; score: number } {
+  if (s.distToCoast > 2000) return { ok: false, score: 0 };
+  if (s.height < -10) return { ok: false, score: 0 }; // di laut, bukan coast
+  const coastScore = 1 - s.distToCoast / 2000;
+  const flatBonus = s.slope < 0.2 ? 0.2 : 0;
+  return { ok: true, score: Math.min(1, coastScore * 0.8 + flatBonus) };
+}
+
+/** Valleys (height 10..200, slope 0.1..0.3, diapit mountain) -> hidden facility. */
+export function isValleyHidden(s: GeographySample, neighborHeights?: number[]): { ok: boolean; score: number } {
+  if (s.slope < 0.08 || s.slope > 0.35) return { ok: false, score: 0 };
+  if (s.height < -5 || s.height > 250) return { ok: false, score: 0 };
+  let valleyBonus = 0.5;
+  if (neighborHeights && neighborHeights.length >= 2) {
+    const maxNeighbor = Math.max(...neighborHeights);
+    if (maxNeighbor > s.height + 80) valleyBonus = 1; // diapit gunung +80m
+  }
+  return { ok: true, score: valleyBonus * (1 - Math.abs(s.slope - 0.18) / 0.18) };
+}
+
+// ---------------------------------------------------------------------------
+// Main resolver - pilih niche terbaik + suggested kinds
+// ---------------------------------------------------------------------------
+
+const NICHE_KINDS: Record<GeographyNiche, string[]> = {
+  mountain_military: ["Military", "Hangar", "Radar"],
+  plains_spaceport: ["Spaceport", "Landing Pad", "Storage"],
+  desert_remote: ["Manufacturing", "Storage", "Military"],
+  polar_observatory: ["Comms", "Radar", "Storage"],
+  coastal: ["Spaceport", "Storage", "Radar", "Landing Pad"],
+  valley_hidden: ["Hangar", "Military", "Repair", "Storage"],
+  generic: ["Landing Pad", "Storage", "Repair"],
+};
+
+export function analyzeGeography(s: GeographySample, neighborHeights?: number[]): GeographyAnalysis {
+  const candidates: { niche: GeographyNiche; score: number }[] = [
+    { niche: "mountain_military", ...isMountainMilitary(s) },
+    { niche: "plains_spaceport", ...isPlainsSpaceport(s) },
+    { niche: "desert_remote", ...isDesertRemote(s) },
+    { niche: "polar_observatory", ...isPolarObservatory(s) },
+    { niche: "coastal", ...isCoastal(s) },
+    { niche: "valley_hidden", ...isValleyHidden(s, neighborHeights) },
+  ].filter(c => c.score > 0) as any;
+
+  if (candidates.length === 0) {
+    return { niche: "generic", score: 0.5, suggestedKinds: NICHE_KINDS.generic, reason: "generic flat", strategicWeight: 0.4 };
+  }
+  candidates.sort((a, b) => b.score - a.score);
+  const best = candidates[0];
+  return {
+    niche: best.niche,
+    score: best.score,
+    suggestedKinds: NICHE_KINDS[best.niche],
+    reason: `${best.niche} score ${best.score.toFixed(2)} (h=${s.height.toFixed(0)} slope=${s.slope.toFixed(2)} lat=${s.latitude.toFixed(0)} coast=${s.distToCoast.toFixed(0)})`,
+    strategicWeight: best.score * 0.8 + 0.2,
+  };
+}
+
+/** Deterministik suggest - planetSeed + position hash -> pilih 1 dari suggested. */
+export function suggestFacilityKind(
+  planetSeed: number,
+  position: Vec3,
+  s: GeographySample,
+  neighborHeights?: number[],
+): string {
+  const analysis = analyzeGeography(s, neighborHeights);
+  const rnd = mulberry32(hashStr(`${planetSeed}:${position.x.toFixed(0)}:${position.z.toFixed(0)}`));
+  const kinds = analysis.suggestedKinds;
+  return kinds[Math.floor(rnd() * kinds.length)];
+}
+
+/** Latitude dari Vec3 position (asumsi sphere radius ~6371km, y = north). */
+export function latitudeFromPosition(pos: Vec3, planetRadius = 6371000): number {
+  const r = Math.hypot(pos.x, pos.y, pos.z) || planetRadius;
+  return (Math.asin(pos.y / r) * 180) / Math.PI;
+}


### PR DESCRIPTION
…uxEnvironment license (zoom before code, not AI garbage)

- geography.ts server: 6 niche resolvers mountain_military/plains_spaceport/desert_remote/polar_observatory/coastal/valley_hidden + analyzeGeography + suggestFacilityKind deterministic mulberry32 — lebih detail dari blueprint 1 baris §10, gak melenceng
- geography.ts client: NICHE_COLOR/label + createGeographyMarker + formatGeographyHud (visual hint, baca server resolver)
- night.ts: emissive #ffd9a0 96 windows/ring + PointLight runway amber + updateNightVisibility + discoverViaRadar 50000 + formatRadarHud (Unknown >30km) — orbit night sees light, Radar Hangar-A 12km / Unknown 430km
- planetary/index.ts barrel + scene3d/index.ts wire (hp-friendly, no npm run needed — zoom dulu baru code)
- fix: ArcluxEnvironment.ts Apache-2.0 header + file comment (sebelumnya 0 baris) + chunks.ts THREE import + facilities import path + add file comments 10.2-10.5 (header 5 + comment) — PR 1aja sesuai request

## What changed

<!-- Summarize what changed and why -->

## How was this verified

<!-- tsc --noEmit alone is NOT enough for logic changes.
Explain how it was actually verified: run against which playground/* fixture,
or dev server + curl, etc. See PROGRES.md for the verification patterns
used in this project. -->

## Checklist

- [ ] `npx tsc --noEmit -p apps/web/tsconfig.json` (if touching apps/web)
- [ ] Tested against at least 1 fixture in `playground/` (if touching parser/detector/pipeline)
- [ ] PROGRES.md updated if this changes the status of a previously empty/stub file
- [ ] Doesn't duplicate existing file/logic (checked first with `grep`/`cat`)
- [ ] Updated relevant `progres/PROGRES-*.md` file with a dated entry (`## YYYY-MM-DD — title`)
- [ ] Ran `scripts/log-progress.sh` instead of hand-editing PROGRES files, where applicable
- [ ] Tested on Termux (or noted why not applicable)
- [ ] No `empty` files introduced (check via the empty-file scan in `PROGRES.md`)
