### PR TITLE
feat(10V-F0): correctness — settle diukur, petir beneran, ADRIFT tag, g per planet, waktu longitude, overlay anomali, F5 18/18

### DIFF
--- a/apps/game/src/renderer/hud.ts
+++ b/apps/game/src/renderer/hud.ts
@@ -165,9 +165,13 @@ export function initHud(container?: HTMLElement): Hud {
       for (const e of region.entities.values()) {
         if (!player || e.id === player.id) continue;
         const d = player ? dist(player.position, e.position) : 0;
+        // F3: other vessels carry their emergency flag — adrift/falling/
+        // crashed contacts are tagged, never silent.
+        const eEmerg = e.kind === "vessel" ? (e as VesselEntity).emergency?.state : undefined;
+        const eTag = eEmerg ? ` <span style="color:${colors.danger}">⚠ ${eEmerg.toUpperCase()}</span>` : "";
         const tag = e.kind === "vessel" ? `▸ VSL ${esc(log2(e.id))}` : `◈ STN ${esc((e as StationEntity).name ?? log2(e.id))}`;
         const dcol = e.kind === "station" ? colors.ok : colors.tactical;
-        vacuum.push(`${tag} <span style="color:${dcol}">${formatDist(d)}</span>`);
+        vacuum.push(`${tag}${eTag} <span style="color:${dcol}">${formatDist(d)}</span>`);
       }
       const html = vacuum.length ? vacuum.join("<br>") : `<span style="color:${colors.empty}">NO CONTACTS</span>`;
       fadeOnChange("target", q('[data-hud="left"]'), html);

--- a/apps/game/src/renderer/scene3d/index.ts
+++ b/apps/game/src/renderer/scene3d/index.ts
@@ -30,7 +30,7 @@ import {
   getSlopeAt,
   type TerrainOpts,
 } from "./planetary/terrain";
-import { createOceanMesh, oceanDepthForHeightmap } from "./planetary/ocean";
+import { createOceanMesh, oceanDepthForHeightmap, stormAmpScale } from "./planetary/ocean";
 import { createAtmosphere, lerpAtmosphereForAltitude } from "./planetary/atmosphere";
 import { ChunkManager, updateChunks } from "./planetary/chunks";
 import { lerpSpaceToSurface, canAutoLand, raycastCrash } from "./planetary/surface";
@@ -39,7 +39,9 @@ import { attachNightLights, updateNightVisibility } from "./planetary/night";
 import { createGeographyMarker, NICHE_COLOR } from "./planetary/geography";
 import { createEnvironmentalContext } from "../../../../../packages/gameserver/planetary/environment";
 import type { EnvironmentalContext } from "../../../../../packages/gameserver/planetary/environment";
+import { generateCosmicEventsForTick } from "../../../../../packages/gameserver/cosmicEvent";
 import { createPlanetary10X, tickPlanetary10X, disposePlanetary10X } from "./planetary/wireX";
+import { strikeDistanceTo } from "./planetary/lightning";
 import { createPlanetary10G, tickPlanetary10G, disposePlanetary10G } from "./planetary/wireG";
 import { createEmergency10X, tickEmergency10X, disposeEmergency10X } from "./planetary/wireE";
 import { createCinematicC, tickCinematicC, disposeCinematicC } from "./cinematic/wireC";
@@ -154,6 +156,13 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
 
   function updateEnvironmentalContext(): void {
     planetTick++;
+    // F7: anomaly overlay regenerated deterministically (same function +
+    // same inputs as the server — zero bandwidth). Demo mapping:
+    // regionId = planetId until snapshot sync carries the authoritative id.
+    const anomalyChunks = generateCosmicEventsForTick("planet-07", planetTick, "planet-07")
+      .filter((e) => e.kind === "anomaly_gravity")
+      .map((e) => (e.payload["chunkKey"] as string | undefined) ?? "")
+      .filter((k) => k.length > 0);
     envContext = createEnvironmentalContext({
       planetId: "planet-07",
       planetSeed,
@@ -162,6 +171,7 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
       worldTime,
       terrainHeight: 0,
       oceanDepth: -10,
+      anomalyChunks,
     });
   }
   updateEnvironmentalContext();
@@ -239,7 +249,8 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
       if (envContext) {
         // Update ocean wind from EnvironmentalContext
         const windDir = envContext.wind.direction;
-        (oceanMesh as any)._tick?.(1 / 60, windDir);
+        // F8: mesh amplitude follows live storm state (calm shrinks, storm grows).
+        (oceanMesh as any)._tick?.(1 / 60, windDir, stormAmpScale(envContext.ocean.waveAmplitude));
         // Update atmosphere cloud drift
         (atmoGroup as any)._tick?.(1 / 60, envContext.wind.speed);
         // Night visibility
@@ -324,8 +335,8 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
     updateExplosions(ctx);
 
     // ── PLANETARY TICK (10.2-10.6) ──
-    // Ocean wave animation
-    (oceanMesh as any)._tick?.(1 / 60, envContext?.wind.direction ?? 0);
+    // Ocean wave animation (F8: amplitude follows live storm state)
+    (oceanMesh as any)._tick?.(1 / 60, envContext?.wind.direction ?? 0, envContext ? stormAmpScale(envContext.ocean.waveAmplitude) : 1);
     // Atmosphere cloud drift
     (atmoGroup as any)._tick?.(1 / 60, envContext?.wind.speed ?? 2);
     // Cloud group opacity based on altitude
@@ -369,7 +380,13 @@ export function initScene3D(container?: HTMLElement, settings?: GameSettings): S
         camera: ctx.camera ?? undefined,
         cameraPosXZ: { x: camX, z: camZ },
         anchor: { x: ctx.anchor.x, z: ctx.anchor.z },
-        distanceToLightning: 2800,
+        // F2: real camera-to-strike distance (fresh <8s) — stale/missing
+        // falls back to STALE_STRIKE_DISTANCE inside strikeDistanceTo.
+        distanceToLightning: strikeDistanceTo(
+          { x: camX, y: ctx.camera ? ctx.camera.position.y : 0, z: camZ },
+          planetary10X.lightning.lastEvent,
+          envContext.worldTime / 1000 + envContext.simulationTick * 0.1,
+        ),
         renderer: ctx.renderer,
         // 10.V U4: presentasi kokpit hidup dari state yang sama.
         cockpitPass: ctx.cockpitPass ?? undefined,

--- a/apps/game/src/renderer/scene3d/planetary/atmosphericContinuity.ts
+++ b/apps/game/src/renderer/scene3d/planetary/atmosphericContinuity.ts
@@ -35,22 +35,31 @@ export function deriveAtmosphericContinuity(ctx: EnvironmentalContext, cameraAlt
   return { haze: Math.min(1, haze), valleyFog: Math.min(1, valleyFog), mountainContrast: Math.min(1, mountainContrast), shadowProgress, horizonGlow: Math.min(1, horizonGlow), entryHaze: Math.min(1, entryHaze) };
 }
 
+/**
+ * @deprecated F5: TIDAK DIPAKAI — scene.fog dimiliki tickFog (fog.ts,
+ * wireX). Dua penulis = rebutan per frame. Dipertahankan agar import
+ * lama tidak patah; jangan panggil dari wire.
+ */
 export function tickAtmosphere(sys: { fog: THREE.FogExp2 }, cont: AtmosphericContinuity, dt: number): void {
   const target = 0.00008 + cont.haze * 0.00022 + cont.valleyFog * 0.00013 + cont.entryHaze * 0.00008;
   sys.fog.density += (target - sys.fog.density) * Math.min(1, dt * 1.4);
   sys.fog.color.setHSL(0.58 + cont.horizonGlow * 0.06, 0.22 + cont.haze * 0.18, 0.72 + cont.horizonGlow * 0.08);
 }
 
-export function tickTerrainShadows(shadowPlane: THREE.Mesh, cont: AtmosphericContinuity, sunDirection: { x: number; y: number; z: number }): void {
+export function tickTerrainShadows(shadowPlane: THREE.Mesh, cont: AtmosphericContinuity, sunDirection: { x: number; y: number; z: number }, dt = 1 / 60): void {
+  // F5: lerp dibasiskan dt (frame-rate independent) — konstanta lama 0.12/0.08
+  // = implisit 60fps.
+  const k = Math.min(1, dt * 7.2);
   const mat = shadowPlane.material as THREE.MeshBasicMaterial;
   const base = cont.mountainContrast * 0.18 * (1 - cont.shadowProgress * 0.42);
   const valleyBoost = cont.valleyFog * 0.04;
   const target = Math.min(0.24, base + valleyBoost);
-  mat.opacity += (target - mat.opacity) * 0.12;
+  mat.opacity += (target - mat.opacity) * k;
   shadowPlane.visible = mat.opacity > 0.02;
   const drift = 1200 * (1 - cont.shadowProgress);
-  shadowPlane.position.x += (sunDirection.x * drift - shadowPlane.position.x) * 0.08;
-  shadowPlane.position.z += (sunDirection.z * drift - shadowPlane.position.z) * 0.08;
+  const kp = Math.min(1, dt * 4.8);
+  shadowPlane.position.x += (sunDirection.x * drift - shadowPlane.position.x) * kp;
+  shadowPlane.position.z += (sunDirection.z * drift - shadowPlane.position.z) * kp;
   shadowPlane.rotation.y = Math.atan2(sunDirection.z, sunDirection.x) * 0.12;
 }
 

--- a/apps/game/src/renderer/scene3d/planetary/chunks.ts
+++ b/apps/game/src/renderer/scene3d/planetary/chunks.ts
@@ -7,6 +7,7 @@
 import * as THREE from "three";
 import { createHeightmap, heightmapToGeometry } from "./terrain";
 import { createOceanMesh, oceanDepthForHeightmap } from "./ocean";
+import { disposeGroup } from "../bootstrap";
 
 function toRegionId(c: { planetId: string; x: number; z: number }): string { return `${c.planetId}:${c.x}:${c.z}`; }
 
@@ -64,7 +65,8 @@ export function updateChunks(manager: ChunkManager, center: { x: number; z: numb
   const { toLoad, toUnload } = manager.update(center);
   for (const id of toUnload) {
     const o = scene.getObjectByName(id);
-    if (o) scene.remove(o);
+    // F5: unload WAJIB dispose — remove tanpa dispose = bocor GPU tiap travel.
+    if (o) { scene.remove(o); disposeGroup(o as THREE.Group); }
   }
   for (const k of toLoad) {
     const id = toRegionId(k);

--- a/apps/game/src/renderer/scene3d/planetary/lightning.ts
+++ b/apps/game/src/renderer/scene3d/planetary/lightning.ts
@@ -141,3 +141,26 @@ export function getLightningThreat(sys: LightningSystem, now: number): number {
   if (age > THREAT_WINDOW_MS) return 0;
   return sys.lastEvent.intensity * Math.max(0, 1 - age / THREAT_WINDOW_MS);
 }
+
+/**
+ * F2: real strike distance for audio/exposure resolvers. Fresh (<8s)
+ * strike → true camera-to-strike distance; stale/missing → documented
+ * fallback (the old hardcoded 2800, now a named constant).
+ */
+export const STALE_STRIKE_DISTANCE = 2800;
+const STRIKE_FRESH_MS = 8000;
+
+export function strikeDistanceTo(
+  cam: { x: number; y: number; z: number },
+  lastEvent: LightningEvent | null,
+  nowMs: number,
+  fallback = STALE_STRIKE_DISTANCE,
+): number {
+  if (!lastEvent) return fallback;
+  const age = nowMs - lastEvent.timestamp;
+  if (age < 0 || age > STRIKE_FRESH_MS) return fallback;
+  const dx = cam.x - lastEvent.position.x;
+  const dy = cam.y - lastEvent.position.y;
+  const dz = cam.z - lastEvent.position.z;
+  return Math.hypot(dx, Math.hypot(dy, dz));
+}

--- a/apps/game/src/renderer/scene3d/planetary/night.ts
+++ b/apps/game/src/renderer/scene3d/planetary/night.ts
@@ -123,6 +123,7 @@ export interface RadarContact {
   distance: number; // m
   position: { x: number; y: number; z: number };
   unknown: boolean; // >30km atau health rendah -> Unknown
+  emergency?: string; // F3: status darurat kapal lain (adrift/falling/crashed)
 }
 
 export interface RadarDiscovery {
@@ -139,14 +140,14 @@ export interface RadarDiscovery {
  */
 export function discoverViaRadar(
   origin: { x: number; y: number; z: number },
-  entities: Array<{ id: string; kind: string; position: { x: number; y: number; z: number }; health?: number }>,
+  entities: Array<{ id: string; kind: string; position: { x: number; y: number; z: number }; health?: number; emergency?: string }>,
 ): RadarDiscovery {
   const contacts: RadarContact[] = entities.map((e) => {
     const dx = e.position.x - origin.x;
     const dz = e.position.z - origin.z;
     const dist = Math.hypot(dx, Math.hypot(e.position.y - origin.y, dz));
     const unknown = dist > 30000 || (e.health ?? 100) < 20;
-    return { id: e.id, kind: unknown ? "Unknown" : e.kind, distance: dist, position: e.position, unknown };
+    return { id: e.id, kind: unknown ? "Unknown" : e.kind, distance: dist, position: e.position, unknown, emergency: e.emergency };
   });
   contacts.sort((a, b) => a.distance - b.distance);
   // Batasi 12 terdekat biar UI gak spam
@@ -158,10 +159,10 @@ export function discoverViaRadar(
   };
 }
 
-/** Format radar untuk HUD: "Hangar-A 12 km / Unknown 430 km". */
+/** Format radar untuk HUD: "Hangar-A 12 km / Unknown 430 km". F3: tag darurat menempel. */
 export function formatRadarHud(d: RadarDiscovery): string {
   if (d.contacts.length === 0) return "No contacts within 50km";
   return d.contacts
-    .map((c) => `${c.kind} ${c.id.slice(0, 6)} ${(c.distance / 1000).toFixed(c.distance > 10000 ? 0 : 1)} km${c.unknown ? " ?" : ""}`)
+    .map((c) => `${c.kind} ${c.id.slice(0, 6)} ${(c.distance / 1000).toFixed(c.distance > 10000 ? 0 : 1)} km${c.unknown ? " ?" : ""}${c.emergency && c.emergency !== "nominal" ? ` [${c.emergency.toUpperCase()}]` : ""}`)
     .join(" / ");
 }

--- a/apps/game/src/renderer/scene3d/planetary/ocean.ts
+++ b/apps/game/src/renderer/scene3d/planetary/ocean.ts
@@ -49,7 +49,9 @@ export function createOceanMesh(opts: OceanOpts = { size: 6000, seg: 64, windSpe
   let t = 0;
   const basePositions = new Float32Array(pos.array as ArrayLike<number>);
 
-  (mesh as any)._tick = (dt: number, windDir = 0) => {
+  (mesh as any)._tick = (dt: number, windDir = 0, ampScale = 1) => {
+    // F8: ampScale scales live storm amplitude (state-driven, default 1 =
+    // creation-time wind). Foam follows the SCALED crest (whitecap ∝ wind).
     t += dt;
     const p = geom.attributes.position as THREE.BufferAttribute;
     const col = geom.attributes.color as THREE.BufferAttribute;
@@ -64,9 +66,9 @@ export function createOceanMesh(opts: OceanOpts = { size: 6000, seg: 64, windSpe
         const wx = w.dirX * cosD - w.dirZ * sinD;
         const wz = w.dirX * sinD + w.dirZ * cosD;
         const phase = ox * w.k * wx + oz * w.k * wz - w.omega * t * (0.7 + wi * 0.15);
-        const h = Math.sin(phase) * w.amp;
+        const h = Math.sin(phase) * w.amp * ampScale;
         y += h;
-        if (wi < 2) foamAcc += Math.max(0, Math.cos(phase)) * w.amp * 0.12;
+        if (wi < 2) foamAcc += Math.max(0, Math.cos(phase)) * w.amp * ampScale * 0.12;
       }
       y += Math.sin(ox * 0.005 + t * 0.3) * 0.7;
       p.setZ(i, y);
@@ -84,6 +86,17 @@ export function createOceanMesh(opts: OceanOpts = { size: 6000, seg: 64, windSpe
   };
 
   return mesh;
+}
+
+/**
+ * F8: live storm scale for `_tick` ampScale. Mesh base amps assume
+ * creation windSpeed 6 dry air (0.9 + 6×0.32); state amplitude is divided
+ * by the same base so calm seas shrink and storms grow the mesh.
+ */
+export const OCEAN_MESH_BASE_AMPLITUDE = 0.9 + 6 * 0.32;
+
+export function stormAmpScale(waveAmplitude: number): number {
+  return Math.max(0.3, Math.min(3, waveAmplitude / OCEAN_MESH_BASE_AMPLITUDE));
 }
 
 export function oceanDepthForHeightmap(heightmap: Float32Array, seaLevel = 0): Float32Array {

--- a/apps/game/src/renderer/scene3d/planetary/surface.ts
+++ b/apps/game/src/renderer/scene3d/planetary/surface.ts
@@ -8,8 +8,10 @@ import * as THREE from "three";
 
 export type TimeOfDay = "dawn" | "day" | "dusk" | "night";
 
-export function timeOfDayFromMs(ms: number): TimeOfDay {
-  const h = (ms % 86400000) / 3600000;
+export function timeOfDayFromMs(ms: number, lonDeg = 0): TimeOfDay {
+  // F6: local solar hour follows longitude (15° = 1 hour); default 0 =
+  // legacy global behavior for callers without position.
+  const h = ((((ms % 86400000) / 3600000 + lonDeg / 15) % 24) + 24) % 24;
   if (h < 5 || h > 19) return "night";
   if (h < 7) return "dawn";
   if (h > 17) return "dusk";

--- a/apps/game/src/renderer/scene3d/planetary/wireG.ts
+++ b/apps/game/src/renderer/scene3d/planetary/wireG.ts
@@ -14,7 +14,7 @@ import type { VesselEntity } from "../../../../../../packages/gameserver/types";
 import { deriveEnvironmentalEvent, tickEnvironmentalEvent, type EnvironmentalEvent } from "./environmentalEvent";
 import { getCoastalZone, createCoastalSystem, tickCoastal, type CoastalSystem } from "./coastal";
 import { getRiverFlow, createRiverSystem, tickRiver, type RiverSystem } from "./hydrological";
-import { deriveAtmosphericContinuity, tickAtmosphere, tickTerrainShadows, createShadowPlane, type AtmosphericContinuity } from "./atmosphericContinuity";
+import { deriveAtmosphericContinuity, tickTerrainShadows, createShadowPlane, type AtmosphericContinuity } from "./atmosphericContinuity";
 
 export interface Planetary10GTickOpts {
   timeSec: number;
@@ -30,7 +30,6 @@ export interface Planetary10G {
   river: RiverSystem;
   shadowPlane: THREE.Mesh;
   continuity: AtmosphericContinuity | null;
-  fog: THREE.FogExp2 | null;
 }
 
 export function createPlanetary10G(scene: THREE.Scene): Planetary10G {
@@ -43,8 +42,7 @@ export function createPlanetary10G(scene: THREE.Scene): Planetary10G {
   scene.add(coastal.shallowPlane);
   river.flowMeshes.forEach(m => scene.add(m));
   scene.add(river.waterfallPoints);
-  const fog = (scene as any).fog as THREE.FogExp2 | undefined ?? null;
-  return { event: null, coastal, river, shadowPlane, continuity: null, fog: fog ?? null };
+  return { event: null, coastal, river, shadowPlane, continuity: null };
 }
 
 export function tickPlanetary10G(sys: Planetary10G, scene: THREE.Scene, env: EnvironmentalContext, dt: number, opts: Planetary10GTickOpts): void {
@@ -54,13 +52,10 @@ export function tickPlanetary10G(sys: Planetary10G, scene: THREE.Scene, env: Env
   sys.event = next;
   const cont = deriveAtmosphericContinuity(env, opts.altitude, env.sun.elevation);
   sys.continuity = cont;
-  const fog = (scene as any).fog as THREE.FogExp2 | undefined ?? sys.fog;
-  if (fog) {
-    const fsys = { fog } as { fog: THREE.FogExp2 };
-    tickAtmosphere(fsys, cont, dt);
-    sys.fog = fog;
-  }
-  tickTerrainShadows(sys.shadowPlane, cont, env.sun.direction);
+  // F5: scene.fog HANYA ditulis tickFog (wireX, dari FogState). Tulis ganda
+  // di sini (tickAtmosphere) vs sana = rebutan per frame — dimatikan di sini,
+  // kontribusi haze/valley sudah masuk deriveFogState.
+  tickTerrainShadows(sys.shadowPlane, cont, env.sun.direction, dt);
   const height = env.terrain.height;
   const slope = env.terrain.slope;
   const distToCoast = Math.abs(height) * 18 + (env.ocean.depth < -4 ? 12 : 180);

--- a/docs/blueprint/10-planetary-runtime.md
+++ b/docs/blueprint/10-planetary-runtime.md
@@ -51,6 +51,12 @@ PLANET (thousands km)
 ```
 
 * **Chunking:** `regionId = planetId:chunkX:chunkZ` distributed via `WorldRegion:41` `relay/registry.ts:33` `claimRegion` - only chunks with players or facilities are ticked; world state for all chunks stays persistent in `persistence.ts:120`.
+
+> ERRATUM F9 (10.V F0, 2026-09-11, mengikat): paragraf chunking di atas
+> DINYATAKAN KELIRU. Fakta terverifikasi: `claimRegion` = handoff shard
+> vessel (bukan tick chunk); chunking yang berjalan = streaming + LOD sisi
+> klien + persist koordinat. Chunk-tick server beneran = opsi (a) yang
+> DITUNDA ke fase MMO-server. Lihat `10-visual-fidelity.md` §4 F9.
 * **Persistent Coordinate:** `position Vec3{x,y,z}` `types.ts:18` stored in `RegionSnapshot:79` `RegionState:65` `Map` - logging out in `Planet-07 / Region-A / Hangar-A` returns to the same `Hangar-A`; `Player A ↔2000 km↔ Player B` are on the same planet, different locations. Coordinates are shareable (`gate.ts:34` `position`) for rendezvous. Spawn is at the chosen facility, not a global `0,0,0`.
 * **Empty Land Rule:** community facilities may only be placed on **empty land** (`ARCLUX` limits buildable area, `forest/ocean` stay natural) - `hutan/laut` remain, `hangar` is built where land is empty.
 
@@ -113,7 +119,7 @@ Planet slowly acquires social geography organically - no global sim needed. `Don
 ## 13. Checklist
 
 * [x] Substrate natural `terrain/ocean/atmosphere/clouds` streaming LOD (visual-only) - 10.2 done
-* [x] Scale + chunk + persistent coordinate `Planet/Chunk` `claimRegion` `Vec3` persist - 10.3 done
+* [x] Scale + chunk + persistent coordinate `Planet/Chunk` `Vec3` persist - 10.3 done (F9 erratum: `claimRegion` DICABUT dari baris ini — handoff shard, bukan tick chunk)
 * [x] Time & compass Newtonian `24h + lunar Kepler + G,σ` - 10.4 done
 * [x] Aerospace seamless `ORBIT->HANGAR` `GateLink` without loading - 10.4 done
 * [x] Community facilities `10` types `StationEntity` persistent - 10.5 done
@@ -419,8 +425,8 @@ Numpang semua:
 
 ### FASE 10.3 - Scale & Chunk + Persistent Coordinate
 
-- [x] `scene3d/planetary/chunks.ts` - streaming LOD, cull jauh, `planetId:chunkX:chunkZ` via `claimRegion` - DONE 10.3 (`world.ts:41` + `relay/registry.ts:33`)
-- [x] `packages/gameserver/planetary/chunks.ts` + `geography.ts` - chunk tick via claimRegion - DONE 10.3
+- [x] `scene3d/planetary/chunks.ts` - streaming LOD, cull jauh, `planetId:chunkX:chunkZ` - DONE 10.3 (F9 erratum: frasa "via `claimRegion`" DICABUT — streaming klien, bukan tick server)
+- [x] `packages/gameserver/planetary/chunks.ts` + `geography.ts` - matematika kunci + helper chunk - DONE 10.3 (F9 erratum: frasa "chunk tick via claimRegion" DICABUT — tanpa loop tick)
 - [x] `types.ts:18 Vec3` - `log out Hangar-A -> Hangar-A`, 2000 km same planet, shareable `gate.ts:34` - DONE via persistence
 - [x] `Verify:` 2 player 2000 km same planet, relog tetap di tempat - DONE
 

--- a/docs/blueprint/10-visual-fidelity.md
+++ b/docs/blueprint/10-visual-fidelity.md
@@ -231,16 +231,50 @@ File: `vesselState.ts`, `simulation.ts`, `index.ts` (hook),
 `environment.ts` (F6/F7), `ocean.ts`+`wireX/G` (F8),
 keputusan F9 (code atau revisi blueprint).
 
-- [ ] F1: `landingOutcome()` dipanggil saat settle + log `crash_impact`
-- [ ] F2: jarak petir dari posisi strike beneran, bukan 2800
-- [ ] F3: tag `ADRIFT` kapal orang lain di daftar kontak
-- [ ] F4: massa+radius per planet dari environs (`g` bervariasi)
-- [ ] F6: waktu lokal longitude + interpolasi batas chunk
-- [ ] F7: overlay anomali->cuaca + `chunkKey` di payload anomali
-- [ ] F8: amplitudo mesh ikut state + trigger STORM per chunk vessel
-- [ ] F9: putuskan chunk-server vs revisi blueprint, eksekusi
-- [ ] F5: SEMUA backlog §7 berubah jadi verified (cek per file)
-- [ ] Verify: `tsc 0` + build + smoke tiap item di atas
+- [x] F1: `landingOutcome()` dipanggil saat settle + log `crash_impact`
+  (VERIFIED F0: `simulation.stepEmergency` vonis tiap falling→crashed dari
+  kinematika asli + log verdict/KE/budget; terrain unknown = konservatif
+  tercatat eksplisit; smoke-f0 5/5)
+- [x] F2: jarak petir dari posisi strike beneran, bukan 2800
+  (VERIFIED F0: `strikeDistanceTo` baca `lastEvent.position` strike segar
+  <8s; basi/hilang = fallback bernama `STALE_STRIKE_DISTANCE`; smoke 3/3)
+- [x] F3: tag `ADRIFT` kapal orang lain di daftar kontak
+  (VERIFIED F0: HUD target list + `discoverViaRadar`/`formatRadarHud`
+  passthrough `[ADRIFT]`/`[FALLING]`/`[CRASHED]`; smoke 2/2)
+- [x] F4: massa+radius per planet dari environs (`g` bervariasi)
+  (VERIFIED F0: `nearestPlanetBody` mengoper massa asli ke `applyGravity`;
+  `surfaceGravity` Bumi 9.82 / Mars 3.71; smoke 3/3)
+- [x] F6: waktu lokal longitude + interpolasi batas chunk
+  (VERIFIED F0: `localHour` + `chunkLonDeg`; `positionXZ` kontinu antar
+  chunk, fallback tengah-chunk error <5 detik; barat vs timur terbukti
+  beda; smoke 6/6)
+- [x] F7: overlay anomali->cuaca + `chunkKey` di payload anomali
+  (VERIFIED F0: payload bawa `chunkKey` deterministik; overlay storm
+  reversibel; generator murni `generateCosmicEventsForTick` identik
+  server==client nol bandwidth; smoke 3/3)
+- [x] F8: amplitudo mesh ikut state + trigger STORM per chunk vessel
+  (VERIFIED F0: `_tick(dt,windDir,ampScale)` + `stormAmpScale` dari
+  `ocean.waveAmplitude` live, jepit 0.3..3; trigger per chunk vessel
+  mengalir via overlay F7 → kind chunk; smoke 3/3)
+- [x] F9: putuskan chunk-server vs revisi blueprint, eksekusi
+  (DIPUTUSKAN F0: opsi (b) — chunking = streaming client + persist
+  koordinat; `claimRegion` tetap handoff shard; erratum ditulis di
+  Blueprint 10 §5 + di bawah)
+- [x] F5: SEMUA backlog §7 berubah jadi verified (cek per file)
+  (VERIFIED F0: 18/18 dibaca + tsc + smoke; 2 FIX: dispose saat unload
+  chunk, tulis fog tunggal;   temuan diteruskan ke A2/A3/L1 di bawah)
+- [x] Verify: `tsc 0` + build + smoke tiap item di atas
+  (`tsc -p apps/game` 0 + server standalone 0 + `build-game.mjs` OK +
+  `smoke-f0.ts` 25/25, 0 FAIL)
+
+> ERRATUM F9 (2026-09-11, mengikat): klaim "chunk di-tick server via
+> `claimRegion`" di Blueprint 10 §5 DINYATAKAN KELIRU. Fakta:
+> `packages/gameserver/planetary/chunks.ts` = matematika kunci + helper
+> (tanpa loop tick); `claimRegion` (`relay/registry.ts:24`) = handoff
+> shard vessel (dipakai `bridge.ts:88` saja). Chunking yang berjalan =
+> streaming + LOD sisi klien (`apps/game/.../planetary/chunks.ts`) +
+> persist koordinat. Opsi (a) (chunk-tick server beneran) DITUNDA ke
+> fase MMO-server; sampai saat itu tidak boleh ada klaim (a).
 
 ### A1 Vegetation (pembunuh kartun #1)
 
@@ -378,47 +412,74 @@ dibaca ulang.
 Riwayat tiap file: versi proto TERBUKTI punya cacat X, versi baru
 MENGKLAIM Y. Sampai dibaca ulang, status = UNVERIFIED.
 
-Substrate (klaim: rewrite AAA):
+Substrate (hasil verifikasi F0 — centang = dibaca + tsc + smoke):
 
-- [ ] `planetary/terrain.ts` — klaim FBM+erosi+LOD; cek: deterministik
-      per-koordinat? seam antar-chunk? LOD beneran streaming?
-- [ ] `planetary/ocean.ts` — klaim 4 Gerstner; cek: Gerstner beneran
-      (displace XZ) atau sinus-Z? foam hidup? preservasi base?
-- [ ] `planetary/atmosphere.ts` — klaim scattering; cek: scattering
-      fisik atau gradien + konstanta? `depthWrite:false` utuh?
-- [ ] `planetary/chunks.ts` (+ server) — klaim LOD + hybrid mesh;
-      cek: bug jarak indeks-vs-pos? planetId hardcode? frustum cull?
-- [ ] `planetary/surface.ts` — klaim Kepler + GateLink; cek: Kepler
-      beneran atau sudut linear? threshold magic terdokumentasi?
-- [ ] `planetary/facilities.ts` — klaim 10 geometri distinct; cek:
-      masih ada fallback kotak? aturan empty-land dobel otoritas?
-- [ ] `planetary/geography.ts` — cek: import server-ke-client masih
-      ada? marker LOD/cull?
-- [ ] `planetary/night.ts` — cek: draw-call per facility? traverse
-      per-tick?
+- [x] `planetary/terrain.ts` — VERIFIED + 2 temuan → A2: (1) `mountainNoise`
+      pakai `rnd()` sekuensial per-vertex (bukan fungsi posisi) → bentuk
+      berubah saat LOD ganti + diskontinu di batas chunk; (2) `detail`
+      pakai `hashPos` indeks LOKAL → pola berulang per chunk. Erosi
+      hidrolik sederhana ASLI. `getSlopeAt` bagi 40 (magic, dicatat).
+- [x] `planetary/ocean.ts` — VERIFIED + koreksi klaim: "4 Gerstner"
+      KELIRU — realitanya sinus-Z (tanpa displace XZ); Gerstner beneran
+      = backlog A3. Foam hidup YA, `basePositions` preserved YA.
+      F8: `_tick` kini terima `ampScale` live.
+- [x] `planetary/atmosphere.ts` — VERIFIED + koreksi klaim: "scattering"
+      = cangkang artistik + konstanta, bukan fisika. `depthWrite:false`
+      UTUH di 4 lapis.
+- [x] `planetary/chunks.ts` (+ server) — VERIFIED + 1 FIX: streaming LOD
+      ASLI (load/unload per jarak); planetId hardcode "planet-07"
+      (demo, dicatat); jarak pakai origin chunk (bias ≤2000m, minor);
+      ocean chunk statis; UNLOAD BOCOR GPU → DIPERBAIKI (dispose).
+      Server `chunks.ts` = matematika + helper, tanpa loop tick (F9).
+- [x] `planetary/surface.ts` — VERIFIED + koreksi klaim: "Kepler"
+      KELIRU — realitanya sudut linear + fase seed; Kepler beneran =
+      backlog (bukan F0). GateLink/approach/raycastCrash ASLI.
+      Threshold magic inline (dicatat, bukan diblokir).
+- [x] `planetary/facilities.ts` — VERIFIED + catatan: 10 kind eksplisit
+      (primitif berbeda, bukan 10 pahatan); fallback kotak default ADA;
+      empty-land HANYA klien (tanpa pasangan server — otoritas
+      penempatan = fase UE).
+- [x] `planetary/geography.ts` — VERIFIED: import server = pola kontrak
+      shared (sama seperti environment), BUKAN pelanggaran; marker tanpa
+      LOD/cull (minor, dicatat).
+- [x] `planetary/night.ts` — VERIFIED + 2 temuan → L1.3: 96 mesh
+      individual per facility (≈109 draw call) + traverse per-frame.
+      Radar + format HUD kini bawa tag darurat (F3).
 
-Gaps G1-G4 (klaim: state machine + zona + river + continuity):
+Gaps G1-G4 (hasil verifikasi F0):
 
-- [ ] `planetary/environmentalEvent.ts` — fase `landing`/`post`
-      tercapai? `startedAt` reset? mist tidak nol-mati?
-- [ ] `planetary/coastal.ts` — bug arah (windSpeed sebagai sudut)?
-      drift unbounded? baca `EnvironmentalContext` sekarang?
-- [ ] `planetary/hydrological.ts` — quad hanyut selamanya?
-      recycle? `river->ocean` beneran ketemu?
-- [ ] `planetary/atmosphericContinuity.ts` — konflik tulis fog
-      dengan sun/fog resolver? `dt` dipakai?
+- [x] `planetary/environmentalEvent.ts` — VERIFIED PASS: fase `landing`/
+      `post` tercapai, `startedAt` reset saat fase ganti, mist non-nol
+      di post/recovery/landing.
+- [x] `planetary/coastal.ts` — VERIFIED PASS: urutan argumen benar
+      (tidak ada bug sudut), drift dibatasi (wrap ±140/±40), baca env
+      via argumen. `Math.random` hanya init/transient (dicatat).
+- [x] `planetary/hydrological.ts` — VERIFIED PASS: quad terbungkus
+      ±60 (tidak hanyut), recycle YA, `river->ocean` ketemu via tint.
+- [x] `planetary/atmosphericContinuity.ts` — VERIFIED + 1 FIX BESAR:
+      KONFLIK TULIS fog terbukti (`tickFog` wireX vs `tickAtmosphere`
+      wireG menulis `scene.fog` yang sama per frame) → DIPERBAIKI
+      (penulis tunggal: `tickFog`; `tickAtmosphere` deprecated).
+      `tickTerrainShadows` kini basis-dt.
 
-Sinematik C6-C10 (klaim: 5 resolver + wire):
+Sinematik C6-C10 (hasil verifikasi F0):
 
-- [ ] `EnvironmentalAudioResolver.ts` — sync wind/rain/thunder,
-      delay thunder = jarak/343?
-- [ ] `CockpitResponseResolver.ts` — presentation-only murni?
-- [ ] `ImpactPresentation.ts` — rantai impact->wreck utuh?
-      transient vs persistent dipisah?
-- [ ] `FacilityDiscovery.ts` — `AtmosphericReveal.ts` (blueprint
-      C.9 minta) ada atau tidak?
-- [ ] `CinematicBudget.ts` — hysteresis? kompatibel qualityBudget?
-- [ ] `wireG.ts` — tick signature konsisten? tidak tulis authority?
+- [x] `EnvironmentalAudioResolver.ts` — VERIFIED PASS: sync
+      wind/rain/thunder dari env; delay thunder = jarak/343.
+- [x] `CockpitResponseResolver.ts` — VERIFIED PASS: presentation-only
+      murni, tanpa `Date.now`. Catatan: divisor flash 4200 vs audio
+      6000 (inkonsistensi minor, dicatat).
+- [x] `ImpactPresentation.ts` — VERIFIED PASS: rantai impact->wreck
+      6 fase utuh, wreck persisten. Catatan: `debrisCount` 6–24 vs
+      10 debris dibangun (minor, dicatat).
+- [x] `FacilityDiscovery.ts` — VERIFIED: fase + threshold asli;
+      `AtmosphericReveal.ts` (blueprint C.9) DINYATAKAN TIDAK ADA —
+      discovery jalan tanpanya; pembuatan = backlog (bukan F0).
+- [x] `CinematicBudget.ts` — VERIFIED: hysteresis via
+      `continuityProgress` ADA. Catatan: sistem budget ganda
+      (CinematicBudget vs qualityBudget) — unifikasi = backlog.
+- [x] `wireG.ts` — VERIFIED PASS: signature konsisten dengan wireX;
+      nol tulis otoritas (visual saja).
 
 Cara verifikasi tiap kotak: baca file + `tsc` + smoke perilaku
 (pola smoke yang sudah ada) + tulis HASILnya di PR. Kotak centang

--- a/packages/gameserver/collision.ts
+++ b/packages/gameserver/collision.ts
@@ -61,7 +61,7 @@ function impactAngleFactor(vessel: VesselEntity, body: SystemBody): number {
 }
 
 /** Mass of a vessel, mirroring simulation's convention (`vessel.mass ?? 5e6`). */
-function vesselMass(vessel: VesselEntity): number {
+export function vesselMass(vessel: VesselEntity): number {
   return (vessel as unknown as { vessel?: { mass?: number } }).vessel?.mass ?? MASS_REF;
 }
 

--- a/packages/gameserver/cosmicEvent.ts
+++ b/packages/gameserver/cosmicEvent.ts
@@ -24,6 +24,21 @@ export interface CosmicEvent {
 }
 
 export function generateCosmicEvents(state: EnvironsState, regionId: string, tick: number): CosmicEvent[] {
+  // Planet namespace for anomaly chunk coverage (F7): first planet body,
+  // deterministic fallback when the region owns no planet.
+  let planetId = "planet-07";
+  for (const b of state.bodies.values()) {
+    if (b.kind === "planet") { planetId = b.id; break; }
+  }
+  return generateCosmicEventsForTick(regionId, tick, planetId);
+}
+
+/**
+ * Pure deterministic generator (F7): identical output for identical
+ * (regionId, tick, planetId) on server AND client — zero bandwidth.
+ * The client regenerates the same anomaly overlay locally.
+ */
+export function generateCosmicEventsForTick(regionId: string, tick: number, planetId: string): CosmicEvent[] {
   const out: CosmicEvent[] = [];
   // mulberry32 seeded by tick+regionId — deterministic, cross-env identical
   const rng = createSeedRng(Math.imul(tick, 0x9e3779b9) ^ (regionId.length * 0x6d2b79f5));
@@ -50,7 +65,12 @@ export function generateCosmicEvents(state: EnvironsState, regionId: string, tic
     const anomalyMass = 1e24 * (0.5 + rng.fract());
     const rAnomaly = 5e10 + rng.fract() * 5e10;
     const a = computeAnomalyAccel(anomalyMass, rAnomaly);
-    out.push({ id: `cosmic:${tick}:anomaly`, tick, kind: "anomaly_gravity", severity: Math.floor(Math.min(100, a * 1e6)), regionId, payload: { mass_kg: anomalyMass, distance_m: rAnomaly, accel_mps2: a } });
+    // F7: deterministic chunk coverage — the anomaly storm cell covers ONE
+    // chunk (±6 around origin); consumers flip that chunk's weather to storm.
+    // Draws happen AFTER all shared draws, so existing sequences are untouched.
+    const cx = Math.floor(rng.fract() * 13) - 6;
+    const cz = Math.floor(rng.fract() * 13) - 6;
+    out.push({ id: `cosmic:${tick}:anomaly`, tick, kind: "anomaly_gravity", severity: Math.floor(Math.min(100, a * 1e6)), regionId, payload: { mass_kg: anomalyMass, distance_m: rAnomaly, accel_mps2: a, chunkKey: `${planetId}:${cx}:${cz}` } });
   }
   return out;
 }

--- a/packages/gameserver/planetary/environment.ts
+++ b/packages/gameserver/planetary/environment.ts
@@ -85,11 +85,44 @@ export function deriveTerrainState(height: number, slope: number, wetness: numbe
   return { height, slope: Math.min(1, slope), biome, wetness, snow: height > 300 ? Math.min(1, (height - 300) / 250) : 0, erosion: Math.min(1, slope * 0.7 + Math.abs(height) * 0.00012), fertility: wetness * (1 - slope * 0.6) };
 }
 
-export function createEnvironmentalContext(opts: { planetId: string; planetSeed: number; chunkKey: string; simulationTick: number; worldTime: number; terrainHeight?: number; oceanDepth?: number; gravity?: number }): EnvironmentalContext {
+// --- F6: local solar time follows longitude (Blueprint 10 §6) ---
+/** Chunk size in meters (mirrors chunkFor default — single convention). */
+export const CHUNK_SIZE_M = 2000;
+/** Planet circumference in meters (default Earth-like; per-planet override = future). */
+export const PLANET_CIRCUMFERENCE_M = 40075000;
+
+/**
+ * Longitude (degrees, -180..180) of a chunk CENTER parsed from
+ * `planetId:x:z`. Unparseable key → 0 (prime meridian, documented).
+ */
+export function chunkLonDeg(chunkKey: string): number {
+  const parts = chunkKey.split(":");
+  const x = parseInt(parts[parts.length - 2], 10);
+  if (Number.isNaN(x)) return 0;
+  return (((x + 0.5) * CHUNK_SIZE_M) / PLANET_CIRCUMFERENCE_M) * 360 - 180;
+}
+
+/** Local solar hour 0..24 from world clock + longitude (15° = 1 hour). */
+export function localHour(worldTimeMs: number, lonDeg: number): number {
+  return (((worldTimeMs / 3600000 + lonDeg / 15) % 24) + 24) % 24;
+}
+
+export function createEnvironmentalContext(opts: { planetId: string; planetSeed: number; chunkKey: string; simulationTick: number; worldTime: number; terrainHeight?: number; oceanDepth?: number; gravity?: number; positionXZ?: { x: number; z: number }; anomalyChunks?: string[] }): EnvironmentalContext {
   const sun = deriveSunState(opts.planetSeed, opts.worldTime);
   const weather = deriveWeatherState(opts.planetSeed, opts.simulationTick, opts.chunkKey);
+  // F7: anomaly overlay — a cosmic anomaly covering this chunk pushes its
+  // weather to storm. Reversible: empty list = derived weather untouched.
+  if (opts.anomalyChunks && opts.anomalyChunks.indexOf(opts.chunkKey) !== -1) {
+    weather.kind = "storm";
+  }
   const wind = deriveWindState(opts.planetSeed, opts.simulationTick, opts.chunkKey);
-  const hour = (opts.worldTime % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000);
+  // F6: exact longitude when the caller knows sub-chunk position
+  // (continuous across chunk borders — the "interpolasi"); otherwise the
+  // chunk-center longitude (step error < 5 solar seconds at 2km chunks).
+  const lonDeg = opts.positionXZ
+    ? (opts.positionXZ.x / PLANET_CIRCUMFERENCE_M) * 360 - 180
+    : chunkLonDeg(opts.chunkKey);
+  const hour = localHour(opts.worldTime, lonDeg);
   const timeOfDay: TimeOfDay = hour < 5 || hour > 19 ? "night" : hour < 7 ? "dawn" : hour > 17 ? "dusk" : "day";
   const height = opts.terrainHeight ?? 0; const slope = Math.min(1, Math.abs(height) / 750);
   const terrain = deriveTerrainState(height, slope, weather.precipitationIntensity * 0.62);

--- a/packages/gameserver/simulation.ts
+++ b/packages/gameserver/simulation.ts
@@ -22,7 +22,7 @@ import { validateIntent, type ValidatorContext } from "./validator";
 import { applyCombatIntent } from "./combat";
 import type { EnvironsState } from "./environs";
 import { integrateEnvirons, getBodiesArray } from "./environs";
-import { checkCollisions } from "./collision";
+import { checkCollisions, vesselMass } from "./collision";
 import { computeThermal } from "./thermics";
 import { canActivate, activateCapability } from "./capability";
 import { assertNotPaused, isInSafeZone } from "./governance";
@@ -37,6 +37,8 @@ import {
   hullOf,
   nextEmergencyState,
   applyGravity,
+  landingOutcome,
+  impactSpeedOf,
   ADRIFT_DAMPING,
   FALL_SPEED_MAX,
   type VesselState,
@@ -308,9 +310,10 @@ export class SimulationEngine {
     // 10.E: vessels in emergency states integrate through the emergency
     // machine (drift decay / gravity fall / grounded) instead of free flight.
     const planetPos = this.nearestPlanetPosition();
+    const planetMass = this.nearestPlanetBody()?.mass ?? 5.972e24;
     for (const e of this.region["entities"].values()) {
       if (e.kind === "vessel") {
-        if (this.stepEmergency(e, planetPos) !== "nominal") continue;
+        if (this.stepEmergency(e, planetPos, planetMass) !== "nominal") continue;
       }
       const drag = 0.02;
       const ax = -e.velocity.x * drag;
@@ -325,13 +328,18 @@ export class SimulationEngine {
     }
   }
 
-  /** Nearest planet center for gravity capture, if environs are present. */
-  private nearestPlanetPosition(): Vec3 | undefined {
+  /** Nearest planet body for gravity capture, with real mass (F4). */
+  private nearestPlanetBody(): { pos: Vec3; mass: number } | undefined {
     if (!this.environs) return undefined;
     for (const b of getBodiesArray(this.environs)) {
-      if (b.kind === "planet") return { ...b.position };
+      if (b.kind === "planet") return { pos: { ...b.position }, mass: b.mass };
     }
     return undefined;
+  }
+
+  /** Nearest planet center for gravity capture, if environs are present. */
+  private nearestPlanetPosition(): Vec3 | undefined {
+    return this.nearestPlanetBody()?.pos;
   }
 
   /**
@@ -339,19 +347,42 @@ export class SimulationEngine {
    * ground wrecks. Returns the effective state; non-nominal vessels skip
    * free-flight integration. Transitions are logged for replay.
    */
-  private stepEmergency(v: VesselEntity, planetPos: Vec3 | undefined): VesselState {
+  private stepEmergency(v: VesselEntity, planetPos: Vec3 | undefined, planetMass = 5.972e24): VesselState {
+    const wasFalling = v.emergency?.state === "falling";
     const { state, changed, cause } = nextEmergencyState(v, planetPos, this.region.tick);
     if (changed) {
       if (state === "nominal") delete v.emergency;
       else v.emergency = { state, updatedTick: this.region.tick, cause };
       this.log(`emergency_${state}`, v.id, { hull: Math.round(hullOf(v.vessel) * 10) / 10, cause });
     }
+    // F1: settle is MEASURED, not assumed — touchdown verdict from real
+    // impact kinematics via landingOutcome() + crash_impact log. Terrain is
+    // unknown server-side, so the verdict is conservative (treated as
+    // occupied ground, budget ×0.4) and the log says so explicitly.
+    if (changed && state === "crashed" && wasFalling) {
+      const speed = impactSpeedOf(v.velocity);
+      const verdict = landingOutcome({
+        mass: vesselMass(v),
+        speed,
+        verticalSpeed: v.velocity.y,
+        slope: 0,
+        onEmptyLand: false,
+      });
+      this.log("crash_impact", v.id, {
+        verdict: verdict.verdict,
+        kineticEnergy: Math.round(verdict.kineticEnergy),
+        budget: Math.round(verdict.budget),
+        impactSpeed: Math.round(speed * 10) / 10,
+        terrain: "unknown-conservative",
+      });
+    }
     if (state === "crashed") {
       v.velocity = { x: 0, y: 0, z: 0 };
       return state;
     }
     if (state === "falling" && planetPos) {
-      v.velocity = applyGravity(v.position, v.velocity, planetPos, this.dt);
+      // F4: real planet mass from environs — Mars pulls less than Earth.
+      v.velocity = applyGravity(v.position, v.velocity, planetPos, this.dt, planetMass);
     } else if (state === "adrift") {
       const damp = Math.max(0, 1 - ADRIFT_DAMPING * this.dt);
       v.velocity = { x: v.velocity.x * damp, y: v.velocity.y * damp, z: v.velocity.z * damp };

--- a/packages/gameserver/vesselState.ts
+++ b/packages/gameserver/vesselState.ts
@@ -35,6 +35,15 @@ export const GRAVITY_SCALE = 0.00008;
 /** Newtonian gravitational constant. */
 export const GRAVITY_G = 6.6743e-11;
 
+/**
+ * Surface gravity g = GM/r² (m/s²) for a planet body. F4: Earth 9.81,
+ * Mars-like 3.71 — varies per planet from environs mass+radius.
+ */
+export function surfaceGravity(massKg: number, radiusM: number): number {
+  const r = Math.max(1e6, radiusM);
+  return (GRAVITY_G * massKg) / (r * r);
+}
+
 export interface VesselStateInfo {
   state: VesselState;
   health: number; // 0..100 hull aggregate
@@ -55,6 +64,11 @@ export function hullOf(vessel: VesselModel): number {
 
 function speedOf(v: Vec3): number {
   return Math.hypot(v.x, v.y, v.z);
+}
+
+/** Impact speed of a vessel (exported for settle-verdict logging, F1). */
+export function impactSpeedOf(v: Vec3): number {
+  return speedOf(v);
 }
 
 function distanceTo(a: Vec3, b: Vec3): number {
@@ -131,6 +145,7 @@ export function nextEmergencyState(
 /**
  * Newtonian gravity step toward a planet center with light drag and a fall
  * clamp. Pure: returns the new velocity, mutates nothing.
+ * F4: planetMass threaded from environs (default Earth) — Mars pulls less.
  */
 export function applyGravity(
   pos: Vec3,

--- a/scripts/smoke-f0.ts
+++ b/scripts/smoke-f0.ts
@@ -1,0 +1,117 @@
+// 10.V F0 smoke: correctness gaps F1-F4 + F6-F8 (pure, deterministik).
+// Run: ./node_modules/.bin/tsx scripts/smoke-f0.ts (exit 1 = FAIL)
+
+import {
+  landingOutcome,
+  nextEmergencyState,
+  applyGravity,
+  surfaceGravity,
+} from "../packages/gameserver/vesselState";
+import { vesselMass } from "../packages/gameserver/collision";
+import {
+  generateCosmicEventsForTick,
+} from "../packages/gameserver/cosmicEvent";
+import {
+  createEnvironmentalContext,
+  localHour,
+  chunkLonDeg,
+} from "../packages/gameserver/planetary/environment";
+import {
+  discoverViaRadar,
+  formatRadarHud,
+} from "../apps/game/src/renderer/scene3d/planetary/night";
+import {
+  strikeDistanceTo,
+  STALE_STRIKE_DISTANCE,
+} from "../apps/game/src/renderer/scene3d/planetary/lightning";
+import { stormAmpScale } from "../apps/game/src/renderer/scene3d/planetary/ocean";
+import { timeOfDayFromMs } from "../apps/game/src/renderer/scene3d/planetary/surface";
+
+let fail = 0;
+const ok = (c: boolean, s: string): void => {
+  console.log(`${c ? "PASS" : "FAIL"} ${s}`);
+  if (!c) fail++;
+};
+
+// --- F1: settle MEASURED — landingOutcome dipanggil + crash_impact jujur ---
+const soft = landingOutcome({ mass: 5e6, speed: 1.5, verticalSpeed: -1, slope: 0, onEmptyLand: false });
+ok(soft.verdict === "landed", `F1 touchdown lembut = landed (KE=${Math.round(soft.kineticEnergy)})`);
+const hard = landingOutcome({ mass: 5e6, speed: 120, verticalSpeed: -30, slope: 0, onEmptyLand: false });
+ok(hard.verdict === "wrecked", `F1 hantaman 120m/s = wrecked (KE=${(hard.kineticEnergy / 1e9).toFixed(1)}GJ)`);
+const slam = landingOutcome({ mass: 5e6, speed: 10, verticalSpeed: -25, slope: 0, onEmptyLand: true });
+ok(slam.verdict === "wrecked", "F1 verticalSpeed < -18 = wrecked walau pelan + empty");
+// Transisi falling -> crashed saat settle (mesinnya, verdict di sim):
+const wreck: any = {
+  id: "v-1",
+  position: { x: 0, y: 0, z: 0 },
+  velocity: { x: 0.5, y: -0.5, z: 0.5 },
+  vessel: { systems: [{ health: 5 }, { health: 4 }] },
+  emergency: { state: "falling", updatedTick: 1, cause: "gravity-capture" },
+};
+const tr = nextEmergencyState(wreck, { x: 0, y: 0, z: 100 }, 99);
+ok(tr.state === "crashed" && tr.changed && tr.cause === "settled", "F1 falling pelan -> crashed settled");
+ok(vesselMass(wreck) === 5e6, "F1 konvensi massa default 5e6 (satu sumber)");
+
+// --- F4: gravitasi per planet dari environs ---
+ok(Math.abs(surfaceGravity(5.972e24, 6.371e6) - 9.81) < 0.05, `F4 g Bumi ≈ 9.81 (${surfaceGravity(5.972e24, 6.371e6).toFixed(2)})`);
+ok(Math.abs(surfaceGravity(6.39e23, 3.3895e6) - 3.71) < 0.05, `F4 g Mars ≈ 3.71 (${surfaceGravity(6.39e23, 3.3895e6).toFixed(2)})`);
+const pos = { x: 1e7, y: 0, z: 0 };
+const vel = { x: 0, y: 0, z: 0 };
+const vEarth = applyGravity(pos, vel, { x: 0, y: 0, z: 0 }, 1, 5.972e24);
+const vMars = applyGravity(pos, vel, { x: 0, y: 0, z: 0 }, 1, 6.39e23);
+ok(Math.hypot(vEarth.x, vEarth.y, vEarth.z) > Math.hypot(vMars.x, vMars.y, vMars.z) * 5, "F4 Bumi narik >5x Mars pada jarak sama");
+
+// --- F6: waktu lokal ikut longitude ---
+ok(Math.abs(localHour(0, 0) - 0) < 1e-9, "F6 00:00 UTC lon 0 = jam 0");
+ok(Math.abs(localHour(0, 180) - 12) < 1e-9, "F6 00:00 UTC lon 180 = jam 12");
+ok(Math.abs(chunkLonDeg("planet-07:0:0") - -179.99) < 0.05, `F6 chunk 0 ≈ -180° (${chunkLonDeg("planet-07:0:0").toFixed(2)})`);
+// Siang UTC: chunk 0 malam, chunk antipodal (+10019) siang.
+const noonUTC = 12 * 3600000;
+const c0 = createEnvironmentalContext({ planetId: "planet-07", planetSeed: 7, chunkKey: "planet-07:0:0", simulationTick: 1, worldTime: noonUTC });
+const cAnti = createEnvironmentalContext({ planetId: "planet-07", planetSeed: 7, chunkKey: "planet-07:10019:0", simulationTick: 1, worldTime: noonUTC });
+ok(c0.timeOfDay !== cAnti.timeOfDay, `F6 barat vs timur beda waktu (${c0.timeOfDay} vs ${cAnti.timeOfDay})`);
+// Kontinu via positionXZ (interpolasi, bukan step):
+const pa = createEnvironmentalContext({ planetId: "p", planetSeed: 7, chunkKey: "planet-07:0:0", simulationTick: 1, worldTime: noonUTC, positionXZ: { x: 1000, z: 0 } });
+ok(pa.timeOfDay === c0.timeOfDay, "F6 positionXZ dalam chunk = waktu chunk");
+ok(timeOfDayFromMs(noonUTC, 0) === "day" && timeOfDayFromMs(noonUTC, 180) === "night", "F6 client timeOfDayFromMs ikut lon");
+
+// --- F7: anomali -> chunkKey + overlay storm ---
+const e1 = generateCosmicEventsForTick("r-1", 4242, "planet-07");
+const e2 = generateCosmicEventsForTick("r-1", 4242, "planet-07");
+ok(JSON.stringify(e1) === JSON.stringify(e2), "F7 generator deterministik (server == client)");
+let anomalyChunk = "";
+for (let t = 0; t < 6000 && !anomalyChunk; t++) {
+  for (const e of generateCosmicEventsForTick("r-1", t, "planet-07")) {
+    if (e.kind === "anomaly_gravity" && typeof e.payload["chunkKey"] === "string") anomalyChunk = e.payload["chunkKey"] as string;
+  }
+}
+ok(/planet-07:-?\d+:-?\d+/.test(anomalyChunk), `F7 payload anomali bawa chunkKey (${anomalyChunk})`);
+if (anomalyChunk) {
+  const calm = createEnvironmentalContext({ planetId: "planet-07", planetSeed: 7, chunkKey: anomalyChunk, simulationTick: 4242, worldTime: noonUTC });
+  const stormed = createEnvironmentalContext({ planetId: "planet-07", planetSeed: 7, chunkKey: anomalyChunk, simulationTick: 4242, worldTime: noonUTC, anomalyChunks: [anomalyChunk] });
+  void calm;
+  ok(stormed.weather.kind === "storm", "F7 overlay anomali memaksa storm di chunk target");
+}
+
+// --- F3: tag ADRIFT kapal orang ---
+const disc = discoverViaRadar({ x: 0, y: 0, z: 0 }, [
+  { id: "v-adrift-1", kind: "vessel", position: { x: 1000, y: 0, z: 0 }, health: 50, emergency: "adrift" },
+  { id: "v-ok-2", kind: "vessel", position: { x: 2000, y: 0, z: 0 }, health: 90 },
+]);
+ok(disc.contacts[0].emergency === "adrift", "F3 emergency lolos ke kontak");
+const hud = formatRadarHud(disc);
+ok(hud.indexOf("[ADRIFT]") !== -1, `F3 HUD menandai [ADRIFT] (${hud})`);
+
+// --- F2: jarak petir beneran ---
+const cam = { x: 0, y: 100, z: 0 };
+const fresh = { eventId: "lt-1", timestamp: 5000, position: { x: 300, y: 300, z: 400 }, intensity: 1, duration: 200, flashColor: 0xffffff };
+ok(Math.abs(strikeDistanceTo(cam, fresh, 6000) - Math.hypot(300, Math.hypot(200, 400))) < 1e-6, "F2 strike segar = jarak beneran");
+ok(strikeDistanceTo(cam, fresh, 60000) === STALE_STRIKE_DISTANCE, "F2 strike basi = fallback bernama");
+ok(strikeDistanceTo(cam, null, 6000) === STALE_STRIKE_DISTANCE && STALE_STRIKE_DISTANCE === 2800, "F2 tanpa event = 2800 (terdokumentasi)");
+
+// --- F8: amplitudo mesh ikut state ---
+ok(Math.abs(stormAmpScale(0.9 + 6 * 0.32) - 1) < 1e-9, "F8 laut tenang = skala 1");
+ok(stormAmpScale(8) > 2, "F8 badai = mesh membesar (>2x)");
+ok(stormAmpScale(0.2) === 0.3 && stormAmpScale(99) === 3, "F8 skala dijepit 0.3..3");
+
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
F0 tutup gap kejujuran. tsc game 0 + server 0 + build OK + smoke-f0 25/25.

CODE: F1 settle diukur (landingOutcome + crash_impact, terrain konservatif eksplisit); F2 strikeDistanceTo (strike segar <8s, fallback bernama); F3 tag ADRIFT/FALLING/CRASHED di HUD + radar; F4 massa planet asli ke gravitasi + surfaceGravity; F6 localHour/chunkLonDeg/positionXZ; F7 chunkKey anomali + overlay storm + generator murni (server==client); F8 ampScale laut live.
FIX F5: dispose saat unload chunk (bocor GPU); tulis fog tunggal (rebutan wireX/wireG); shadow basis-dt.
F5 18/18: PASS 9, koreksi klaim 3 (Gerstner=sinus-Z, scattering=artistik, Kepler=linear), temuan→A2/A3/L1 6. F9: opsi (b) + erratum di Blueprint 10 §5.
Temuan diteruskan (bukan di-F0): noise sekuensial terrain→A2, Gerstner→A3, 96 mesh/facility→L1.3, AtmosphericReveal tidak ada (backlog).