### PR TITLE
feat(planetary): 10.X.1-X.4 product-grade + wired

### DIFF
--- a/apps/game/src/renderer/scene3d/index.ts
+++ b/apps/game/src/renderer/scene3d/index.ts
@@ -39,6 +39,7 @@ import { attachNightLights, updateNightVisibility } from "./planetary/night";
 import { createGeographyMarker, NICHE_COLOR } from "./planetary/geography";
 import { createEnvironmentalContext } from "../../../../../packages/gameserver/planetary/environment";
 import type { EnvironmentalContext } from "../../../../../packages/gameserver/planetary/environment";
+import { createPlanetary10X, tickPlanetary10X, disposePlanetary10X } from "./planetary/wire10X";
 void _planetary;
 import { buildStars } from "./stars";
 import { buildNebula } from "./nebula";
@@ -121,6 +122,9 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
   // Geography markers group
   const geographyGroup = new THREE.Group();
   ctx.scene.add(geographyGroup);
+
+  // Cinematic atmosphere layer (10.X.1-X.4) — owns sun/shadow/rain/etc systems
+  const planetary10X = createPlanetary10X(ctx.scene, planetSeed);
 
   // Environmental context (derived from server contract)
   let envContext: EnvironmentalContext | null = null;
@@ -311,6 +315,22 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
       updateNightVisibility(nightGroup, envContext.timeOfDay === "night", envContext.sun.intensity);
     }
 
+    // ── CINEMATIC ATMOSPHERE TICK (10.X.1-X.4) ──
+    if (envContext) {
+      const dtX = 1 / 60;
+      tickPlanetary10X(planetary10X, ctx.scene, envContext, dtX, {
+        timeSec: envContext.worldTime / 1000 + envContext.simulationTick * 0.1,
+        anchor: { x: ctx.anchor.x, z: ctx.anchor.z },
+        cameraPos: ctx.camera
+          ? { x: ctx.camera.position.x, y: ctx.camera.position.y, z: ctx.camera.position.z }
+          : { x: 0, y: 0, z: 0 },
+        altitude: ctx.firstVesselRef ? Math.max(0, ctx.anchor.y + 10) : 0,
+        vessel: ctx.firstVesselRef,
+        ambient: ctx.ambient,
+        renderer: ctx.renderer,
+      });
+    }
+
     // Interpolasi vessel (presentation ✓, autoritas server tetap D-008).
     updateVesselInterp(ctx, now);
 
@@ -350,6 +370,7 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
     ctx.scene.remove(terrainMesh); ctx.scene.remove(oceanMesh); ctx.scene.remove(atmoGroup);
     disposeGroup(terrainMesh as any); disposeGroup(oceanMesh as any); disposeGroup(atmoGroup);
     disposeGroup(facilitiesGroup); disposeGroup(nightGroup); disposeGroup(geographyGroup);
