### PR TITLE
fix(license): ArcluxEnvironment Apache Mikatoshi

### DIFF
--- a/packages/environment/ArcluxEnvironment.ts
+++ b/packages/environment/ArcluxEnvironment.ts
@@ -1,8 +1,12 @@
-// Copyright 2026 GSF-001
-//
-// Licensed under the Apache License, Version 2.0 — See LICENSE-ENGINE in the repo root.
-// SPDX-License-Identifier: Apache-2.0
-//
+/**
+ * Copyright 2026 Mikatoshi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 
 // environment/ArcluxEnvironment.ts — interactive ARCLUX repository shell (readline REPL, execSync per command).
 


### PR DESCRIPTION
Fix header yang kemarin ngawur GSF-001 -> yang bener Mikatoshi Apache 2.0. PR BARU, bukan numpang yang udah merge.