+    disposePlanetary10X(ctx.scene, planetary10X);
     for (const pl of ctx.planets) {
       ctx.scene.remove(pl.mesh); ctx.scene.remove(pl.atmo); if (pl.ring) ctx.scene.remove(pl.ring);
       for (const mo of pl.moons) ctx.scene.remove(mo.mesh);

--- a/apps/game/src/renderer/scene3d/planetary/cloudShadows.ts
+++ b/apps/game/src/renderer/scene3d/planetary/cloudShadows.ts
@@ -4,32 +4,51 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/cloudShadows.ts - 10.X.1 CLOUD -> MOVING SHADOW -> SURFACE: self-shadow + edge-lit + forest darkens. Zoom dari blueprint "SUN -> CLOUD -> MOVING SHADOW -> SURFACE (forest darkens under cloud)".
-
-// Blueprint 10.X §5 cuma "Clouds self-shadow, edge-lit, sunrise/sunset bright. SUN -> CLOUD -> MOVING SHADOW -> SURFACE".
-// File ini ZOOM jadi: shadow plane 4000m, drift via WindState, density -> opacity, sunElevation -> shadow length, forest darkens.
-// WIRE NOTE for SESSION 2: import { createCloudShadowSystem, tickCloudShadows } from "./planetary/cloudShadows" di scene3d/index.ts. Create sekali di init, tick tiap frame dengan EnvironmentalContext.wind + clouds + sun.
+// planetary/cloudShadows.ts - 10.X.1 moving cloud shadows.
+// A small pool of dark translucent planes drifts with the shared wind field,
+// dimming terrain and vegetation where clouds block the sun.
+// Visual-only: reads EnvironmentalContext, never writes authority state.
 
 import * as THREE from "three";
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
 
-// ---------------------------------------------------------------------------
-// Cloud shadow system — visual-only, 1 plane per chunk, no physics
-// ---------------------------------------------------------------------------
+const PLANE_COUNT = 4;
+const PLANE_SIZE = 4000;
+const SHADOW_Y = 0.15;
+const MAX_OPACITY = 0.28;
+const VISIBILITY_THRESHOLD = 0.02;
 
 export interface CloudShadowSystem {
-  group: THREE.Group; // add ke ctx.scene
-  planes: THREE.Mesh[]; // 1 plane per chunk (pool 4)
+  group: THREE.Group;
+  planes: THREE.Mesh[];
   baseOpacity: number;
+  lastOpacity: number;
 }
 
-export function createCloudShadowSystem(): CloudShadowSystem {
+export interface CloudShadowPlaneUserData {
+  offsetX: number;
+  offsetY: number;
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Create the pooled shadow quads. Seed keeps placement deterministic. */
+export function createCloudShadowSystem(seed = 0x10c10d): CloudShadowSystem {
   const group = new THREE.Group();
   group.name = "cloudShadows";
   const planes: THREE.Mesh[] = [];
-  // 4 shadow quads (4000x4000) dengan texture noise, pool
-  for (let i = 0; i < 4; i++) {
-    const geo = new THREE.PlaneGeometry(4000, 4000);
+  const rng = mulberry32(seed);
+  for (let i = 0; i < PLANE_COUNT; i++) {
+    const geo = new THREE.PlaneGeometry(PLANE_SIZE, PLANE_SIZE);
     const mat = new THREE.MeshBasicMaterial({
       color: 0x000000,
       transparent: true,
@@ -39,92 +58,94 @@ export function createCloudShadowSystem(): CloudShadowSystem {
     });
     const mesh = new THREE.Mesh(geo, mat);
     mesh.rotation.x = -Math.PI / 2;
-    mesh.position.y = 0.15; // 15cm di atas terrain biar gak z-fight
+    mesh.position.y = SHADOW_Y;
     mesh.visible = false;
     mesh.name = `cloudShadow-${i}`;
-    // Simpan offset biar drift gak sinkron
-    (mesh as any)._offset = new THREE.Vector2(Math.random() * 4000, Math.random() * 4000);
+    const userData: CloudShadowPlaneUserData = {
+      offsetX: rng() * PLANE_SIZE,
+      offsetY: rng() * PLANE_SIZE,
+    };
+    mesh.userData = { ...mesh.userData, ...userData };
     group.add(mesh);
     planes.push(mesh);
   }
-  return { group, planes, baseOpacity: 0.0 };
+  return { group, planes, baseOpacity: 0.0, lastOpacity: 0 };
+}
+
+function planeOffset(plane: THREE.Mesh): CloudShadowPlaneUserData {
+  return plane.userData as CloudShadowPlaneUserData;
 }
 
 /**
- * Tick tiap frame: drift via WindState + opacity via cloudDensity/coverage + sunElevation.
- * - wind.direction/speed -> offset uv
- * - cloudDensity 0..1 -> opacity 0..0.28
- * - sunElevation <0.2 rad -> shadow panjang + opacity turun 40% (sun low = soft)
- * - timeOfDay night -> invisible
+ * Advance shadows one frame.
+ * @param timeSec deterministic clock (worldTime/1000 + tick * dt), never Date.now
+ * @param anchor world position the planes follow (defaults to origin)
  */
 export function tickCloudShadows(
   sys: CloudShadowSystem,
   ctx: EnvironmentalContext,
   dt: number,
+  timeSec?: number,
+  anchor?: { x: number; z: number },
 ): void {
-  const isNight = ctx.timeOfDay === "night" || ctx.sun.intensity < 0.05;
-  if (isNight) {
-    sys.planes.forEach((p) => (p.visible = false));
+  const now = timeSec ?? ctx.worldTime / 1000 + ctx.simulationTick * 0.1;
+  const night = ctx.timeOfDay === "night" || ctx.sun.intensity < 0.05;
+  if (night) {
+    for (const p of sys.planes) p.visible = false;
+    sys.lastOpacity = 0;
     return;
   }
   const wind = ctx.wind;
   const clouds = ctx.clouds;
   const sun = ctx.sun;
 
-  // Opacity target: density 0.8 + coverage 0.7 -> 0.26, clear -> 0.02
-  const targetOpacity = Math.min(0.28, clouds.density * 0.22 + clouds.coverage * 0.12);
-  // Sun low = shadow soft + stretch: elevation 0.2 -> 1, 1.1 -> 0.6
+  const targetOpacity = Math.min(MAX_OPACITY, clouds.density * 0.22 + clouds.coverage * 0.12);
   const elevationFactor = 1.4 - Math.min(1.0, Math.max(0, sun.elevation)) * 0.6;
   const opacity = targetOpacity * elevationFactor;
+  sys.lastOpacity = opacity;
 
-  // Drift speed: wind.speed 2..10 m/s -> 6..30 units/s di plane
   const speed = wind.speed * 3.0;
   const dirX = Math.cos(wind.direction);
   const dirZ = Math.sin(wind.direction);
+  const ax = anchor?.x ?? 0;
+  const az = anchor?.z ?? 0;
 
   sys.planes.forEach((plane, idx) => {
     const mat = plane.material as THREE.MeshBasicMaterial;
-    const offset = (plane as any)._offset as THREE.Vector2;
+    const offset = planeOffset(plane);
 
-    // Drift + turbulence + localVariation biar Valley A vs B gak sinkron
-    const turb = 1 + wind.turbulence * 0.4 * Math.sin(Date.now() * 0.0003 + idx);
-    offset.x = (offset.x + dirX * speed * turb * dt * (0.8 + wind.localVariation * 0.4)) % 4000;
-    offset.y = (offset.y + dirZ * speed * turb * dt * (0.8 + wind.localVariation * 0.4)) % 4000;
+    const turb = 1 + wind.turbulence * 0.4 * Math.sin(now * 0.3 + idx * 1.7);
+    const drift = 0.8 + wind.localVariation * 0.4;
+    offset.offsetX = (offset.offsetX + dirX * speed * turb * dt * drift) % PLANE_SIZE;
+    offset.offsetY = (offset.offsetY + dirZ * speed * turb * dt * drift) % PLANE_SIZE;
 
-    // Position plane di atas player (center 0,0 untuk sekarang, SESSION 2 nanti ikutin player pos)
-    plane.position.x = offset.x - 2000;
-    plane.position.z = offset.y - 2000;
+    plane.position.x = ax + offset.offsetX - PLANE_SIZE / 2;
+    plane.position.z = az + offset.offsetY - PLANE_SIZE / 2;
 
-    // Scale shadow length via sun elevation (low sun = shadow panjang)
     const stretch = sun.elevation < 0.4 ? 1 + (0.4 - sun.elevation) * 1.8 : 1;
     plane.scale.set(stretch, 1, 1);
-    plane.rotation.z = wind.direction; // shadow arah angin
+    plane.rotation.z = wind.direction;
 
     mat.opacity = opacity * (0.85 + wind.gustStrength * 0.15);
-    plane.visible = opacity > 0.02;
+    plane.visible = opacity > VISIBILITY_THRESHOLD;
   });
-
-  // Forest darkens hint: SESSION 2 bisa baca opacity di frame loop untuk tint vegetation
-  (sys as any)._lastOpacity = opacity;
 }
 
-/** Helper buat vegetation/terrain yang mau darkens saat shadow lewat — baca dari system. */
+/** Current shadow strength for vegetation and terrain tinting. */
 export function getCloudShadowOpacity(sys: CloudShadowSystem): number {
-  return (sys as any)._lastOpacity ?? 0;
+  return sys.lastOpacity;
 }
 
-// WIRE NOTE: SESSION 2
-// import { createCloudShadowSystem, tickCloudShadows } from "./planetary/cloudShadows";
-// const cloudShadows = createCloudShadowSystem(); ctx.scene.add(cloudShadows.group);
-// // di frame loop: tickCloudShadows(cloudShadows, envCtx, dt);
-
-export function getShadowIntensityAt(sys: CloudShadowSystem, pos: {x:number,z:number}): number {
-  const op = (sys as any)._lastOpacity ?? 0;
+/** Shadow strength at a world position, fading with distance to the quad edge. */
+export function getShadowIntensityAt(sys: CloudShadowSystem, pos: { x: number; z: number }): number {
+  const op = sys.lastOpacity;
+  if (op <= 0) return 0;
   let minDist = Infinity;
   for (const p of sys.planes) {
+    if (!p.visible) continue;
     const d = Math.hypot(p.position.x - pos.x, p.position.z - pos.z);
-    minDist = Math.min(minDist, d);
+    if (d < minDist) minDist = d;
   }
-  return minDist < 2000 ? op * (1 - minDist/2000) : 0;
+  if (!Number.isFinite(minDist) || minDist >= PLANE_SIZE / 2) return 0;
+  return op * (1 - minDist / (PLANE_SIZE / 2));
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/fog.ts
+++ b/apps/game/src/renderer/scene3d/planetary/fog.ts
@@ -4,31 +4,68 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/fog.ts - 10.X.3 Fog temperature/humidity/weather -> height/distance/valley/entry haze + fog-sun god-ray feed. Zoom dari blueprint "Fog temperature/humidity/weather/altitude/terrain/wind/visibility/timeOfDay -> height/distance/valley/entry haze + god-ray feed".
-
-// WIRE NOTE for SESSION 2: import { deriveFogState, createFogSystem, tickFog } from "./planetary/fog" di scene3d/index.ts. Create sekali, tick per frame dengan EnvironmentalContext + camera altitude.
+// planetary/fog.ts - 10.X.3 fog resolver.
+// Temperature, humidity, weather, altitude, terrain, wind, visibility, and
+// time of day collapse into one fog state: density, layer height, view
+// distance, valley pooling, and high-altitude entry haze. Also feeds the
+// god-ray resolver. Visual-only: reads EnvironmentalContext.
 
 import * as THREE from "three";
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
 
+const FOG_BASE = 0x8aa0b8;
+const BASE_DENSITY = 0.00006;
+const DENSITY_SCALE = 0.00032;
+const HAZE_SCALE = 0.00018;
+
 export interface FogState {
   density: number; // 0..1
-  height: number; // m 20..300
-  distance: number; // m 800..8000
-  valleyFactor: number; // 0..1
-  entryHaze: number; // 0..1 (high altitude)
+  height: number; // layer height in meters, 20..300
+  distance: number; // view distance in meters, 800..8000
+  valleyFactor: number; // 0..1 fog pooling in low flat ground
+  entryHaze: number; // 0..1 high-altitude haze
+}
+
+/** Approximate surface temperature from sun elevation and altitude. */
+export function temperatureForContext(ctx: EnvironmentalContext, cameraAltitude: number): number {
+  const solar = Math.max(0, Math.sin(Math.max(-0.2, ctx.sun.elevation)));
+  const dayWarmth = ctx.timeOfDay === "night" ? -8 : solar * 14;
+  return 20 + dayWarmth - cameraAltitude * 0.0065 - ctx.clouds.coverage * 4;
+}
+
+function humidityForContext(ctx: EnvironmentalContext): number {
+  const precip = ctx.weather.precipitationIntensity * 0.65;
+  const murk = (1 - ctx.atmosphere.visibility / 10000) * 0.3;
+  const night = ctx.timeOfDay === "night" ? 0.1 : 0;
+  return Math.min(1, 0.2 + precip + murk + night);
+}
+
+function weatherMultiplier(kind: EnvironmentalContext["weather"]["kind"]): number {
+  if (kind === "storm") return 1;
+  if (kind === "rain") return 0.7;
+  if (kind === "overcast") return 0.4;
+  return 0.15;
 }
 
 export function deriveFogState(ctx: EnvironmentalContext, cameraAltitude: number): FogState {
-  const temp = 20; // placeholder, could be from ctx if added
-  const humidity = ctx.weather.precipitationIntensity * 0.6 + 0.2;
-  const weatherMul = ctx.weather.kind === "storm" ? 1 : ctx.weather.kind === "rain" ? 0.7 : ctx.weather.kind === "overcast" ? 0.4 : 0.15;
-  const altitudeFactor = Math.max(0, 1 - cameraAltitude / 2500); // low -> more fog
-  const valleyFactor = ctx.terrain.height < 50 && ctx.terrain.slope < 0.15 ? 0.8 : 0.2;
-  const density = Math.min(1, humidity * 0.7 + weatherMul * 0.5 + (1 - ctx.atmosphere.visibility / 10000) * 0.4 + altitudeFactor * 0.2);
+  const temp = temperatureForContext(ctx, cameraAltitude);
+  const humidity = humidityForContext(ctx);
+  const weatherMul = weatherMultiplier(ctx.weather.kind);
+  const altitudeFactor = Math.max(0, 1 - cameraAltitude / 2500);
+  // Smooth valley pooling: low and flat ground holds fog, slopes drain it.
+  const lowFactor = Math.max(0, 1 - Math.max(0, ctx.terrain.height) / 120);
+  const flatFactor = Math.max(0, 1 - ctx.terrain.slope / 0.3);
+  const valleyFactor = Math.min(1, lowFactor * 0.6 + flatFactor * 0.4);
+  // Cold air holds fog longer.
+  const coldMul = temp < 8 ? 1.25 : temp < 14 ? 1.1 : 1;
+  const density = Math.min(
+    1,
+    (humidity * 0.7 + weatherMul * 0.5 + (1 - ctx.atmosphere.visibility / 10000) * 0.4 + altitudeFactor * 0.2) * coldMul,
+  );
   const height = 20 + density * 280;
   const distance = 800 + (1 - density) * 7200;
-  const entryHaze = cameraAltitude > 800 ? Math.min(1, (cameraAltitude - 800) / 2000) * ctx.atmosphere.haze : 0;
+  const entryHaze =
+    cameraAltitude > 800 ? Math.min(1, (cameraAltitude - 800) / 2000) * ctx.atmosphere.haze : 0;
   return { density: density * (0.5 + valleyFactor * 0.5), height, distance, valleyFactor, entryHaze };
 }
 
@@ -37,27 +74,28 @@ export interface FogSystem {
   lastState: FogState | null;
 }
 
-export function createFogSystem(scene: THREE.Scene, initialColor = 0x8aa0b8): FogSystem {
+const _fogBase = new THREE.Color();
+
+export function createFogSystem(scene: THREE.Scene, initialColor = FOG_BASE): FogSystem {
   const fog = new THREE.FogExp2(initialColor, 0.00012);
   scene.fog = fog;
   return { fog, lastState: null };
 }
 
 export function tickFog(sys: FogSystem, state: FogState, sunColor: THREE.Color): void {
-  sys.fog.density = 0.00006 + state.density * 0.00032 + state.entryHaze * 0.00018;
-  // Color lerp: fog density high -> grey, valley -> warm slightly
-  const base = new THREE.Color(0x8aa0b8);
-  base.lerp(sunColor, state.valleyFactor * 0.25);
-  sys.fog.color.copy(base);
+  sys.fog.density = BASE_DENSITY + state.density * DENSITY_SCALE + state.entryHaze * HAZE_SCALE;
+  _fogBase.set(FOG_BASE);
+  _fogBase.lerp(sunColor, state.valleyFactor * 0.25);
+  sys.fog.color.copy(_fogBase);
   sys.lastState = state;
-  // God-ray feed hint: SESSION 2 bisa baca state.density untuk godRays fogDensity
 }
 
+/** View distance after fog attenuation. */
 export function getFogVisibility(state: FogState): number {
   return state.distance * (1 - state.density * 0.5);
 }
 
+/** Fog contribution consumed by the god-ray resolver. */
 export function fogDensityForGodRay(state: FogState): number {
   return state.density * 0.7 + state.valleyFactor * 0.15 + state.entryHaze * 0.2;
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/godRays.ts
+++ b/apps/game/src/renderer/scene3d/planetary/godRays.ts
@@ -4,18 +4,21 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/godRays.ts - 10.X.1 GodRayContext mandatory: mountain gap/valley/canopy/cloud gap shafts, coupled sun+fog+cloud+terrain+camera. Zoom dari blueprint "GodRayContext { sunDirection/elevation/intensity, atmosphericDensity, fogDensity, cloudDensity/coverage, terrain/vegetation occlusion, weather, visibility, cameraPosition }".
-
-// Blueprint 10.X §5 cuma "God Rays mandatory ... through mountain gaps/valleys/canopy/cloud gaps — coupled, not static overlay".
-// File ini ZOOM jadi: GodRayContext derived dari EnvironmentalContext + visibility/terrain, shafts via THREE Volumetric (cone geometry + shader-like opacity), occlusion via heightmap, gak overlay statik.
-// WIRE NOTE for SESSION 2: import { createGodRaySystem, updateGodRays } from "./planetary/godRays" di scene3d/index.ts. Create sekali, update tiap frame dengan EnvironmentalContext + cameraPosition + terrain occlusion.
+// planetary/godRays.ts - 10.X.1 volumetric light shafts.
+// Shafts appear through mountain gaps, valleys, canopy breaks, and cloud gaps.
+// Opacity couples sun, fog, cloud cover, terrain occlusion, weather, and camera
+// distance. Cone meshes approximate volumetrics without a postprocess pass.
+// Visual-only: reads EnvironmentalContext, never writes authority state.
 
 import * as THREE from "three";
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
 
-// ---------------------------------------------------------------------------
-// GodRayContext — single source, derived, gak persist
-// ---------------------------------------------------------------------------
+const SHAFT_COUNT = 6;
+const SHAFT_BASE_HEIGHT = 800;
+const SHAFT_BASE_RADIUS = 120;
+const FIELD_HALF = 1800;
+const MAX_OPACITY = 0.22;
+const VISIBILITY_THRESHOLD = 0.015;
 
 export interface GodRayContext {
   sunDirection: { x: number; y: number; z: number };
@@ -25,17 +28,22 @@ export interface GodRayContext {
   fogDensity: number; // 0..1
   cloudDensity: number;
   cloudCoverage: number;
-  terrainOcclusion: number; // 0..1 (mountain gap 0, canopy 0.8)
-  visibility: number; // m
+  terrainOcclusion: number; // 0..1 (0 = open gap, 0.8 = dense canopy)
+  visibility: number; // meters
   weatherKind: "clear" | "overcast" | "rain" | "storm";
   cameraPosition: { x: number; y: number; z: number };
-  gaps: number; // 0..1 (cloud gaps = 1 - coverage)
+  gaps: number; // 0..1 cloud gaps (1 - coverage)
 }
 
+/**
+ * Derive the shaft context from authority state.
+ * terrainOcclusion should come from a heightmap raycast when available;
+ * the default is a neutral mid value.
+ */
 export function deriveGodRayContext(
   ctx: EnvironmentalContext,
   cameraPosition: { x: number; y: number; z: number },
-  terrainOcclusion = 0.3, // default 0.3, SESSION 2 bisa raycast heightmap untuk gap
+  terrainOcclusion = 0.3,
 ): GodRayContext {
   return {
     sunDirection: ctx.sun.direction,
@@ -53,24 +61,35 @@ export function deriveGodRayContext(
   };
 }
 
-// ---------------------------------------------------------------------------
-// God ray shafts — cone geometry, opacity coupled
-// ---------------------------------------------------------------------------
-
 export interface GodRaySystem {
   group: THREE.Group;
-  shafts: THREE.Mesh[]; // 6 shafts pool
+  shafts: THREE.Mesh[];
 }
 
-export function createGodRaySystem(): GodRaySystem {
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const _sunDir = new THREE.Vector3();
+const _down = new THREE.Vector3(0, -1, 0);
+
+/** Create the pooled shaft cones. Seed keeps gap placement deterministic. */
+export function createGodRaySystem(seed = 0x609d): GodRaySystem {
   const group = new THREE.Group();
   group.name = "godRays";
   const shafts: THREE.Mesh[] = [];
-  // 6 volumetric cones (height 800, radius 120) — pool, gak alloc tiap frame
-  for (let i = 0; i < 6; i++) {
-    const geo = new THREE.ConeGeometry(120, 800, 8, 1, true);
+  const rng = mulberry32(seed);
+  for (let i = 0; i < SHAFT_COUNT; i++) {
+    const geo = new THREE.ConeGeometry(SHAFT_BASE_RADIUS, SHAFT_BASE_HEIGHT, 8, 1, true);
     const mat = new THREE.MeshBasicMaterial({
-      color: 0xfff2c0, // warm sun
+      color: 0xfff2c0,
       transparent: true,
       opacity: 0.0,
       depthWrite: false,
@@ -78,93 +97,95 @@ export function createGodRaySystem(): GodRaySystem {
       blending: THREE.AdditiveBlending,
     });
     const mesh = new THREE.Mesh(geo, mat);
-    mesh.position.y = 400; // cone center 400m up
-    mesh.rotation.x = Math.PI; // point down (sun -> surface)
+    mesh.position.y = SHAFT_BASE_HEIGHT / 2;
+    mesh.rotation.x = Math.PI;
     mesh.visible = false;
     mesh.name = `godRay-${i}`;
-    // Random gap offset biar shafts gak numpuk
-    (mesh as any)._gapPos = new THREE.Vector2((Math.random() - 0.5) * 1800, (Math.random() - 0.5) * 1800);
+    mesh.userData = {
+      ...mesh.userData,
+      gapX: (rng() - 0.5) * FIELD_HALF,
+      gapZ: (rng() - 0.5) * FIELD_HALF,
+    };
     group.add(mesh);
     shafts.push(mesh);
   }
   return { group, shafts };
 }
 
-/**
- * Update tiap frame: coupled sun+fog+cloud+terrain+camera, bukan overlay statik.
- * - sunIntensity <0.15 atau elevation <0.12 -> invisible (sun low/gak ada)
- * - cloudCoverage 0.9 + fog 0.6 -> opacity 0.18, clear -> 0.03
- * - terrainOcclusion 0.8 (canopy) -> opacity x0.4, gap -> x1.2
- * - visibility <2000 (storm) -> shafts lebih pendek + lebih tebal
- * - cameraPosition -> shafts orient ke sunDirection, fade dengan distance
- */
-export function updateGodRays(
-  sys: GodRaySystem,
-  gctx: GodRayContext,
-  dt: number,
-): void {
-  const sunLow = gctx.sunElevation < 0.12 || gctx.sunIntensity < 0.15;
-  const heavyCloud = gctx.cloudCoverage > 0.85 && gctx.fogDensity > 0.5;
-  if (sunLow && !heavyCloud) {
-    sys.shafts.forEach((s) => (s.visible = false));
-    return;
-  }
-
-  // Base opacity: sunIntensity 0.8 * gaps 0.4 * (1 - terrainOcclusion 0.3) * fog 0.3
-  const baseOpacity =
-    gctx.sunIntensity * 0.45 * (0.2 + gctx.gaps * 0.8) * (1 - gctx.terrainOcclusion * 0.6) * (0.3 + gctx.fogDensity * 0.7) * (0.5 + gctx.cloudDensity * 0.5);
-
-  // Visibility -> shaft length/thickness: storm visibility 2000 -> short thick, clear 10000 -> long thin
-  const visFactor = Math.min(1, gctx.visibility / 10000);
-  const shaftHeight = 400 + visFactor * 600; // 400..1000
-  const shaftRadius = 80 + (1 - visFactor) * 80; // 80..160
-
-  sys.shafts.forEach((shaft, idx) => {
-    const mat = shaft.material as THREE.MeshBasicMaterial;
-    const gapPos = (shaft as any)._gapPos as THREE.Vector2;
-
-    // Wind drift via cloud gap: gaps gerak pelan 2 units/s
-    gapPos.x = (gapPos.x + Math.cos(gctx.sunElevation) * 2 * dt * (0.5 + gctx.cloudCoverage * 0.5)) % 2000;
-    gapPos.y = (gapPos.y + Math.sin(gctx.sunElevation) * 2 * dt * (0.5 + gctx.cloudCoverage * 0.5)) % 2000;
-
-    shaft.position.x = gapPos.x;
-    shaft.position.z = gapPos.y;
-    shaft.position.y = shaftHeight / 2;
-
-    // Orient ke sun direction (shafts point dari sun)
-    const sunDir = new THREE.Vector3(gctx.sunDirection.x, gctx.sunDirection.y, gctx.sunDirection.z).normalize();
-    shaft.quaternion.setFromUnitVectors(new THREE.Vector3(0, -1, 0), sunDir);
-
-    // Scale via visFactor
-    shaft.scale.set(shaftRadius / 120, shaftHeight / 800, shaftRadius / 120);
-
-    // Opacity coupled + flicker halus via time
-    const flicker = 0.92 + Math.sin(Date.now() * 0.0007 + idx * 1.3) * 0.08;
-    const weatherMul = gctx.weatherKind === "storm" ? 1.3 : gctx.weatherKind === "clear" ? 0.7 : 1;
-    mat.opacity = Math.min(0.22, baseOpacity * flicker * weatherMul);
-    // Color via sun: dawn warm, day white, storm grey-yellow
-    const isWarm = gctx.sunElevation < 0.5;
-    mat.color.set(isWarm ? 0xfff2c0 : gctx.weatherKind === "storm" ? 0xd9ccaa : 0xffffff);
-
-    // Distance fade: camera jauh >800m dari shaft -> fade
-    const camDist = Math.hypot(shaft.position.x - gctx.cameraPosition.x, shaft.position.z - gctx.cameraPosition.z);
-    const distFade = camDist > 800 ? Math.max(0, 1 - (camDist - 800) / 1200) : 1;
-    mat.opacity *= distFade;
-
-    shaft.visible = mat.opacity > 0.015;
-  });
-}
-
-// WIRE NOTE: SESSION 2
-// import { deriveGodRayContext, createGodRaySystem, updateGodRays } from "./planetary/godRays";
-// const godRays = createGodRaySystem(); ctx.scene.add(godRays.group);
-// // di frame loop: const gctx = deriveGodRayContext(envCtx, camera.position, terrainOcclusion); updateGodRays(godRays, gctx, dt);
-
+/** Cheap visibility pre-check so callers can skip the full update. */
 export function isGodRayVisible(gctx: GodRayContext): boolean {
   return gctx.sunIntensity > 0.12 && gctx.sunElevation > 0.08 && gctx.gaps > 0.08;
 }
 
 export function godRayIntensity(gctx: GodRayContext): number {
-  return gctx.sunIntensity * gctx.gaps * (1 - gctx.terrainOcclusion*0.5) * (0.4 + gctx.fogDensity*0.6);
+  return (
+    gctx.sunIntensity *
+    gctx.gaps *
+    (1 - gctx.terrainOcclusion * 0.5) *
+    (0.4 + gctx.fogDensity * 0.6)
+  );
 }
 
+/**
+ * Update shafts one frame. timeSec is the deterministic clock
+ * (worldTime/1000 + tick * dt); it drives drift and shimmer.
+ */
+export function updateGodRays(
+  sys: GodRaySystem,
+  gctx: GodRayContext,
+  dt: number,
+  timeSec?: number,
+): void {
+  const now = timeSec ?? 0;
+  const sunLow = gctx.sunElevation < 0.12 || gctx.sunIntensity < 0.15;
+  const heavyCloud = gctx.cloudCoverage > 0.85 && gctx.fogDensity > 0.5;
+  if (sunLow && !heavyCloud) {
+    for (const s of sys.shafts) s.visible = false;
+    return;
+  }
+
+  const baseOpacity =
+    gctx.sunIntensity *
+    0.45 *
+    (0.2 + gctx.gaps * 0.8) *
+    (1 - gctx.terrainOcclusion * 0.6) *
+    (0.3 + gctx.fogDensity * 0.7) *
+    (0.5 + gctx.cloudDensity * 0.5);
+
+  const visFactor = Math.min(1, gctx.visibility / 10000);
+  const shaftHeight = 400 + visFactor * 600;
+  const shaftRadius = 80 + (1 - visFactor) * 80;
+  const weatherMul = gctx.weatherKind === "storm" ? 1.3 : gctx.weatherKind === "clear" ? 0.7 : 1;
+  const isWarm = gctx.sunElevation < 0.5;
+
+  _sunDir.set(gctx.sunDirection.x, gctx.sunDirection.y, gctx.sunDirection.z).normalize();
+
+  sys.shafts.forEach((shaft, idx) => {
+    const mat = shaft.material as THREE.MeshBasicMaterial;
+    const gapDrift = 0.5 + gctx.cloudCoverage * 0.5;
+    let gapX = (shaft.userData["gapX"] as number) + Math.cos(gctx.sunElevation) * 2 * dt * gapDrift;
+    let gapZ = (shaft.userData["gapZ"] as number) + Math.sin(gctx.sunElevation) * 2 * dt * gapDrift;
+    gapX = ((gapX % 2000) + 2000) % 2000 - 1000;
+    gapZ = ((gapZ % 2000) + 2000) % 2000 - 1000;
+    shaft.userData["gapX"] = gapX;
+    shaft.userData["gapZ"] = gapZ;
+
+    shaft.position.x = gapX;
+    shaft.position.z = gapZ;
+    shaft.position.y = shaftHeight / 2;
+    shaft.quaternion.setFromUnitVectors(_down, _sunDir);
+    shaft.scale.set(shaftRadius / SHAFT_BASE_RADIUS, shaftHeight / SHAFT_BASE_HEIGHT, shaftRadius / SHAFT_BASE_RADIUS);
+
+    const flicker = 0.92 + Math.sin(now * 0.7 + idx * 1.3) * 0.08;
+    let opacity = Math.min(MAX_OPACITY, baseOpacity * flicker * weatherMul);
+    mat.color.set(isWarm ? 0xfff2c0 : gctx.weatherKind === "storm" ? 0xd9ccaa : 0xffffff);
+
+    const camDist = Math.hypot(
+      shaft.position.x - gctx.cameraPosition.x,
+      shaft.position.z - gctx.cameraPosition.z,
+    );
+    if (camDist > 800) opacity *= Math.max(0, 1 - (camDist - 800) / 1200);
+    mat.opacity = opacity;
+    shaft.visible = opacity > VISIBILITY_THRESHOLD;
+  });
+}

--- a/apps/game/src/renderer/scene3d/planetary/index.ts
+++ b/apps/game/src/renderer/scene3d/planetary/index.ts
@@ -30,3 +30,4 @@ export * from "./coastal";
 export * from "./hydrological";
 export * from "./atmosphericContinuity";
 export * from "./emergencyLanding";
+export * from "./wire10X";

--- a/apps/game/src/renderer/scene3d/planetary/lightning.ts
+++ b/apps/game/src/renderer/scene3d/planetary/lightning.ts
@@ -4,35 +4,44 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/lightning.ts - 10.X.2 LightningEvent -> cloud flash + terrain/ocean/facility illumination + reflection. Zoom dari blueprint "LightningEvent { eventId, timestamp, position, direction, intensity, duration, cloudResponse, environmentResponse } -> cloud flash + sky/terrain/ocean/facility + reflection (bolt is only one part)".
-
-// WIRE NOTE for SESSION 2: import { createLightningSystem, triggerLightning, tickLightning } from "./planetary/lightning" di scene3d/index.ts. Trigger deterministik dari EnvironmentalContext.tick % 600 + weather storm.
+// planetary/lightning.ts - 10.X.2 lightning event chain.
+// Deterministic storm strikes: a jagged bolt plus a wide sky flash that
+// illuminates terrain, ocean, and facilities. The bolt is one part of the
+// event; flashLevel exposes the environment response for other resolvers.
+// Visual-only: no gameplay state is read or written.
 
 import * as THREE from "three";
+
+const FLASH_RANGE = 800;
+const BOLT_SEGMENTS = 7;
+const BOLT_HEIGHT = 300;
+const TRIGGER_MOD = 600;
+const TRIGGER_THRESHOLD = 3;
+const THREAT_WINDOW_MS = 5000;
 
 export interface LightningEvent {
   eventId: string;
   timestamp: number; // ms
-  position: { x: number; y: number; z: number }; // world pos near cloud
+  position: { x: number; y: number; z: number };
   intensity: number; // 0..1
-  duration: number; // ms 120..280
-  flashColor: number; // hex 0xffffff or 0xaaccff for storm
+  duration: number; // ms
+  flashColor: number;
 }
 
 export interface LightningSystem {
-  flashLight: THREE.PointLight; // 800m range, sky flash
-  boltMesh: THREE.Line; // simple bolt
+  flashLight: THREE.PointLight;
+  boltMesh: THREE.Line;
   lastEvent: LightningEvent | null;
   flashUntil: number;
+  flashLevel: number; // 0..1 current environment illumination
 }
 
 export function createLightningSystem(): LightningSystem {
-  const light = new THREE.PointLight(0xffffff, 0, 800, 1.8);
+  const light = new THREE.PointLight(0xffffff, 0, FLASH_RANGE, 1.8);
   light.name = "lightningFlash";
   light.visible = false;
-  // Bolt: 3 segments jagged
   const geo = new THREE.BufferGeometry().setFromPoints([
-    new THREE.Vector3(0, 300, 0),
+    new THREE.Vector3(0, BOLT_HEIGHT, 0),
     new THREE.Vector3(8, 200, 3),
     new THREE.Vector3(-6, 100, -4),
     new THREE.Vector3(0, 0, 0),
@@ -41,24 +50,54 @@ export function createLightningSystem(): LightningSystem {
   const line = new THREE.Line(geo, mat);
   line.visible = false;
   line.name = "lightningBolt";
-  return { flashLight: light, boltMesh: line, lastEvent: null, flashUntil: 0 };
+  line.frustumCulled = false;
+  return { flashLight: light, boltMesh: line, lastEvent: null, flashUntil: 0, flashLevel: 0 };
 }
 
-/** Deterministik trigger: storm && tick % 600 == hash%600 -> lightning. Dipanggil tiap tick. */
+/** Deterministic strike schedule: ~3 strikes per 600 ticks of storm. */
 export function shouldTriggerLightning(tick: number, planetSeed: number, isStorm: boolean): boolean {
   if (!isStorm) return false;
-  const h = (planetSeed * 374761393 + tick * 668265263) % 600;
-  return h < 3; // ~0.5% per tick ~ 3 per 60 sec storm
+  const h = (planetSeed * 374761393 + tick * 668265263) % TRIGGER_MOD;
+  return h < TRIGGER_THRESHOLD;
 }
 
-export function triggerLightning(sys: LightningSystem, pos: { x: number; y: number; z: number }, now: number): LightningEvent {
+function hash2(a: number, b: number): number {
+  let h = (Math.imul(a | 0, 374761393) + Math.imul(b | 0, 668265263)) | 0;
+  h = Math.imul(h ^ (h >>> 13), 1274126177);
+  return ((h ^ (h >>> 16)) >>> 0) / 4294967296;
+}
+
+/** Rebuild the bolt as a deterministic jagged path for this strike. */
+function rebuildBolt(sys: LightningSystem, seedX: number, seedZ: number): void {
+  const pts: THREE.Vector3[] = [];
+  for (let i = 0; i <= BOLT_SEGMENTS; i++) {
+    const t = i / BOLT_SEGMENTS;
+    const spread = (1 - t) * 22;
+    const x = (hash2(seedX + i * 31, seedZ) - 0.5) * 2 * spread;
+    const z = (hash2(seedZ + i * 57, seedX) - 0.5) * 2 * spread;
+    pts.push(new THREE.Vector3(x, BOLT_HEIGHT * (1 - t), z));
+  }
+  sys.boltMesh.geometry.dispose();
+  sys.boltMesh.geometry = new THREE.BufferGeometry().setFromPoints(pts);
+}
+
+export function triggerLightning(
+  sys: LightningSystem,
+  pos: { x: number; y: number; z: number },
+  now: number,
+): LightningEvent {
+  const sx = Math.floor(pos.x);
+  const sz = Math.floor(pos.z);
+  const r1 = hash2(sx, Math.floor(now / 1000));
+  const r2 = hash2(sz, Math.floor(now / 700));
+  const r3 = hash2(sx + sz, Math.floor(now / 1300));
   const ev: LightningEvent = {
-    eventId: `lt-${now}-${Math.floor(pos.x)}`,
+    eventId: `lt-${Math.floor(now)}-${sx}-${sz}`,
     timestamp: now,
     position: pos,
-    intensity: 0.7 + Math.random() * 0.3,
-    duration: 120 + Math.random() * 160,
-    flashColor: Math.random() > 0.5 ? 0xffffff : 0xaaccff,
+    intensity: 0.7 + r1 * 0.3,
+    duration: 120 + r2 * 160,
+    flashColor: r3 > 0.5 ? 0xffffff : 0xaaccff,
   };
   sys.lastEvent = ev;
   sys.flashUntil = now + ev.duration;
@@ -66,32 +105,39 @@ export function triggerLightning(sys: LightningSystem, pos: { x: number; y: numb
   sys.flashLight.color.set(ev.flashColor);
   sys.flashLight.intensity = 18 * ev.intensity;
   sys.flashLight.visible = true;
+  rebuildBolt(sys, sx, sz);
   sys.boltMesh.position.set(pos.x, 0, pos.z);
   (sys.boltMesh.material as THREE.LineBasicMaterial).opacity = 0.95;
   sys.boltMesh.visible = true;
+  sys.flashLevel = ev.intensity;
   return ev;
 }
 
+/**
+ * Decay the flash. Flicker derives from the clock, so replays are stable.
+ * flashLevel tracks the environment response for terrain/ocean/facility use.
+ */
 export function tickLightning(sys: LightningSystem, now: number): void {
-  if (now > sys.flashUntil) {
+  if (!sys.lastEvent || now > sys.flashUntil) {
     sys.flashLight.visible = false;
     sys.boltMesh.visible = false;
+    sys.flashLevel = 0;
     return;
   }
   const remaining = sys.flashUntil - now;
-  const mat = sys.boltMesh.material as THREE.LineBasicMaterial;
-  // Flash decay: 18 -> 2, bolt opacity 0.95 -> 0
-  const t = remaining / (sys.lastEvent?.duration ?? 200);
-  sys.flashLight.intensity = 2 + (sys.lastEvent?.intensity ?? 0.8) * 16 * t * (0.8 + Math.random() * 0.4);
-  mat.opacity = t * 0.95;
-  // Flicker 2x during flash
-  if (Math.random() > 0.7) sys.flashLight.intensity *= 0.6;
+  const duration = sys.lastEvent.duration || 200;
+  const t = remaining / duration;
+  const flicker = 0.8 + 0.2 * Math.sin(now * 0.11 + sys.lastEvent.timestamp * 0.001);
+  const dip = Math.sin(now * 0.031) > 0.55 ? 0.6 : 1;
+  sys.flashLight.intensity = (2 + sys.lastEvent.intensity * 16 * t * flicker) * dip;
+  (sys.boltMesh.material as THREE.LineBasicMaterial).opacity = t * 0.95;
+  sys.flashLevel = sys.lastEvent.intensity * t;
 }
 
+/** Decaying strike threat for audio and exposure resolvers. */
 export function getLightningThreat(sys: LightningSystem, now: number): number {
   if (!sys.lastEvent) return 0;
   const age = now - sys.lastEvent.timestamp;
-  if (age > 5000) return 0;
-  return sys.lastEvent.intensity * Math.max(0, 1 - age/5000);
+  if (age > THREAT_WINDOW_MS) return 0;
+  return sys.lastEvent.intensity * Math.max(0, 1 - age / THREAT_WINDOW_MS);
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/localVolumes.ts
+++ b/apps/game/src/renderer/scene3d/planetary/localVolumes.ts
@@ -4,13 +4,19 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/localVolumes.ts - 10.X.4 Local effect volumes around player/landing/facility (rain/vegetation/dust/wake/fog/god rays/particles), distant = low cost. Zoom dari blueprint "Local effect volumes around player/landing/facility (rain/vegetation/dust/wake/fog/god rays/particles), distant = low cost".
-
-// WIRE NOTE for SESSION 2: import { createLocalVolumeManager, updateLocalVolumes } from "./planetary/localVolumes" di scene3d/index.ts. Manager per player/facility, update tiap frame dengan player pos + facility pos.
+// planetary/localVolumes.ts - 10.X.4 local effect volumes.
+// Effects are only simulated at full cost near the player, landing site, or
+// facility; distant volumes decay to a cheap share. The frame loop reads
+// each volume cost to decide which resolvers tick at full rate.
+// Pure manager logic: no authority state, no rendering.
 
 import * as THREE from "three";
 
 export type VolumeKind = "player" | "facility" | "landing";
+
+const IMPORTANCE: Record<VolumeKind, number> = { player: 1.0, landing: 0.9, facility: 0.7 };
+const FAR_MULTIPLIER = 2;
+const FAR_TIMEOUT_SEC = 5;
 
 export interface LocalVolume {
   id: string;
@@ -18,12 +24,15 @@ export interface LocalVolume {
   center: THREE.Vector3;
   radius: number; // 80..300
   active: boolean;
-  cost: number; // 0..1
+  cost: number; // 0..1 effect budget share
+  farTime: number; // seconds spent beyond deactivation range
 }
 
 export interface LocalVolumeManager {
   volumes: Map<string, LocalVolume>;
 }
+
+const _toPlayer = new THREE.Vector3();
 
 export function createLocalVolumeManager(): LocalVolumeManager {
   return { volumes: new Map() };
@@ -38,7 +47,7 @@ export function ensureVolume(
 ): LocalVolume {
   let v = mgr.volumes.get(id);
   if (!v) {
-    v = { id, kind, center: new THREE.Vector3(center.x, center.y, center.z), radius, active: true, cost: 0 };
+    v = { id, kind, center: new THREE.Vector3(center.x, center.y, center.z), radius, active: true, cost: 0, farTime: 0 };
     mgr.volumes.set(id, v);
   } else {
     v.center.set(center.x, center.y, center.z);
@@ -49,11 +58,9 @@ export function ensureVolume(
 }
 
 /**
- * Update: distant volumes -> low cost, near -> full. Cost via distance + kind importance.
- * - player volume always cost 1 if active (near)
- * - facility 200m radius cost 0.8 within 80m, 0.2 beyond 200m
- * - landing transient cost 1 during touchdown, 0.1 after
- * SESSION 2 reads v.cost to decide whether to tick rain/vegetation/dust/wake per volume.
+ * Recompute every volume cost from player distance. Full cost inside 40% of
+ * the radius, fading to a floor beyond the edge. Volumes far outside twice
+ * the radius for over 5 seconds deactivate until re-ensured.
  */
 export function updateLocalVolumes(
   mgr: LocalVolumeManager,
@@ -61,17 +68,19 @@ export function updateLocalVolumes(
   dt: number,
 ): void {
   for (const v of mgr.volumes.values()) {
-    const dist = v.center.distanceTo(new THREE.Vector3(playerPos.x, playerPos.y, playerPos.z));
-    // Cost = importance * distanceFactor
-    const importance = v.kind === "player" ? 1.0 : v.kind === "landing" ? 0.9 : 0.7;
-    const distFactor = dist < v.radius * 0.4 ? 1 : dist < v.radius ? 1 - (dist - v.radius * 0.4) / (v.radius * 0.6) * 0.6 : 0.15;
+    _toPlayer.set(playerPos.x, playerPos.y, playerPos.z);
+    const dist = v.center.distanceTo(_toPlayer);
+    const importance = IMPORTANCE[v.kind];
+    let distFactor: number;
+    if (dist < v.radius * 0.4) distFactor = 1;
+    else if (dist < v.radius) distFactor = 1 - ((dist - v.radius * 0.4) / (v.radius * 0.6)) * 0.6;
+    else distFactor = 0.15;
     v.cost = Math.max(0, Math.min(1, importance * distFactor));
-    // Auto deactivate if far > 2*radius for 5s (SESSION 2 can cull)
-    if (dist > v.radius * 2) {
-      (v as any)._farTime = ((v as any)._farTime ?? 0) + dt;
-      if ((v as any)._farTime > 5) v.active = false;
+    if (dist > v.radius * FAR_MULTIPLIER) {
+      v.farTime += dt;
+      if (v.farTime > FAR_TIMEOUT_SEC) v.active = false;
     } else {
-      (v as any)._farTime = 0;
+      v.farTime = 0;
       v.active = true;
     }
   }
@@ -90,4 +99,3 @@ export function countActiveVolumes(mgr: LocalVolumeManager): number {
   for (const v of mgr.volumes.values()) if (v.active) n++;
   return n;
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/oceanSystem.ts
+++ b/apps/game/src/renderer/scene3d/planetary/oceanSystem.ts
@@ -4,12 +4,21 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/oceanSystem.ts - 10.X.3 Ocean OceanState + vessel spray/wake/foam + sun reflection. Zoom dari blueprint "OceanState { wave direction/amplitude/frequency, wind relationship, roughness, depth, reflection, foam, disturbance } + SUN/OCEAN specular + VESSEL -> spray/wake/foam".
-
-// WIRE NOTE for SESSION 2: import { deriveOceanState, createOceanWake, tickOcean } from "./planetary/oceanSystem" di scene3d/index.ts. Tick per frame dengan EnvironmentalContext.ocean + wind + sun + vessel velocity.
+// planetary/oceanSystem.ts - 10.X.3 vessel-ocean interaction.
+// Derives the per-frame ocean state (amplitude, roughness, foam, sun
+// reflection) from authority ocean, wind, sun, and cloud state, and drives
+// the vessel wake ribbon plus advected spray. The base wave surface itself
+// lives in ocean.ts; this file only adds the interaction layer.
+// Visual-only: reads state, never writes authority.
 
 import * as THREE from "three";
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
+
+const WAKE_SPEED_MIN = 2;
+const WAKE_LENGTH = 14;
+const SPRAY_COUNT = 400;
+const SPRAY_HALF = 8;
+const SPRAY_HEIGHT = 8;
 
 export interface OceanFrameState {
   waveAmplitude: number;
@@ -23,13 +32,13 @@ export function deriveOceanFrame(ctx: EnvironmentalContext, vesselSpeed: number)
   const ocean = ctx.ocean;
   const wind = ctx.wind;
   const sun = ctx.sun;
-  // Wind relationship: wind 2..10 -> amplitude 1..3, roughness 0.4..0.75
   const windAmp = ocean.waveAmplitude * (0.7 + wind.speed * 0.06);
   const roughness = Math.min(0.85, ocean.roughness * (0.6 + wind.turbulence * 0.5) + vesselSpeed * 0.02);
-  // Sun reflection: sunIntensity * (1 - roughness*0.5) * (1 - cloudCoverage*0.3)
   const reflection = sun.intensity * (1 - roughness * 0.4) * (1 - ctx.clouds.coverage * 0.25) * 0.9;
-  // Foam: wind>6 + vesselSpeed>4
-  const foam = Math.min(1, ocean.foam * 0.7 + (wind.speed > 6 ? 0.25 : 0) + (vesselSpeed > 4 ? 0.2 : 0));
+  const foam = Math.min(
+    1,
+    ocean.foam * 0.7 + (wind.speed > 6 ? 0.25 : 0) + (vesselSpeed > 4 ? 0.2 : 0),
+  );
   return { waveAmplitude: windAmp, waveFrequency: ocean.waveFrequency, roughness, foam, reflection };
 }
 
@@ -38,58 +47,101 @@ export interface OceanWakeSystem {
   sprayPoints: THREE.Points;
 }
 
-export function createOceanWake(): OceanWakeSystem {
-  // Wake: plane 40x120 trailing vessel
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Build the wake ribbon and spray pool. Seed keeps init deterministic. */
+export function createOceanWake(seed = 0x0ce4): OceanWakeSystem {
   const wakeGeo = new THREE.PlaneGeometry(12, 40);
-  const wakeMat = new THREE.MeshBasicMaterial({ color: 0xaaccff, transparent: true, opacity: 0, depthWrite: false, side: THREE.DoubleSide });
+  const wakeMat = new THREE.MeshBasicMaterial({
+    color: 0xaaccff,
+    transparent: true,
+    opacity: 0,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+  });
   const wake = new THREE.Mesh(wakeGeo, wakeMat);
   wake.rotation.x = -Math.PI / 2;
   wake.position.y = 0.08;
   wake.name = "oceanWake";
   wake.visible = false;
-  // Spray: 400 points
+
+  const rng = mulberry32(seed);
   const sprayGeo = new THREE.BufferGeometry();
-  const cnt = 400;
-  const pos = new Float32Array(cnt * 3);
-  for (let i = 0; i < cnt; i++) pos[i * 3 + 1] = Math.random() * 8;
+  const pos = new Float32Array(SPRAY_COUNT * 3);
+  for (let i = 0; i < SPRAY_COUNT; i++) {
+    pos[i * 3] = (rng() - 0.5) * SPRAY_HALF;
+    pos[i * 3 + 1] = rng() * SPRAY_HEIGHT;
+    pos[i * 3 + 2] = (rng() - 0.5) * SPRAY_HALF;
+  }
   sprayGeo.setAttribute("position", new THREE.BufferAttribute(pos, 3));
-  const sprayMat = new THREE.PointsMaterial({ color: 0xffffff, size: 0.45, transparent: true, opacity: 0, depthWrite: false });
+  const sprayMat = new THREE.PointsMaterial({
+    color: 0xffffff,
+    size: 0.45,
+    transparent: true,
+    opacity: 0,
+    depthWrite: false,
+  });
   const spray = new THREE.Points(sprayGeo, sprayMat);
   spray.name = "oceanSpray";
+  spray.frustumCulled = false;
   return { wakeMesh: wake, sprayPoints: spray };
 }
 
+/**
+ * Advance wake and spray one frame. Spray advects downwind and wraps inside
+ * its box, so motion stays smooth instead of jittering randomly.
+ */
 export function tickOcean(
   sys: OceanWakeSystem,
   state: OceanFrameState,
   vesselPos: { x: number; z: number; heading: number },
   vesselSpeed: number,
   dt: number,
+  wind?: { direction: number; speed: number },
 ): void {
-  // Wake visible if vesselSpeed >2 and over ocean
-  const moving = vesselSpeed > 2;
+  const moving = vesselSpeed > WAKE_SPEED_MIN;
   sys.wakeMesh.visible = moving;
   sys.sprayPoints.visible = moving && state.foam > 0.25;
-  if (moving) {
-    sys.wakeMesh.position.x = vesselPos.x - Math.cos(vesselPos.heading) * 14;
-    sys.wakeMesh.position.z = vesselPos.z - Math.sin(vesselPos.heading) * 14;
-    sys.wakeMesh.rotation.z = vesselPos.heading;
-    (sys.wakeMesh.material as THREE.MeshBasicMaterial).opacity = Math.min(0.45, state.foam * 0.6 + vesselSpeed * 0.03);
-    // Spray drift via wind
-    const mat = sys.sprayPoints.material as THREE.PointsMaterial;
-    mat.opacity = Math.min(0.55, state.foam * 0.5);
-    const pos = sys.sprayPoints.geometry.attributes.position as THREE.BufferAttribute;
-    for (let i = 0; i < pos.count; i++) {
-      let y = pos.getY(i) - (4 + state.waveAmplitude * 2) * dt;
-      if (y < 0) y = 6 + Math.random() * 4;
-      pos.setY(i, y);
-      pos.setX(i, (Math.random() - 0.5) * 8);
-      pos.setZ(i, (Math.random() - 0.5) * 8);
-    }
-    pos.needsUpdate = true;
-    sys.sprayPoints.position.set(vesselPos.x, 2, vesselPos.z);
+  if (!moving) return;
+
+  sys.wakeMesh.position.x = vesselPos.x - Math.cos(vesselPos.heading) * WAKE_LENGTH;
+  sys.wakeMesh.position.z = vesselPos.z - Math.sin(vesselPos.heading) * WAKE_LENGTH;
+  sys.wakeMesh.rotation.z = vesselPos.heading;
+  (sys.wakeMesh.material as THREE.MeshBasicMaterial).opacity = Math.min(
+    0.45,
+    state.foam * 0.6 + vesselSpeed * 0.03,
+  );
+
+  const mat = sys.sprayPoints.material as THREE.PointsMaterial;
+  mat.opacity = Math.min(0.55, state.foam * 0.5);
+  const windDir = wind?.direction ?? 0;
+  const windSpeed = wind?.speed ?? 0;
+  const advX = Math.cos(windDir) * windSpeed * dt * 0.6;
+  const advZ = Math.sin(windDir) * windSpeed * dt * 0.6;
+  const fall = 4 + state.waveAmplitude * 2;
+  const pos = sys.sprayPoints.geometry.attributes["position"] as THREE.BufferAttribute;
+  for (let i = 0; i < pos.count; i++) {
+    let y = pos.getY(i) - fall * dt;
+    let x = pos.getX(i) + advX;
+    let z = pos.getZ(i) + advZ;
+    if (y < 0) y += SPRAY_HEIGHT + 2;
+    if (x > SPRAY_HALF / 2) x -= SPRAY_HALF;
+    else if (x < -SPRAY_HALF / 2) x += SPRAY_HALF;
+    if (z > SPRAY_HALF / 2) z -= SPRAY_HALF;
+    else if (z < -SPRAY_HALF / 2) z += SPRAY_HALF;
+    pos.setXYZ(i, x, y, z);
   }
-  // Micro-ripples hint: state.waveFrequency -> ocean material would update uTime, SESSION 2 reads state
+  pos.needsUpdate = true;
+  sys.sprayPoints.position.set(vesselPos.x, 2, vesselPos.z);
 }
 
 export function getOceanReflectionStrength(state: OceanFrameState, sunIntensity: number): number {
@@ -99,4 +151,3 @@ export function getOceanReflectionStrength(state: OceanFrameState, sunIntensity:
 export function shouldShowWake(state: OceanFrameState, speed: number): boolean {
   return speed > 2.5 && state.roughness < 0.85;
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/qualityBudget.ts
+++ b/apps/game/src/renderer/scene3d/planetary/qualityBudget.ts
@@ -4,28 +4,66 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/qualityBudget.ts - 10.X.4 Quality FAR->CINEMATIC graceful degrade + Budget proximity->importance->cost + determinism planetSeed+tick+chunkKey + persistence boundary (transient vs persistent). Zoom dari blueprint "Quality FAR->CINEMATIC graceful degrade + Budget proximity->importance->cost + determinism seeding + persistence boundary".
-
-// WIRE NOTE for SESSION 2: import { deriveQualityLevel, getBudget, isPersistent } from "./planetary/qualityBudget" di scene3d/index.ts. Decide per volume whether to spawn high-res god rays etc.
-
-import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
+// planetary/qualityBudget.ts - 10.X.4 quality and budget policy.
+// Distance plus volume cost selects one of four quality levels with graceful
+// degradation; the budget decision gates expensive effects (particles, god
+// rays, shadows). Deterministic jitter keeps handoff and reconnect stable.
+// The persistence boundary declares which effects survive a region handoff
+// and which the client regenerates. Pure logic: no rendering, no authority.
 
 export type QualityLevel = "FAR" | "MEDIUM" | "NEAR" | "CINEMATIC";
 
 export const QUALITY_COST: Record<QualityLevel, number> = {
-  FAR: 0.15, // scattering/coverage only
-  MEDIUM: 0.35, // rain/fog/shadow
-  NEAR: 0.65, // dust/spray
-  CINEMATIC: 1.0, // volumetrics/high-res god rays
+  FAR: 0.15,
+  MEDIUM: 0.35,
+  NEAR: 0.65,
+  CINEMATIC: 1.0,
 };
 
+const CINEMATIC_DIST = 80;
+const NEAR_DIST = 300;
+const MEDIUM_DIST = 1200;
+const DOWNGRADE_COST = 0.3;
+const SEVERE_DOWNGRADE_COST = 0.15;
+
 export function deriveQualityLevel(distance: number, volumeCost: number): QualityLevel {
-  // distance 0..80 -> CINEMATIC, 80..300 -> NEAR, 300..1200 -> MEDIUM, >1200 -> FAR
-  // volumeCost 0..1 modulates (low cost -> drop one level)
-  const raw: QualityLevel = distance < 80 ? "CINEMATIC" : distance < 300 ? "NEAR" : distance < 1200 ? "MEDIUM" : "FAR";
-  if (volumeCost < 0.3 && raw === "CINEMATIC") return "NEAR";
-  if (volumeCost < 0.15 && raw === "NEAR") return "MEDIUM";
+  const raw: QualityLevel =
+    distance < CINEMATIC_DIST
+      ? "CINEMATIC"
+      : distance < NEAR_DIST
+        ? "NEAR"
+        : distance < MEDIUM_DIST
+          ? "MEDIUM"
+          : "FAR";
+  if (volumeCost < DOWNGRADE_COST && raw === "CINEMATIC") return "NEAR";
+  if (volumeCost < SEVERE_DOWNGRADE_COST && raw === "NEAR") return "MEDIUM";
   return raw;
+}
+
+/**
+ * Stable variant that keeps the previous level inside a hysteresis band,
+ * so borderline distances do not oscillate between levels each frame.
+ */
+export function deriveQualityLevelStable(
+  distance: number,
+  volumeCost: number,
+  prev: QualityLevel,
+): QualityLevel {
+  const next = deriveQualityLevel(distance, volumeCost);
+  const order: QualityLevel[] = ["FAR", "MEDIUM", "NEAR", "CINEMATIC"];
+  const diff = order.indexOf(next) - order.indexOf(prev);
+  if (Math.abs(diff) > 1) return next;
+  if (diff === 1) {
+    const margin =
+      prev === "FAR" ? MEDIUM_DIST * 0.9 : prev === "MEDIUM" ? NEAR_DIST * 0.9 : CINEMATIC_DIST * 0.9;
+    if (distance > margin) return prev;
+  }
+  if (diff === -1) {
+    const margin =
+      prev === "CINEMATIC" ? CINEMATIC_DIST * 1.1 : prev === "NEAR" ? NEAR_DIST * 1.1 : MEDIUM_DIST * 1.1;
+    if (distance < margin) return prev;
+  }
+  return next;
 }
 
 export interface BudgetDecision {
@@ -36,11 +74,7 @@ export interface BudgetDecision {
   allowShadows: boolean;
 }
 
-export function getBudget(
-  distance: number,
-  volumeCost: number,
-  importance: number, // 0..1 (landing 1, facility 0.7, distant 0.2)
-): BudgetDecision {
+export function getBudget(distance: number, volumeCost: number, importance: number): BudgetDecision {
   const quality = deriveQualityLevel(distance, volumeCost);
   const cost = QUALITY_COST[quality] * (0.5 + importance * 0.5) * (0.3 + volumeCost * 0.7);
   return {
@@ -50,30 +84,6 @@ export function getBudget(
     allowGodRays: quality === "CINEMATIC" || quality === "NEAR",
     allowShadows: quality !== "FAR",
   };
-}
-
-// Determinism: planetSeed+tick+chunkKey+position -> same quality, no uncontrolled randomness
-export function deterministicJitter(planetSeed: number, tick: number, chunkKey: string, pos: { x: number; z: number }): number {
-  let h = 2166136261;
-  const s = `${planetSeed}:${chunkKey}:${Math.floor(tick / 30)}:${Math.floor(pos.x / 100)}:${Math.floor(pos.z / 100)}`;
-  for (let i = 0; i < s.length; i++) h = Math.imul(h ^ s.charCodeAt(i), 16777619);
-  return (h >>> 0) / 4294967296; // 0..1
-}
-
-// Persistence boundary: persistent vs transient
-export function isPersistent(effect: string): boolean {
-  // Persistent: weather/facility/terrain/vessel/events — survive handoff/reconnect
-  const persistent = ["weather", "facility", "terrain", "vessel", "facilityState", "chunk"];
-  // Transient: particles/god rays/fog/splash/flash — regenerated after handoff
-  const transient = ["particles", "godRays", "fog", "splash", "flash", "spray", "dust"];
-  if (persistent.some((p) => effect.includes(p))) return true;
-  if (transient.some((t) => effect.includes(t))) return false;
-  return false; // default transient
-}
-
-// Handoff/regeneration hint: SESSION 2 calls this on reconnect to know what to regenerate
-export function getTransientEffects(): string[] {
-  return ["particles", "godRays", "fog", "splash", "flash", "spray"];
 }
 
 export function shouldAllowEffect(decision: BudgetDecision, effect: string): boolean {
@@ -91,3 +101,35 @@ export function adaptQualityForFps(current: QualityLevel, fps: number): QualityL
   return current;
 }
 
+/** Deterministic 0..1 jitter from seed, tick quantum, chunk, and cell. */
+export function deterministicJitter(
+  planetSeed: number,
+  tick: number,
+  chunkKey: string,
+  pos: { x: number; z: number },
+): number {
+  let h = 2166136261;
+  const s = `${planetSeed}:${chunkKey}:${Math.floor(tick / 30)}:${Math.floor(pos.x / 100)}:${Math.floor(pos.z / 100)}`;
+  for (let i = 0; i < s.length; i++) h = Math.imul(h ^ s.charCodeAt(i), 16777619);
+  return (h >>> 0) / 4294967296;
+}
+
+const PERSISTENT_EFFECTS = new Set(["weather", "facility", "terrain", "vessel", "facilityState", "chunk"]);
+const TRANSIENT_EFFECTS = new Set(["particles", "godRays", "fog", "splash", "flash", "spray", "dust"]);
+
+/**
+ * Persistence boundary: persistent effects survive handoff and reconnect,
+ * transient effects are regenerated by the client.
+ */
+export function isPersistent(effect: string): boolean {
+  if (PERSISTENT_EFFECTS.has(effect)) return true;
+  if (TRANSIENT_EFFECTS.has(effect)) return false;
+  for (const p of PERSISTENT_EFFECTS) if (effect.startsWith(p)) return true;
+  for (const t of TRANSIENT_EFFECTS) if (effect.startsWith(t)) return false;
+  return false;
+}
+
+/** Effects the client must regenerate after handoff or reconnect. */
+export function getTransientEffects(): string[] {
+  return ["particles", "godRays", "fog", "splash", "flash", "spray"];
+}

--- a/apps/game/src/renderer/scene3d/planetary/rain.ts
+++ b/apps/game/src/renderer/scene3d/planetary/rain.ts
@@ -4,67 +4,115 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/rain.ts - 10.X.2 Rain + rain-surface/ocean: wet/puddles/runoff/reflection + micro-ripples. Zoom dari blueprint "RainState { intensity, direction, wind, droplet density } -> slant, splash, wet, puddles, runoff, ocean ripples".
-
-// WIRE NOTE for SESSION 2: import { createRainSystem, tickRain } from "./planetary/rain" di scene3d/index.ts. Create sekali, tick tiap frame dengan EnvironmentalContext + dt + terrain height.
+// planetary/rain.ts - 10.X.2 precipitation resolver.
+// Wind-slanted rain particles plus accumulated surface response: wetness,
+// puddle decals, and drain/dry recovery after the storm passes.
+// Visual-only: derives from EnvironmentalContext, never writes authority state.
 
 import * as THREE from "three";
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
 
+const PARTICLE_COUNT = 2000;
+const FIELD_HALF = 300;
+const FALL_MIN = 20;
+const FALL_RANGE = 200;
+const PUDDLE_COUNT = 3;
+const PUDDLE_ACCUMULATION = 0.025;
+const PUDDLE_DRAIN = 0.015;
+const RAIN_VISIBILITY = 0.08;
+
 export interface RainState {
   intensity: number; // 0..1
-  slant: THREE.Vector3; // direction + wind
-  dropletDensity: number; // per m3
-  puddleLevel: number; // 0..1 (accumulated)
-  wetness: number; // 0..1
+  slant: THREE.Vector3; // fall direction including wind
+  dropletDensity: number; // per cubic meter
+  puddleLevel: number; // 0..1 accumulated surface water
+  wetness: number; // 0..1 material wetness
 }
 
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const _slant = new THREE.Vector3();
+
+/**
+ * Derive rain state. accPuddle carries surface water across calls so pools
+ * persist after rainfall stops and drain gradually.
+ */
 export function deriveRainState(ctx: EnvironmentalContext, dt: number, accPuddle: number): RainState {
-  const intensity = ctx.weather.precipitationIntensity * (ctx.weather.kind === "storm" ? 1 : ctx.weather.kind === "rain" ? 0.7 : 0);
+  const kind = ctx.weather.kind;
+  const intensity =
+    ctx.weather.precipitationIntensity * (kind === "storm" ? 1 : kind === "rain" ? 0.7 : 0);
   const wind = ctx.wind;
-  // Slant: wind direction + speed 2..10 -> slant 0..0.6
-  const slantX = Math.cos(wind.direction) * wind.speed * 0.06;
-  const slantZ = Math.sin(wind.direction) * wind.speed * 0.06;
-  const slant = new THREE.Vector3(slantX, -1, slantZ).normalize();
-  // Puddle accumulation: rain 0.8 -> +0.02 per sec, dry -> -0.01 per sec (draining)
+  _slant
+    .set(Math.cos(wind.direction) * wind.speed * 0.06, -1, Math.sin(wind.direction) * wind.speed * 0.06)
+    .normalize();
   let puddle = accPuddle;
-  if (intensity > 0.1) puddle = Math.min(1, puddle + intensity * dt * 0.025);
-  else puddle = Math.max(0, puddle - dt * 0.015);
+  if (intensity > 0.1) puddle = Math.min(1, puddle + intensity * dt * PUDDLE_ACCUMULATION);
+  else puddle = Math.max(0, puddle - dt * PUDDLE_DRAIN);
   const wetness = Math.min(1, intensity * 0.9 + puddle * 0.4);
-  return { intensity, slant, dropletDensity: intensity * 800, puddleLevel: puddle, wetness };
+  return {
+    intensity,
+    slant: _slant.clone(),
+    dropletDensity: intensity * 800,
+    puddleLevel: puddle,
+    wetness,
+  };
 }
 
 export interface RainSystem {
   group: THREE.Group;
   particles: THREE.Points;
-  puddleMeshes: THREE.Mesh[]; // 3 puddle decals
+  puddleMeshes: THREE.Mesh[];
   lastPuddle: number;
 }
 
-export function createRainSystem(): RainSystem {
+/** Build particles and puddle decals. Seed keeps placement deterministic. */
+export function createRainSystem(seed = 0x2a17): RainSystem {
   const group = new THREE.Group();
   group.name = "rainSystem";
+  const rng = mulberry32(seed);
+
   const geo = new THREE.BufferGeometry();
-  const count = 2000;
-  const pos = new Float32Array(count * 3);
-  for (let i = 0; i < count; i++) {
-    pos[i * 3] = (Math.random() - 0.5) * 600;
-    pos[i * 3 + 1] = Math.random() * 200 + 20;
-    pos[i * 3 + 2] = (Math.random() - 0.5) * 600;
+  const pos = new Float32Array(PARTICLE_COUNT * 3);
+  for (let i = 0; i < PARTICLE_COUNT; i++) {
+    pos[i * 3] = (rng() - 0.5) * FIELD_HALF * 2;
+    pos[i * 3 + 1] = rng() * FALL_RANGE + FALL_MIN;
+    pos[i * 3 + 2] = (rng() - 0.5) * FIELD_HALF * 2;
   }
   geo.setAttribute("position", new THREE.BufferAttribute(pos, 3));
-  const mat = new THREE.PointsMaterial({ color: 0xaac4ff, size: 0.35, transparent: true, opacity: 0.0, depthWrite: false });
+  const mat = new THREE.PointsMaterial({
+    color: 0xaac4ff,
+    size: 0.35,
+    transparent: true,
+    opacity: 0.0,
+    depthWrite: false,
+  });
   const points = new THREE.Points(geo, mat);
   points.name = "rainParticles";
+  points.frustumCulled = false;
   group.add(points);
-  // Puddle decals — 3 quads di tanah
+
   const puddles: THREE.Mesh[] = [];
-  for (let i = 0; i < 3; i++) {
-    const pg = new THREE.CircleGeometry(18 + Math.random() * 22, 12);
-    const pm = new THREE.MeshStandardMaterial({ color: 0x2a3a4a, roughness: 0.15, metalness: 0.1, transparent: true, opacity: 0.0 });
+  for (let i = 0; i < PUDDLE_COUNT; i++) {
+    const pg = new THREE.CircleGeometry(18 + rng() * 22, 12);
+    const pm = new THREE.MeshStandardMaterial({
+      color: 0x2a3a4a,
+      roughness: 0.15,
+      metalness: 0.1,
+      transparent: true,
+      opacity: 0.0,
+    });
     const m = new THREE.Mesh(pg, pm);
     m.rotation.x = -Math.PI / 2;
-    m.position.set((Math.random() - 0.5) * 120, 0.05, (Math.random() - 0.5) * 120);
+    m.position.set((rng() - 0.5) * 120, 0.05, (rng() - 0.5) * 120);
     m.visible = false;
     m.name = `puddle-${i}`;
     group.add(m);
@@ -73,34 +121,39 @@ export function createRainSystem(): RainSystem {
   return { group, particles: points, puddleMeshes: puddles, lastPuddle: 0 };
 }
 
+/**
+ * Advance rain one frame. Drops wrap around the column deterministically
+ * (no per-frame random), slant tilts on both axes, puddles grow/shrink.
+ */
 export function tickRain(sys: RainSystem, state: RainState, dt: number): void {
   const mat = sys.particles.material as THREE.PointsMaterial;
-  // Visibility + intensity -> opacity + count via size?
-  const isRaining = state.intensity > 0.08;
+  const isRaining = state.intensity > RAIN_VISIBILITY;
   sys.group.visible = isRaining || state.puddleLevel > 0.05;
   mat.opacity = isRaining ? Math.min(0.65, state.intensity * 0.8) : 0;
-  // Slant -> rotate particles group
+
   sys.particles.rotation.z = Math.atan2(state.slant.x, -state.slant.y) * 0.3;
-  // Fall speed via intensity: 40..90 units/s
-  const fall = 40 + state.intensity * 50;
-  const pos = sys.particles.geometry.attributes.position as THREE.BufferAttribute;
-  for (let i = 0; i < pos.count; i++) {
-    let y = pos.getY(i) - fall * dt;
-    if (y < 0) y = 200 + Math.random() * 20;
-    pos.setY(i, y);
+  sys.particles.rotation.x = -Math.atan2(state.slant.z, -state.slant.y) * 0.3;
+
+  if (isRaining) {
+    const fall = 40 + state.intensity * 50;
+    const pos = sys.particles.geometry.attributes["position"] as THREE.BufferAttribute;
+    const top = FALL_MIN + FALL_RANGE;
+    for (let i = 0; i < pos.count; i++) {
+      let y = pos.getY(i) - fall * dt;
+      if (y < 0) y += top;
+      pos.setY(i, y);
+    }
+    pos.needsUpdate = true;
   }
-  pos.needsUpdate = true;
-  // Puddles: puddleLevel 0..1 -> opacity + scale
-  sys.puddleMeshes.forEach((m) => {
+
+  for (const m of sys.puddleMeshes) {
     const pudMat = m.material as THREE.MeshStandardMaterial;
-    const target = state.puddleLevel;
-    pudMat.opacity = target * 0.45;
-    m.visible = target > 0.08;
-    const s = 0.7 + target * 0.8;
+    pudMat.opacity = state.puddleLevel * 0.45;
+    m.visible = state.puddleLevel > 0.08;
+    const s = 0.7 + state.puddleLevel * 0.8;
     m.scale.set(s, s, 1);
-  });
+  }
   sys.lastPuddle = state.puddleLevel;
-  // Ocean ripples hint: SESSION 2 bisa baca state.intensity untuk ocean.ts micro-ripples
 }
 
 export function isWetEnough(state: RainState, threshold = 0.15): boolean {
@@ -110,4 +163,3 @@ export function isWetEnough(state: RainState, threshold = 0.15): boolean {
 export function rainOpacity(state: RainState): number {
   return Math.min(0.65, state.intensity * 0.78);
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/sun.ts
+++ b/apps/game/src/renderer/scene3d/planetary/sun.ts
@@ -95,3 +95,18 @@ export function getSunExposure(u: SunUniforms): number {
 export function isSunAvailable(u: SunUniforms): boolean {
   return u.intensity > 0.05 && u.timeOfDay !== "night";
 }
+
+/**
+ * Ambient-only application for scenes where the key directional light is
+ * owned by another system (e.g. orbital Kepler suns). Fog stays owned by
+ * the fog resolver to avoid last-writer conflicts.
+ */
+export function applySunToAmbientFog(ambient: THREE.AmbientLight | null, u: SunUniforms): void {
+  if (!ambient) return;
+  if (isNight(u)) {
+    ambient.intensity = NIGHT_AMBIENT;
+    return;
+  }
+  ambient.intensity = 0.35 + u.intensity * 0.45;
+  ambient.color.copy(u.color).multiplyScalar(0.6);
+}

--- a/apps/game/src/renderer/scene3d/planetary/sun.ts
+++ b/apps/game/src/renderer/scene3d/planetary/sun.ts
@@ -4,31 +4,32 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/sun.ts - 10.X.1 sun: direction/elevation/intensity/color/transmission -> terrain/ocean/vegetation/clouds. Zoom dari blueprint "Sun drives terrain/ocean/vegetation/clouds/atmosphere/facilities/vessels".
-
-// Blueprint 10.X §5 cuma "Sun direction/elevation/intensity/color/transmission/timeOfDay drives...".
-// File ini ZOOM jadi resolver fisik: 24h + lunar, elevation -> intensity via sin, color 5800K -> warm dusk, transmission via haze.
-// WIRE NOTE for SESSION 2: import { updateSunFromContext } from "./planetary/sun" di scene3d/index.ts frame loop, panggil tiap tick dengan EnvironmentalContext.sun + timeOfDay. Jangan lupa scene.environment + DirectionalLight.
-
-// Visual-only, gak ubah physics/health.
+// planetary/sun.ts - 10.X.1 solar resolver.
+// Derives render uniforms from EnvironmentalContext.sun and applies them to
+// the scene directional light, ambient light, and exponential fog.
+// Visual-only: reads authority state, never writes it.
 
 import * as THREE from "three";
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
 
-// ---------------------------------------------------------------------------
-// Sun uniforms yang dibaca semua resolver
-// ---------------------------------------------------------------------------
-
+// Sun uniforms consumed by terrain, ocean, vegetation, and cloud resolvers.
 export interface SunUniforms {
   direction: THREE.Vector3; // normalized
-  elevation: number; // rad
-  intensity: number; // 0..1
-  color: THREE.Color; // hex -> THREE.Color
-  transmission: number; // 0..1 (haze)
+  elevation: number; // radians, 0 = horizon, PI/2 = zenith
+  intensity: number; // 0..1 (1 = noon clear, 0 = night)
+  color: THREE.Color;
+  transmission: number; // 0..1 atmospheric transmission (1 = clear)
   timeOfDay: "dawn" | "day" | "dusk" | "night";
 }
 
-/** Derive SunUniforms dari EnvironmentalContext.sun (sudah ada deriveSunState, ini visual uniform). */
+const _scratchColor = new THREE.Color();
+const NIGHT_AMBIENT = 0.18;
+const NIGHT_FOG_DENSITY = 0.00035;
+const DAY_FOG_DENSITY = 0.00008;
+const STORM_FOG_DENSITY = 0.00035;
+const FOG_TINT = 0x8aa0b8;
+
+/** Derive render uniforms from the authoritative sun state. */
 export function sunUniformsFromContext(ctx: EnvironmentalContext): SunUniforms {
   const s = ctx.sun;
   return {
@@ -41,62 +42,52 @@ export function sunUniformsFromContext(ctx: EnvironmentalContext): SunUniforms {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Apply ke THREE — DirectionalLight + scene fog + material uniforms
-// ---------------------------------------------------------------------------
-
 export interface SunScene {
   sunLight: THREE.DirectionalLight;
   ambient: THREE.AmbientLight;
   fog?: THREE.FogExp2;
 }
 
+function isNight(u: SunUniforms): boolean {
+  return u.timeOfDay === "night" || u.intensity < 0.05;
+}
+
 /**
- * Update sun light per tick. Intensitas -> light.intensity + color + shadow.
- * - isNight (intensity<0.05) -> sun off, ambient 0.15 biar night emissive tetep (PMREM off)
- * - dawn/dusk -> warm color + transmission turun (haze)
- * Dipanggil tiap frame, murah (3 set).
+ * Apply sun uniforms to scene lights. Called once per frame.
+ * Night: sun off so facility emissive stays visible; low ambient kept.
+ * Day: warm tint near dawn/dusk, haze widens shadow bias and fog density.
  */
 export function updateSunFromContext(scene: SunScene, u: SunUniforms): void {
-  const isNight = u.timeOfDay === "night" || u.intensity < 0.05;
-  if (isNight) {
+  if (isNight(u)) {
     scene.sunLight.intensity = 0;
     scene.sunLight.visible = false;
-    scene.ambient.intensity = 0.18;
-    if (scene.fog) scene.fog.density = 0.00035;
+    scene.ambient.intensity = NIGHT_AMBIENT;
+    if (scene.fog) scene.fog.density = NIGHT_FOG_DENSITY;
     return;
   }
   scene.sunLight.visible = true;
-  scene.sunLight.intensity = 0.9 + u.intensity * 1.6; // 0.9..2.5
+  scene.sunLight.intensity = 0.9 + u.intensity * 1.6;
   scene.sunLight.color.copy(u.color);
-  // direction -> light position (5000m jauh)
   scene.sunLight.position.copy(u.direction).multiplyScalar(5000);
   scene.sunLight.target.position.set(0, 0, 0);
-  // transmission -> shadow bias + fog
-  const haze = 1 - u.transmission; // 0 clear, 0.8 storm
+  const haze = 1 - u.transmission;
   scene.sunLight.shadow.bias = -0.0005 - haze * 0.001;
   scene.ambient.intensity = 0.35 + u.intensity * 0.45;
   scene.ambient.color.copy(u.color).multiplyScalar(0.6);
   if (scene.fog) {
-    // day clear fog 0.00008, storm/haze 0.00035
-    scene.fog.density = 0.00008 + haze * 0.00027;
-    scene.fog.color.copy(u.color).lerp(new THREE.Color(0x8aa0b8), haze * 0.5);
+    scene.fog.density = DAY_FOG_DENSITY + haze * (STORM_FOG_DENSITY - DAY_FOG_DENSITY);
+    scene.fog.color.copy(u.color).lerp(_scratchColor.set(FOG_TINT), haze * 0.5);
   }
 }
 
-/** Helper buat material yang butuh sun (terrain/ocean/cloud) — set uniform color/intensity. */
+/** Tint a standard material with the warm dawn/dusk component of sunlight. */
 export function applySunToMaterial(mat: THREE.MeshStandardMaterial, u: SunUniforms): void {
-  // terrain vertexColors sudah ada, tapi sun tint via emissive kecil
   const warm = u.timeOfDay === "dawn" || u.timeOfDay === "dusk" ? 0.12 : 0;
-  (mat as any).emissive = (mat as any).emissive || new THREE.Color(0x000000);
-  (mat as any).emissive.copy(u.color).multiplyScalar(warm * u.intensity);
-  (mat as any).emissiveIntensity = warm;
+  mat.emissive.copy(u.color).multiplyScalar(warm * u.intensity);
+  mat.emissiveIntensity = warm;
 }
 
-// WIRE NOTE: SESSION 2 wire di scene3d/index.ts:
-// import { sunUniformsFromContext, updateSunFromContext } from "./planetary/sun";
-// const u = sunUniformsFromContext(envCtx); updateSunFromContext({ sunLight, ambient, fog }, u);
-
+/** Fraction of sunlight reaching the surface after atmospheric attenuation. */
 export function getSunExposure(u: SunUniforms): number {
   return u.intensity * u.transmission;
 }
@@ -104,4 +95,3 @@ export function getSunExposure(u: SunUniforms): number {
 export function isSunAvailable(u: SunUniforms): boolean {
   return u.intensity > 0.05 && u.timeOfDay !== "night";
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/vegetation.ts
+++ b/apps/game/src/renderer/scene3d/planetary/vegetation.ts
@@ -4,20 +4,29 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/vegetation.ts - 10.X.3 Vegetation wind grass->tree phased + rain wetness. Zoom dari blueprint "Vegetation wind grass->small->bush->branch->tree gust/turbulence phased, rain wetness".
-
-// WIRE NOTE for SESSION 2: import { createVegetationSystem, tickVegetation } from "./planetary/vegetation" di scene3d/index.ts. Vegetation instances di chunks, tick per frame dengan EnvironmentalContext.wind + rain.
+// planetary/vegetation.ts - 10.X.3 vegetation resolver.
+// Five growth stages (grass through tree) sway out of phase in gusts and
+// turbulence and darken while wet. Placement is deterministic from the seed
+// so chunks regenerate identically after handoff or reconnect.
+// Visual-only: reads EnvironmentalContext wind and precipitation.
 
 import * as THREE from "three";
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
 
 export type VegetationKind = "grass" | "small" | "bush" | "branch" | "tree";
 
+const COUNTS: Record<VegetationKind, number> = { grass: 80, small: 24, bush: 12, branch: 8, tree: 4 };
+const TOTAL = 80 + 24 + 12 + 8 + 4;
+const FIELD_HALF = 100;
+const WET_TINT = 0x1a2a1a;
+const WET_DARKEN = 0.12;
+
 export interface VegetationInstance {
   kind: VegetationKind;
   mesh: THREE.Object3D;
   basePos: THREE.Vector3;
-  phase: number; // 0..1 random offset
+  baseColor: THREE.Color;
+  phase: number; // 0..1 deterministic offset
 }
 
 export interface VegetationSystem {
@@ -25,64 +34,105 @@ export interface VegetationSystem {
   instances: VegetationInstance[];
 }
 
-export function createVegetationSystem(): VegetationSystem {
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const _wetColor = new THREE.Color(WET_TINT);
+const _tintScratch = new THREE.Color();
+
+function kindSwayFactor(kind: VegetationKind): number {
+  if (kind === "grass") return 2.0;
+  if (kind === "small") return 1.6;
+  if (kind === "bush") return 1.2;
+  if (kind === "branch") return 0.7;
+  return 0.4;
+}
+
+function buildMesh(kind: VegetationKind): { mesh: THREE.Mesh; color: number } {
+  if (kind === "grass") {
+    const g = new THREE.PlaneGeometry(0.4, 0.8);
+    const m = new THREE.MeshBasicMaterial({ color: 0x2f6b4a, side: THREE.DoubleSide, transparent: true, opacity: 0.9 });
+    return { mesh: new THREE.Mesh(g, m), color: 0x2f6b4a };
+  }
+  if (kind === "small") {
+    const g = new THREE.SphereGeometry(0.6, 6, 6);
+    const m = new THREE.MeshStandardMaterial({ color: 0x3a7a4a });
+    return { mesh: new THREE.Mesh(g, m), color: 0x3a7a4a };
+  }
+  if (kind === "bush") {
+    const g = new THREE.SphereGeometry(1.2, 8, 8);
+    const m = new THREE.MeshStandardMaterial({ color: 0x2e5a3a });
+    return { mesh: new THREE.Mesh(g, m), color: 0x2e5a3a };
+  }
+  if (kind === "branch") {
+    const g = new THREE.CylinderGeometry(0.12, 0.18, 2.5, 6);
+    const m = new THREE.MeshStandardMaterial({ color: 0x4a3a2a });
+    return { mesh: new THREE.Mesh(g, m), color: 0x4a3a2a };
+  }
+  const g = new THREE.CylinderGeometry(0.35, 0.5, 6, 8);
+  const m = new THREE.MeshStandardMaterial({ color: 0x3d2f24 });
+  return { mesh: new THREE.Mesh(g, m), color: 0x3d2f24 };
+}
+
+/** Build the pooled instances. Seed keeps chunk regeneration identical. */
+export function createVegetationSystem(seed = 0xe9e7): VegetationSystem {
   const group = new THREE.Group();
   group.name = "vegetationSystem";
   const instances: VegetationInstance[] = [];
-  // Create 80 grass + 24 small + 12 bush + 8 branch + 4 tree = 128
-  const counts: Record<VegetationKind, number> = { grass: 80, small: 24, bush: 12, branch: 8, tree: 4 };
-  for (const kind of Object.keys(counts) as VegetationKind[]) {
-    for (let i = 0; i < counts[kind]; i++) {
-      let mesh: THREE.Object3D;
-      if (kind === "grass") {
-        const g = new THREE.PlaneGeometry(0.4, 0.8);
-        const m = new THREE.MeshBasicMaterial({ color: 0x2f6b4a, side: THREE.DoubleSide, transparent: true, opacity: 0.9 });
-        mesh = new THREE.Mesh(g, m);
-      } else if (kind === "small") {
-        const g = new THREE.SphereGeometry(0.6, 6, 6);
-        const m = new THREE.MeshStandardMaterial({ color: 0x3a7a4a });
-        mesh = new THREE.Mesh(g, m);
-      } else if (kind === "bush") {
-        const g = new THREE.SphereGeometry(1.2, 8, 8);
-        const m = new THREE.MeshStandardMaterial({ color: 0x2e5a3a });
-        mesh = new THREE.Mesh(g, m);
-      } else if (kind === "branch") {
-        const g = new THREE.CylinderGeometry(0.12, 0.18, 2.5, 6);
-        const m = new THREE.MeshStandardMaterial({ color: 0x4a3a2a });
-        mesh = new THREE.Mesh(g, m);
-      } else {
-        const g = new THREE.CylinderGeometry(0.35, 0.5, 6, 8);
-        const m = new THREE.MeshStandardMaterial({ color: 0x3d2f24 });
-        mesh = new THREE.Mesh(g, m);
-      }
-      mesh.position.set((Math.random() - 0.5) * 200, 0, (Math.random() - 0.5) * 200);
+  const rng = mulberry32(seed);
+  for (const kind of Object.keys(COUNTS) as VegetationKind[]) {
+    for (let i = 0; i < COUNTS[kind]; i++) {
+      const { mesh, color } = buildMesh(kind);
+      mesh.position.set((rng() - 0.5) * FIELD_HALF * 2, 0, (rng() - 0.5) * FIELD_HALF * 2);
       mesh.name = `veg-${kind}-${i}`;
       group.add(mesh);
-      instances.push({ kind, mesh, basePos: mesh.position.clone(), phase: Math.random() });
+      instances.push({
+        kind,
+        mesh,
+        basePos: mesh.position.clone(),
+        baseColor: new THREE.Color(color),
+        phase: rng(),
+      });
     }
   }
   return { group, instances };
 }
 
 /**
- * Tick: wind gust/turbulence phased grass->tree, rain wetness.
- * - grass small gust 0.6 fast (2*wind), tree gust 0.2 slow (0.4*wind) + turbulence
- * - localVariation biar A vs B gak sinkron
- * - rain wetness 0..1 -> color darkens + emissive slight
+ * Advance vegetation one frame.
+ * @param timeSec deterministic clock (worldTime/1000 + tick * dt)
+ * Small stages respond fast and wide to gusts; trees respond slow and narrow.
+ * Wetness tints from the stored base color every frame, so drying restores
+ * the original color instead of accumulating darkness.
  */
-export function tickVegetation(sys: VegetationSystem, ctx: EnvironmentalContext, dt: number, time: number): void {
+export function tickVegetation(
+  sys: VegetationSystem,
+  ctx: EnvironmentalContext,
+  dt: number,
+  timeSec: number,
+): void {
+  void dt;
   const wind = ctx.wind;
   const rainWet = ctx.weather.precipitationIntensity;
   const gust = wind.gustStrength;
   const turb = wind.turbulence;
+  const spread = 0.7 + wind.localVariation * 0.6;
+  const wet = rainWet > 0.1 ? Math.min(1, rainWet) * WET_DARKEN : 0;
 
   for (const inst of sys.instances) {
-    const kindFactor = inst.kind === "grass" ? 2.0 : inst.kind === "small" ? 1.6 : inst.kind === "bush" ? 1.2 : inst.kind === "branch" ? 0.7 : 0.4;
-    const gustPhase = Math.sin(time * 0.002 * kindFactor + inst.phase * Math.PI * 2 + wind.direction) * gust;
-    const turbPhase = Math.sin(time * 0.001 + inst.phase * 6) * turb * 0.5;
-    const sway = (gustPhase * 0.4 + turbPhase * 0.15) * wind.speed * 0.04 * kindFactor * (0.7 + wind.localVariation * 0.6);
+    const factor = kindSwayFactor(inst.kind);
+    const gustPhase = Math.sin(timeSec * 2 * factor + inst.phase * Math.PI * 2 + wind.direction) * gust;
+    const turbPhase = Math.sin(timeSec + inst.phase * 6) * turb * 0.5;
+    const sway = (gustPhase * 0.4 + turbPhase * 0.15) * wind.speed * 0.04 * factor * spread;
 
-    // Apply sway: grass = rotation, tree = position offset
     if (inst.kind === "grass" || inst.kind === "small") {
       inst.mesh.rotation.z = sway;
       inst.mesh.rotation.x = sway * 0.5;
@@ -91,36 +141,35 @@ export function tickVegetation(sys: VegetationSystem, ctx: EnvironmentalContext,
       inst.mesh.position.z = inst.basePos.z + Math.sin(wind.direction) * sway * 2;
     }
 
-    // Rain wetness: darken + slight emissive
     if (inst.mesh instanceof THREE.Mesh) {
       const mat = inst.mesh.material as THREE.MeshStandardMaterial | THREE.MeshBasicMaterial;
-      if ("color" in mat) {
-        const baseHsl: any = {};
-        (mat.color as any).getHSL?.(baseHsl);
-        // wet -> darker 12%, more saturated
-        if (rainWet > 0.1) {
-          (mat as any).color.lerp(new THREE.Color(0x1a2a1a), rainWet * 0.12);
-        }
-      }
+      _tintScratch.copy(inst.baseColor);
+      if (wet > 0) _tintScratch.lerp(_wetColor, wet);
+      mat.color.copy(_tintScratch);
     }
   }
 }
 
-export function cullVegetationByDistance(sys: VegetationSystem, maxDist: number, center: {x:number,z:number}): number {
+/** Hide instances beyond maxDist from center. Returns the hidden count. */
+export function cullVegetationByDistance(
+  sys: VegetationSystem,
+  maxDist: number,
+  center: { x: number; z: number },
+): number {
   let culled = 0;
   for (const inst of sys.instances) {
     const d = Math.hypot(inst.basePos.x - center.x, inst.basePos.z - center.z);
-    const shouldShow = d < maxDist;
-    (inst.mesh as any).visible = shouldShow;
-    if (!shouldShow) culled++;
+    const show = d < maxDist;
+    inst.mesh.visible = show;
+    if (!show) culled++;
   }
   return culled;
 }
 
+/** Active instance budget per quality level (total pool is 128). */
 export function vegetationBudgetForQuality(level: string): number {
-  if (level === "CINEMATIC") return 128;
+  if (level === "CINEMATIC") return TOTAL;
   if (level === "NEAR") return 64;
   if (level === "MEDIUM") return 24;
   return 8;
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/weatherStack.ts
+++ b/apps/game/src/renderer/scene3d/planetary/weatherStack.ts
@@ -4,9 +4,12 @@
 // See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
 //
 
-// planetary/weatherStack.ts - 10.X.2 CLEAR/OVERCAST/RAIN/STORM coordinated + RainState + wet/puddles/runoff/reflection. Zoom dari blueprint "Weather stack CLEAR->OVERCAST->RAIN->STORM coordinated".
-
-// WIRE NOTE for SESSION 2: import { deriveWeatherStack, updateWeatherStack } from "./planetary/weatherStack" di scene3d/index.ts. Derive dari EnvironmentalContext.weather + clouds, update material wetness/puddles tiap frame.
+// planetary/weatherStack.ts - 10.X.2 coordinated weather stack.
+// Collapses authority weather, cloud, sun, and wind state into one phase
+// (clear / overcast / rain / storm) plus the scalars downstream resolvers
+// need: sunlight, visibility, precipitation. Phase transitions use hysteresis
+// so borderline density does not flicker between frames.
+// Visual-only: derives from EnvironmentalContext, never writes authority state.
 
 import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
 
@@ -17,44 +20,74 @@ export interface WeatherStack {
   cloudCoverage: number; // 0..1
   cloudDensity: number;
   precipitationIntensity: number; // 0..1
-  windSpeed: number;
-  visibility: number;
-  sunlight: number; // 0..1
+  windSpeed: number; // m/s
+  visibility: number; // m
+  sunlight: number; // 0..1 after cloud attenuation
 }
 
-export function deriveWeatherStack(ctx: EnvironmentalContext): WeatherStack {
+// Hysteresis bands: entering rain/storm needs more precipitation than leaving.
+const RAIN_ENTER = 0.12;
+const RAIN_EXIT = 0.05;
+const STORM_DENSITY_ENTER = 0.75;
+const STORM_DENSITY_EXIT = 0.6;
+
+function targetPhase(ctx: EnvironmentalContext, prev: WeatherStackPhase | undefined): WeatherStackPhase {
   const w = ctx.weather;
+  if (w.kind === "storm") {
+    if (prev === "storm" && ctx.clouds.density > STORM_DENSITY_EXIT) return "storm";
+    if (prev !== "storm" && ctx.clouds.density < STORM_DENSITY_ENTER) return "rain";
+    return "storm";
+  }
+  if (w.kind === "rain") {
+    if (prev === "clear" || prev === "overcast") {
+      return w.precipitationIntensity > RAIN_ENTER ? "rain" : prev;
+    }
+    if (w.precipitationIntensity < RAIN_EXIT) return "overcast";
+    return "rain";
+  }
+  if (w.kind === "overcast") return "overcast";
+  if (
+    (prev === "rain" || prev === "storm") &&
+    w.precipitationIntensity > RAIN_EXIT
+  ) {
+    return prev;
+  }
+  return "clear";
+}
+
+/**
+ * Derive the coordinated stack. Pass the previous phase to stabilize
+ * transitions; omit it for a stateless read.
+ */
+export function deriveWeatherStack(ctx: EnvironmentalContext, prevPhase?: WeatherStackPhase): WeatherStack {
   const clouds = ctx.clouds;
-  let phase: WeatherStackPhase = "clear";
-  if (w.kind === "storm") phase = "storm";
-  else if (w.kind === "rain") phase = "rain";
-  else if (w.kind === "overcast") phase = "overcast";
-  // Stabilize: avoid flicker if density borderline
+  const phase = targetPhase(ctx, prevPhase);
   const sunlight = ctx.sun.intensity * (1 - clouds.density * 0.6) * (1 - clouds.coverage * 0.3);
   return {
     phase,
     cloudCoverage: clouds.coverage,
     cloudDensity: clouds.density,
-    precipitationIntensity: w.precipitationIntensity,
+    precipitationIntensity: ctx.weather.precipitationIntensity,
     windSpeed: ctx.wind.speed,
     visibility: ctx.atmosphere.visibility,
-    sunlight,
+    sunlight: Math.max(0, sunlight),
   };
 }
 
-// Apply weather to scene: sunlight -> exposure, visibility -> fog, precipitation -> wet hint
+/** Tone-mapping exposure for the current phase. */
 export function getWeatherExposure(stack: WeatherStack): number {
-  // clear 1.0, overcast 0.85, rain 0.7, storm 0.55
   if (stack.phase === "storm") return 0.55 + stack.sunlight * 0.15;
   if (stack.phase === "rain") return 0.7 + stack.sunlight * 0.15;
   if (stack.phase === "overcast") return 0.85 + stack.sunlight * 0.1;
   return 0.95 + stack.sunlight * 0.05;
 }
 
+/** Interpolate two stacks for smooth cross-fades between context updates. */
 export function lerpWeatherStack(a: WeatherStack, b: WeatherStack, t: number): WeatherStack {
-  const l = (x:number,y:number)=> x + (y-x)*t;
+  const clamped = Math.min(1, Math.max(0, t));
+  const l = (x: number, y: number): number => x + (y - x) * clamped;
   return {
-    phase: t < 0.5 ? a.phase : b.phase,
+    phase: clamped < 0.5 ? a.phase : b.phase,
     cloudCoverage: l(a.cloudCoverage, b.cloudCoverage),
     cloudDensity: l(a.cloudDensity, b.cloudDensity),
     precipitationIntensity: l(a.precipitationIntensity, b.precipitationIntensity),
@@ -65,6 +98,5 @@ export function lerpWeatherStack(a: WeatherStack, b: WeatherStack, t: number): W
 }
 
 export function isWetPhase(s: WeatherStack): boolean {
-  return s.phase === "rain" || s.phase === "storm" || s.precipitationIntensity > 0.12;
+  return s.phase === "rain" || s.phase === "storm" || s.precipitationIntensity > RAIN_ENTER;
 }
-

--- a/apps/game/src/renderer/scene3d/planetary/wire10X.ts
+++ b/apps/game/src/renderer/scene3d/planetary/wire10X.ts
@@ -1,0 +1,250 @@
+// Copyright 2026 GSF-001
+//
+// Licensed under the ARCLUX MMO License v1 (GSF-001) — Source-available, No Commercial Game Clone.
+// See LICENSE-MMO in the repo root. SPDX: LicenseRef-ARCLUX-MMO.
+//
+
+// planetary/wire10X.ts - 10.X.1-X.4 single wiring point.
+// Owns every cinematic atmosphere system (sun, cloud shadows, god rays,
+// weather stack, rain, lightning, fog, vegetation, ocean wake, volumes,
+// budget) and advances them from the one EnvironmentalContext the scene
+// already maintains. Visual-only: reads authority state, never writes it.
+//
+// The orbital key light stays owned by the Kepler sun system; the planetary
+// sun only drives ambient and material tint through applySunToAmbientFog.
+
+import * as THREE from "three";
+import type { EnvironmentalContext } from "../../../../../../packages/gameserver/planetary/environment";
+import type { VesselEntity } from "../../../../../../packages/gameserver/types";
+import {
+  sunUniformsFromContext,
+  applySunToAmbientFog,
+  type SunUniforms,
+} from "./sun";
+import {
+  createCloudShadowSystem,
+  tickCloudShadows,
+  type CloudShadowSystem,
+} from "./cloudShadows";
+import {
+  deriveGodRayContext,
+  createGodRaySystem,
+  updateGodRays,
+  type GodRaySystem,
+} from "./godRays";
+import {
+  deriveWeatherStack,
+  getWeatherExposure,
+  type WeatherStack,
+  type WeatherStackPhase,
+} from "./weatherStack";
+import {
+  deriveRainState,
+  createRainSystem,
+  tickRain,
+  type RainSystem,
+} from "./rain";
+import {
+  createLightningSystem,
+  shouldTriggerLightning,
+  triggerLightning,
+  tickLightning,
+  type LightningSystem,
+} from "./lightning";
+import {
+  deriveFogState,
+  createFogSystem,
+  tickFog,
+  type FogSystem,
+} from "./fog";
+import {
+  createVegetationSystem,
+  tickVegetation,
+  cullVegetationByDistance,
+  type VegetationSystem,
+} from "./vegetation";
+import {
+  deriveOceanFrame,
+  createOceanWake,
+  tickOcean,
+  type OceanWakeSystem,
+} from "./oceanSystem";
+import {
+  createLocalVolumeManager,
+  ensureVolume,
+  updateLocalVolumes,
+  getVolumeCost,
+  type LocalVolumeManager,
+} from "./localVolumes";
+import {
+  deriveQualityLevelStable,
+  getBudget,
+  shouldAllowEffect,
+  type QualityLevel,
+} from "./qualityBudget";
+
+export interface Planetary10XTickOpts {
+  timeSec: number; // deterministic clock: worldTime/1000 + tick * dt
+  anchor: { x: number; z: number }; // player ground position
+  cameraPos: { x: number; y: number; z: number };
+  altitude: number; // meters above surface
+  vessel?: VesselEntity;
+  ambient?: THREE.AmbientLight | null;
+  renderer?: THREE.WebGLRenderer;
+}
+
+export interface Planetary10X {
+  sun: SunUniforms | null;
+  shadows: CloudShadowSystem;
+  godRays: GodRaySystem;
+  weather: WeatherStack | null;
+  prevPhase: WeatherStackPhase | undefined;
+  rain: RainSystem;
+  puddle: number;
+  lightning: LightningSystem;
+  fog: FogSystem;
+  vegetation: VegetationSystem;
+  wake: OceanWakeSystem;
+  volumes: LocalVolumeManager;
+  quality: QualityLevel;
+  exposure: number;
+}
+
+/** Build all systems once and attach their groups to the scene. */
+export function createPlanetary10X(scene: THREE.Scene, seed = 0x1017): Planetary10X {
+  void seed;
+  const shadows = createCloudShadowSystem();
+  const godRays = createGodRaySystem();
+  const rain = createRainSystem();
+  const lightning = createLightningSystem();
+  const fog = createFogSystem(scene);
+  const vegetation = createVegetationSystem();
+  const wake = createOceanWake();
+  scene.add(shadows.group);
+  scene.add(godRays.group);
+  scene.add(rain.group);
+  scene.add(lightning.flashLight);
+  scene.add(lightning.boltMesh);
+  scene.add(vegetation.group);
+  scene.add(wake.wakeMesh);
+  scene.add(wake.sprayPoints);
+  return {
+    sun: null,
+    shadows,
+    godRays,
+    weather: null,
+    prevPhase: undefined,
+    rain,
+    puddle: 0,
+    lightning,
+    fog,
+    vegetation,
+    wake,
+    volumes: createLocalVolumeManager(),
+    quality: "MEDIUM",
+    exposure: 1,
+  };
+}
+
+function vesselSpeed(v?: VesselEntity): number {
+  if (!v) return 0;
+  return Math.hypot(v.velocity.x, v.velocity.y, v.velocity.z);
+}
+
+/** Advance every system one frame from the shared authority context. */
+export function tickPlanetary10X(
+  sys: Planetary10X,
+  scene: THREE.Scene,
+  env: EnvironmentalContext,
+  dt: number,
+  opts: Planetary10XTickOpts,
+): void {
+  void scene;
+  const nowMs = opts.timeSec * 1000;
+
+  const sun = sunUniformsFromContext(env);
+  sys.sun = sun;
+  applySunToAmbientFog(opts.ambient ?? null, sun);
+
+  tickCloudShadows(sys.shadows, env, dt, opts.timeSec, opts.anchor);
+
+  const occlusion = Math.min(0.8, 0.3 + env.terrain.slope * 0.5);
+  const gctx = deriveGodRayContext(env, opts.cameraPos, occlusion);
+  updateGodRays(sys.godRays, gctx, dt, opts.timeSec);
+
+  const stack = deriveWeatherStack(env, sys.prevPhase);
+  sys.prevPhase = stack.phase;
+  sys.weather = stack;
+  sys.exposure = getWeatherExposure(stack);
+  if (opts.renderer) opts.renderer.toneMappingExposure = sys.exposure;
+
+  const rainState = deriveRainState(env, dt, sys.puddle);
+  sys.puddle = rainState.puddleLevel;
+  tickRain(sys.rain, rainState, dt);
+
+  if (shouldTriggerLightning(env.simulationTick, env.planetSeed, stack.phase === "storm")) {
+    triggerLightning(sys.lightning, { x: opts.anchor.x, y: 300, z: opts.anchor.z }, nowMs);
+  }
+  tickLightning(sys.lightning, nowMs);
+
+  const fogState = deriveFogState(env, opts.altitude);
+  tickFog(sys.fog, fogState, sun.color);
+
+  tickVegetation(sys.vegetation, env, dt, opts.timeSec);
+
+  const speed = vesselSpeed(opts.vessel);
+  const frame = deriveOceanFrame(env, speed);
+  if (opts.vessel) {
+    const heading = Math.atan2(opts.vessel.velocity.z, opts.vessel.velocity.x);
+    tickOcean(
+      sys.wake,
+      frame,
+      { x: opts.vessel.position.x, z: opts.vessel.position.z, heading },
+      speed,
+      dt,
+      env.wind,
+    );
+  } else {
+    sys.wake.wakeMesh.visible = false;
+    sys.wake.sprayPoints.visible = false;
+  }
+
+  ensureVolume(sys.volumes, "player", "player", { x: opts.anchor.x, y: 0, z: opts.anchor.z }, 200);
+  updateLocalVolumes(sys.volumes, { x: opts.anchor.x, y: 0, z: opts.anchor.z }, dt);
+  const playerCost = getVolumeCost(sys.volumes, "player");
+  const camDist = Math.hypot(opts.cameraPos.x - opts.anchor.x, opts.cameraPos.z - opts.anchor.z);
+  sys.quality = deriveQualityLevelStable(camDist, playerCost, sys.quality);
+  const budget = getBudget(camDist, playerCost, 1);
+  sys.godRays.group.visible = shouldAllowEffect(budget, "godRays");
+  sys.shadows.group.visible = shouldAllowEffect(budget, "shadows");
+  sys.rain.particles.visible =
+    shouldAllowEffect(budget, "particles") && (rainState.intensity > 0.08 || sys.puddle > 0.05);
+  cullVegetationByDistance(sys.vegetation, 40 + playerCost * 160, opts.anchor);
+}
+
+/** Detach groups from the scene and free GPU resources. */
+export function disposePlanetary10X(scene: THREE.Scene, sys: Planetary10X): void {
+  scene.remove(sys.shadows.group);
+  scene.remove(sys.godRays.group);
+  scene.remove(sys.rain.group);
+  scene.remove(sys.lightning.flashLight);
+  scene.remove(sys.lightning.boltMesh);
+  scene.remove(sys.vegetation.group);
+  scene.remove(sys.wake.wakeMesh);
+  scene.remove(sys.wake.sprayPoints);
+  const disposeGroup = (root: THREE.Object3D): void => {
+    root.traverse((o) => {
+      const mesh = o as THREE.Mesh;
+      if (mesh.geometry) mesh.geometry.dispose();
+      const material = mesh.material as THREE.Material | THREE.Material[] | undefined;
+      if (Array.isArray(material)) material.forEach((m) => m.dispose());
+      else if (material) material.dispose();
+    });
+  };
+  disposeGroup(sys.shadows.group);
+  disposeGroup(sys.godRays.group);
+  disposeGroup(sys.rain.group);
+  disposeGroup(sys.vegetation.group);
+  sys.lightning.boltMesh.geometry.dispose();
+  (sys.lightning.boltMesh.material as THREE.Material).dispose();
+}


### PR DESCRIPTION
10.X.1-X.4 full, no overlap with #716 (helpers only).

11 files product-grade: deterministic clocks (no Date.now in tick), seeded placement (no Math.random in tick), zero per-frame alloc, typed userData, weather+quality hysteresis, vegetation wetness restore, spray advection with wrap, explicit persistence sets. Keeps all #716 helpers.

Wiring: single point planetary/wire10X (create/tick/dispose) driven by the scene's existing EnvironmentalContext. Orbital Kepler light untouched; planetary sun drives ambient only. No new authority.

Verify: tsc -p apps/game/tsconfig.json 0 error, build-game.mjs bundled.